### PR TITLE
Add immutable theme snapshots and ThemeBuilder

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Install Deps
       run: |
         # sync deps
-        atlas -t --update install
+        atlas -t --update --features:kosmo install
 
     - name: Clean generated examples
       run: |

--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ NIMKIT_FONT_SIZE=15 nim r examples/quick_start.nim
 
 The `NIMKIT_` variables take priority over their `MERENDA_FONT`,
 `MERENDA_MONOSPACE_FONT`, and `MERENDA_FONT_SIZE` aliases. Font roles can also
-be configured directly on a theme:
+be configured while deriving an immutable theme snapshot:
 
 ```nim
-var theme = initTheme()
-theme.setFontName(frUI, "IBMPlexSans-Regular.ttf")
-theme.setFontName(frMonospace, "HackNerdFont-Regular.ttf")
-root.appearance = initAppearance(theme)
+var builder = initThemeBuilder(initTheme())
+builder.setFontName(frUI, "IBMPlexSans-Regular.ttf")
+builder.setFontName(frMonospace, "HackNerdFont-Regular.ttf")
+root.appearance = initAppearance(builder.finish())
 ```
 
 Merenda follows FigDraw's resolved `figdrawTextBackend` constant. The default

--- a/config.nims
+++ b/config.nims
@@ -25,9 +25,6 @@ when defined(useNativeDynlib):
   elif defined(linux) or defined(bsd):
     switch("define", "nativeLibrary=../figdraw/bin/libfigdraw_native.so")
 
-when defined(feature.merenda.kosmo):
-  switch("import", "src/merenda/kosmo/moe_sync_compat.nim")
-
 const
   referenceDir = "docs/reference"
   openStepSpecUrl = "https://levenez.com/NeXTSTEP/OpenStepSpec.pdf"

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -21,7 +21,7 @@ feature "uirelays":
   requires "gh:nim-lang/uirelays#688dd44"
 
 feature "kosmo":
-  requires "gh:fox0430/moe#d650f95b892519613e605f84dade85130d4437ed"
+  requires "gh:fox0430/moe#4f18384"
 
 feature "references":
   requires "https://github.com/ravynsoft/ravynos"

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -21,7 +21,8 @@ feature "uirelays":
   requires "gh:nim-lang/uirelays#688dd44"
 
 feature "kosmo":
-  requires "gh:fox0430/moe#4f18384"
+  # requires "gh:fox0430/moe#4f18384"
+  requires "gh:elcritch/moe#fix-results-imports"
 
 feature "references":
   requires "https://github.com/ravynsoft/ravynos"

--- a/src/merenda/nimkit/app/application.nim
+++ b/src/merenda/nimkit/app/application.nim
@@ -339,7 +339,7 @@ proc appearance*(app: Application): Appearance =
 
 proc effectiveAppearance*(app: Application): Appearance =
   if not app.xHasAppearance:
-    if app.xAppearance.theme.tokens.isNil:
+    if not app.xAppearance.theme.isInitialized:
       app.xAppearance = initAppearance()
     return app.xAppearance
   app.xAppearance

--- a/src/merenda/nimkit/app/settings.nim
+++ b/src/merenda/nimkit/app/settings.nim
@@ -458,18 +458,23 @@ proc appearanceFor(
   of stSynthwave83:
     result = initAppearance(initSynthwave83Theme())
 
+  var
+    builder = initThemeBuilder(result.theme)
+    selectedFonts: array[FontRole, string]
   for role in FontRole:
     let selectedFont =
       if fontPaths[role].len > 0:
         fontPaths[role]
       else:
         defaultFontName(role)
-    result.theme.setFontName(role, selectedFont)
+    selectedFonts[role] = selectedFont
+    builder.setFontName(role, selectedFont)
   for role in TextStyleRoles:
-    result.theme[role, StyleFontSize] = fontSize
+    builder[role, StyleFontSize] = fontSize
   let preview = initStyleSelector(srTextField, id = SettingsFontPreviewIdentifier)
-  result.theme[preview, StyleFontName] = styleKeyword(result.fontName(previewRole))
-  result.theme[preview, StyleFontSize] = fontSize
+  builder[preview, StyleFontName] = styleKeyword(selectedFonts[previewRole])
+  builder[preview, StyleFontSize] = fontSize
+  result.theme = builder.finish()
 
 proc newSettingsPage(): tuple[view: View, stack: StackView] =
   result.view = newView()

--- a/src/merenda/nimkit/app/windows.nim
+++ b/src/merenda/nimkit/app/windows.nim
@@ -987,7 +987,7 @@ proc effectiveAppearance*(window: Window): Appearance =
     return window.xAppearance
   if window.xHasInheritedAppearance:
     return window.xInheritedAppearance
-  if window.xInheritedAppearance.theme.tokens.isNil:
+  if not window.xInheritedAppearance.theme.isInitialized:
     window.xInheritedAppearance = initAppearance()
   window.xInheritedAppearance
 

--- a/src/merenda/nimkit/drawing/chrome.nim
+++ b/src/merenda/nimkit/drawing/chrome.nim
@@ -177,7 +177,7 @@ proc drawChromeBacking*(
       drawChromeBackingFor(), (context: context, chrome: chrome, extras: resolvedExtras)
     )
 
-proc installDefaultChrome(theme: var Theme) =
+proc installDefaultChrome(theme: var ThemeBuilder) =
   theme.installChrome(DefaultChromeName, defaultChrome())
 
 registerThemeInstaller(installDefaultChrome)

--- a/src/merenda/nimkit/drawing/chromes/aquachrome.nim
+++ b/src/merenda/nimkit/drawing/chromes/aquachrome.nim
@@ -1856,7 +1856,7 @@ proc rubyAquaChrome(): Chrome =
     )
   fallbackRubyAquaChrome
 
-proc installAquaChrome*(theme: var Theme) =
+proc installAquaChrome*(theme: var ThemeBuilder) =
   theme.installChrome(AquaChromeName, aquaChrome())
   theme.installChrome(RubyAquaChromeName, rubyAquaChrome())
 

--- a/src/merenda/nimkit/drawing/chromes/flattransparentchrome.nim
+++ b/src/merenda/nimkit/drawing/chromes/flattransparentchrome.nim
@@ -497,7 +497,7 @@ proc flatTransparentChrome(): Chrome =
     fallbackFlatTransparentChrome = newFlatTransparentChrome()
   fallbackFlatTransparentChrome
 
-proc installFlatTransparentChrome*(theme: var Theme) =
+proc installFlatTransparentChrome*(theme: var ThemeBuilder) =
   theme.installChrome(FlatTransparentChromeName, flatTransparentChrome())
 
 registerThemeInstaller(installFlatTransparentChrome)

--- a/src/merenda/nimkit/resources/resrcconstruction.nim
+++ b/src/merenda/nimkit/resources/resrcconstruction.nim
@@ -308,7 +308,7 @@ proc toStyleValue(value: ResourceStyleValue): StyleValue =
   of rsvKeyword:
     styleKeyword(value.text)
 
-proc applyThemeFragment(theme: var Theme, fragment: ThemeFragmentResource) =
+proc applyThemeFragment(theme: var ThemeBuilder, fragment: ThemeFragmentResource) =
   for token in fragment.tokens:
     theme[token.name] = token.value.toStyleValue()
   for rule in fragment.rules:
@@ -321,9 +321,8 @@ proc applyThemeFragment(theme: var Theme, fragment: ThemeFragmentResource) =
         states.incl state
     let selector =
       initStyleSelector(role, states, rule.selector.id, rule.selector.classes)
-    let patch = theme.stylePatch(selector)
     for style in rule.styles:
-      patch.setStyle(style.name, style.value.toStyleValue())
+      theme.setStyle(selector, style.name, style.value.toStyleValue())
 
 proc constructThemes(state: var ConstructionState) =
   var remaining = state.bundle.themes
@@ -333,13 +332,14 @@ proc constructThemes(state: var ConstructionState) =
     for fragment in remaining:
       if fragment.parentId.isEmpty or
           state.instance.themesValue.hasKey(fragment.parentId):
-        var theme =
+        let baseTheme =
           if fragment.parentId.isEmpty:
             initTheme()
           else:
-            state.instance.themesValue[fragment.parentId].clone()
-        theme.applyThemeFragment(fragment)
-        state.instance.themesValue[fragment.id] = theme
+            state.instance.themesValue[fragment.parentId]
+        var builder = initThemeBuilder(baseTheme)
+        builder.applyThemeFragment(fragment)
+        state.instance.themesValue[fragment.id] = builder.finish()
         madeProgress = true
       else:
         next.add fragment

--- a/src/merenda/nimkit/themes/darkbsdtheme.nim
+++ b/src/merenda/nimkit/themes/darkbsdtheme.nim
@@ -76,7 +76,7 @@ func rubyButtonPressedShadows(): seq[BoxShadow] =
 func graphiteControlShadows(): seq[BoxShadow] =
   @[dropShadow(color(0.0, 0.0, 0.0, 0.38), y = 1.0, blur = 3.0)]
 
-proc installDarkBSDTokens(theme: var Theme) =
+proc installDarkBSDTokens(theme: var ThemeBuilder) =
   theme["accent"] = color(0.58, 0.022, 0.052, 1.0)
   theme["accent.pressed"] = color(0.36, 0.005, 0.020, 1.0)
   theme["focus.ring.color"] = color(0.70, 0.06, 0.24, 0.64)
@@ -113,7 +113,7 @@ proc installDarkBSDTokens(theme: var Theme) =
   theme["splitView.divider.fill"] = color(1.0, 1.0, 1.0, 0.035)
   theme["splitView.divider.mark.color"] = color(0.72, 0.72, 0.76, 0.82)
 
-proc installDarkBSDButtonStyle(theme: var Theme) =
+proc installDarkBSDButtonStyle(theme: var ThemeBuilder) =
   theme[srButton, StyleChrome] = styleKeyword(RubyAquaChromeName)
   theme[srButton, StyleCornerRadius] = 10.0
   theme[srButton, StyleBorderWidth] = 1.0
@@ -122,7 +122,7 @@ proc installDarkBSDButtonStyle(theme: var Theme) =
   theme[srButton, StyleTextHighlightColor] = color(1.0, 0.90, 0.92, 0.34)
   theme[srButton, StyleTextShadowColor] = color(0.16, 0.0, 0.025, 0.66)
 
-proc installDarkBSDControlStyles(theme: var Theme) =
+proc installDarkBSDControlStyles(theme: var ThemeBuilder) =
   theme[srSwitch, {ssSelected}, StyleFill] = styleToken("accent")
   theme[srSwitch, {ssSelected}, StyleBorderColor] = styleToken("accent.pressed")
   theme[srSlider, StyleKnobFill] = fill(color(0.25, 0.25, 0.27, 1.0))
@@ -137,10 +137,11 @@ proc installDarkBSDControlStyles(theme: var Theme) =
   theme[srSplitView, StyleMarkColor] = styleToken("splitView.divider.mark.color")
 
 proc initDarkBSDTheme*(): Theme =
-  result = initMacOSDarkTheme()
-  result.installDarkBSDTokens()
-  result.installDarkBSDButtonStyle()
-  result.installDarkBSDControlStyles()
+  var builder = initThemeBuilder(initMacOSDarkTheme())
+  builder.installDarkBSDTokens()
+  builder.installDarkBSDButtonStyle()
+  builder.installDarkBSDControlStyles()
+  builder.finish()
 
 registerThemeFactory("darkbsd", initDarkBSDTheme)
 registerThemeFactory("dark-bsd", initDarkBSDTheme)

--- a/src/merenda/nimkit/themes/defaulttheme.nim
+++ b/src/merenda/nimkit/themes/defaulttheme.nim
@@ -3,7 +3,7 @@ import std/[os, strutils, tables]
 import ../foundation/types
 
 proc addRoleRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     fill: StyleValue,
@@ -16,7 +16,7 @@ proc addRoleRule(
   theme[selector, StyleTextColor] = textColor
 
 proc addChoiceRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     fill: StyleValue,
@@ -31,7 +31,7 @@ proc addChoiceRule(
   theme[selector, StyleTextColor] = textColor
 
 proc addLabelRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     className: string,
     fillValue: Fill,
     borderColor: Color,
@@ -377,13 +377,13 @@ func aquaSwitchKnobShadows(enabled: bool): seq[BoxShadow] =
     ),
   ]
 
-proc clearBackgroundPinstripes*(theme: var Theme, selector: StyleSelector) =
+proc clearBackgroundPinstripes*(theme: var ThemeBuilder, selector: StyleSelector) =
   theme[selector, StyleBackgroundPinstripeHighlightColor] = color(0.0, 0.0, 0.0, 0.0)
   theme[selector, StyleBackgroundPinstripeColor] = color(0.0, 0.0, 0.0, 0.0)
   theme[selector, StyleBackgroundPinstripePeriod] = 0.0
   theme[selector, StyleBackgroundPinstripeHeight] = 0.0
 
-proc clearBackgroundPinstripes*(theme: var Theme) =
+proc clearBackgroundPinstripes*(theme: var ThemeBuilder) =
   theme.clearBackgroundPinstripes(initStyleSelector(srView))
 
 const TextStyleRoles = [
@@ -391,9 +391,8 @@ const TextStyleRoles = [
   srComboBoxItem, srTab, srTableHeaderCell, srRowItem, srCascadingRowItem, srTooltip,
 ]
 
-proc initAquaTheme*(): Theme =
-  result.tokens = newStyleTokenStore()
-  result.chromes = initTable[string, Chrome]()
+proc buildAquaTheme(): ThemeBuilder =
+  result = initThemeBuilder()
   result.setFontName(frUI, defaultFontName(frUI))
   result.setFontName(frMonospace, defaultFontName(frMonospace))
   for role in TextStyleRoles:
@@ -1352,8 +1351,11 @@ proc initAquaTheme*(): Theme =
   result[srCascadingRowItem, StyleAlternatingFill] = fill(color(0.96, 0.97, 0.99, 0.95))
   result.installThemeExtensions()
 
-proc initBannerTheme*(): Theme =
-  result = initAquaTheme()
+proc initAquaTheme*(): Theme =
+  buildAquaTheme().finish()
+
+proc buildBannerTheme(): ThemeBuilder =
+  result = initThemeBuilder(initAquaTheme())
   result[srDocumentTab, StyleCloseButtonPosition] = styleKeyword("right")
   result[srButton, StyleChrome] = styleKeyword(DefaultChromeName)
   result[srCheckBox, StyleChrome] = styleKeyword(DefaultChromeName)
@@ -1448,6 +1450,9 @@ proc initBannerTheme*(): Theme =
   result[srTableHeaderCell, StyleMarkColor] = color(0.16, 0.15, 0.15, 1.0)
   result[srRowItem, StyleAlternatingFill] = fill(color(0.98, 0.95, 0.90, 1.0))
 
+proc initBannerTheme*(): Theme =
+  buildBannerTheme().finish()
+
 type ThemeFactory* = proc(): Theme
 
 var
@@ -1504,7 +1509,7 @@ proc initThemeFromEnv*(): Theme =
   initThemeByName(themeNameFromEnv())
 
 proc initAppearance*(theme: Theme): Appearance =
-  Appearance(theme: theme.clone)
+  Appearance(theme: theme)
 
 proc initAppearance*(): Appearance =
   initAppearance(initThemeFromEnv())

--- a/src/merenda/nimkit/themes/macostheme.nim
+++ b/src/merenda/nimkit/themes/macostheme.nim
@@ -15,7 +15,7 @@ func darkKnobShadow(): seq[BoxShadow] =
   @[dropShadow(color(0.0, 0.0, 0.0, 0.52), y = 1.0, blur = 4.0)]
 
 proc addMacOSLabelRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     className: string,
     fillValue: Fill,
     borderColor: Color,
@@ -40,7 +40,7 @@ proc addMacOSLabelRule(
   theme[selector, StyleBoxShadows] = newSeq[BoxShadow]()
   theme[selector, StyleChrome] = styleKeyword(DefaultChromeName)
 
-proc installMacOSTokens(theme: var Theme) =
+proc installMacOSTokens(theme: var ThemeBuilder) =
   theme["accent"] = color(0.04, 0.52, 1.0, 1.0)
   theme["accent.pressed"] = color(0.0, 0.38, 0.82, 1.0)
   theme["progress.fill"] = styleToken("accent")
@@ -180,7 +180,7 @@ proc installMacOSTokens(theme: var Theme) =
   theme["documentTab.button.mark.color.disabled"] =
     styleToken("tab.text.color.disabled")
 
-proc installMacOSControlStyles(theme: var Theme) =
+proc installMacOSControlStyles(theme: var ThemeBuilder) =
   theme.clearBackgroundPinstripes()
   theme[srView, StyleBackgroundColor] = color(0.93, 0.93, 0.94, 1.0)
   theme[srView, StyleBackgroundFill] = fill(color(0.93, 0.93, 0.94, 1.0))
@@ -287,7 +287,7 @@ proc installMacOSControlStyles(theme: var Theme) =
   theme[srTableHeaderCell, StyleMarkColor] = color(0.35, 0.35, 0.37, 1.0)
   theme[srRowItem, StyleAlternatingFill] = fill(color(0.0, 0.0, 0.0, 0.025))
 
-proc installMacOSLabels(theme: var Theme) =
+proc installMacOSLabels(theme: var ThemeBuilder) =
   let
     bodySize = defaultFontSize()
     titleSize = bodySize + 4.0'f32
@@ -356,7 +356,7 @@ proc installMacOSLabels(theme: var Theme) =
     bodySize,
   )
 
-proc installMacOSDarkTokens(theme: var Theme) =
+proc installMacOSDarkTokens(theme: var ThemeBuilder) =
   theme["accent"] = color(0.04, 0.52, 1.0, 1.0)
   theme["accent.pressed"] = color(0.0, 0.38, 0.82, 1.0)
   theme["progress.fill"] = styleToken("accent")
@@ -464,7 +464,7 @@ proc installMacOSDarkTokens(theme: var Theme) =
   theme["tab.border.color.disabled"] = color(0.0, 0.0, 0.0, 0.0)
   theme["documentTab.fill.pressed"] = color(1.0, 1.0, 1.0, 0.08)
 
-proc installMacOSDarkControlStyles(theme: var Theme) =
+proc installMacOSDarkControlStyles(theme: var ThemeBuilder) =
   let background = color(0.12, 0.12, 0.14, 1.0)
   theme[srView, StyleBackgroundColor] = background
   theme[srView, StyleBackgroundFill] = fill(background)
@@ -502,7 +502,7 @@ proc installMacOSDarkControlStyles(theme: var Theme) =
   theme[srTableHeaderCell, StyleMarkColor] = color(0.65, 0.65, 0.68, 1.0)
   theme[srRowItem, StyleAlternatingFill] = fill(color(1.0, 1.0, 1.0, 0.025))
 
-proc installMacOSDarkLabels(theme: var Theme) =
+proc installMacOSDarkLabels(theme: var ThemeBuilder) =
   let
     body = initStyleSelector(srTextField, classes = @[LabelStyleClass])
     title = initStyleSelector(srTextField, classes = @[LabelTitleStyleClass])
@@ -520,16 +520,18 @@ proc installMacOSDarkLabels(theme: var Theme) =
   theme[icon, StyleMarkColor] = styleToken("accent")
 
 proc initMacOSTheme*(): Theme =
-  result = initAquaTheme()
-  result.installMacOSTokens()
-  result.installMacOSControlStyles()
-  result.installMacOSLabels()
+  var builder = initThemeBuilder(initAquaTheme())
+  builder.installMacOSTokens()
+  builder.installMacOSControlStyles()
+  builder.installMacOSLabels()
+  builder.finish()
 
 proc initMacOSDarkTheme*(): Theme =
-  result = initMacOSTheme()
-  result.installMacOSDarkTokens()
-  result.installMacOSDarkControlStyles()
-  result.installMacOSDarkLabels()
+  var builder = initThemeBuilder(initMacOSTheme())
+  builder.installMacOSDarkTokens()
+  builder.installMacOSDarkControlStyles()
+  builder.installMacOSDarkLabels()
+  builder.finish()
 
 registerThemeFactory("macos", initMacOSTheme)
 registerThemeFactory("mac", initMacOSTheme)

--- a/src/merenda/nimkit/themes/nebulatheme.nim
+++ b/src/merenda/nimkit/themes/nebulatheme.nim
@@ -3,7 +3,7 @@ import ./themecore
 import ../foundation/types
 
 proc addRoleRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     fill: StyleValue,
@@ -16,7 +16,7 @@ proc addRoleRule(
   theme[selector, StyleTextColor] = textColor
 
 proc addChoiceRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     fill: StyleValue,
@@ -31,7 +31,7 @@ proc addChoiceRule(
   theme[selector, StyleTextColor] = textColor
 
 proc addLabelRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     className: string,
     fillValue: Fill,
     borderColor: Color,
@@ -135,7 +135,7 @@ func nebulaKnobShadows(): seq[BoxShadow] =
     insetShadow(color(0.80, 1.0, 1.0, 0.42), y = 1.0, blur = 3.0),
   ]
 
-proc installNebulaTokens(theme: var Theme) =
+proc installNebulaTokens(theme: var ThemeBuilder) =
   theme[srView, StyleBackgroundColor] = color(0.04, 0.06, 0.12)
 
   theme["accent"] = color(0.10, 0.92, 1.0, 0.92)
@@ -223,7 +223,7 @@ proc installNebulaTokens(theme: var Theme) =
   theme["tab.border.color.selected"] = color(0.78, 0.24, 1.0, 0.74)
   theme["tab.border.color.disabled"] = color(0.22, 0.34, 0.44, 0.32)
 
-proc installNebulaControlStyles(theme: var Theme) =
+proc installNebulaControlStyles(theme: var ThemeBuilder) =
   theme[srButton, StyleCornerRadius] = 9.0
   theme[srButton, StyleTextHighlightColor] = color(0.64, 1.0, 1.0, 0.28)
   theme[srButton, StyleTextShadowColor] = color(0.0, 0.0, 0.0, 0.46)
@@ -272,7 +272,7 @@ proc installNebulaControlStyles(theme: var Theme) =
   theme[srProgressIndicator, StyleFocusRingColor] = styleToken("progress.border.color")
   theme[srProgressIndicator, StyleBoxShadows] = nebulaInsetShadows()
 
-proc installNebulaLabels(theme: var Theme) =
+proc installNebulaLabels(theme: var ThemeBuilder) =
   theme.addLabelRule(
     LabelStyleClass,
     fill(color(0.0, 0.0, 0.0, 0.0)),
@@ -324,7 +324,7 @@ proc installNebulaLabels(theme: var Theme) =
     initSize(0.0, 18.0),
   )
 
-proc installNebulaTables(theme: var Theme) =
+proc installNebulaTables(theme: var ThemeBuilder) =
   theme[srTableHeader, StyleFill] = fill(color(0.04, 0.14, 0.24, 0.66))
   theme[srTableHeader, StyleBorderColor] = color(0.16, 0.80, 1.0, 0.38)
   theme[srTableHeader, StyleInsertionIndicatorFill] = nebulaSelectionFill()
@@ -337,12 +337,13 @@ proc installNebulaTables(theme: var Theme) =
   theme[srRowItem, StyleAlternatingFill] = fill(color(0.10, 0.30, 0.42, 0.10))
 
 proc initNebulaTheme*(): Theme =
-  result = initAquaTheme()
-  result[srDocumentTab, StyleCloseButtonPosition] = styleKeyword("right")
-  result.installNebulaTokens()
-  result.installNebulaControlStyles()
-  result.installNebulaLabels()
-  result.installNebulaTables()
+  var builder = initThemeBuilder(initAquaTheme())
+  builder[srDocumentTab, StyleCloseButtonPosition] = styleKeyword("right")
+  builder.installNebulaTokens()
+  builder.installNebulaControlStyles()
+  builder.installNebulaLabels()
+  builder.installNebulaTables()
+  builder.finish()
 
 registerThemeFactory("nebula", initNebulaTheme)
 registerThemeFactory("nebula-glass", initNebulaTheme)

--- a/src/merenda/nimkit/themes/peachytheme.nim
+++ b/src/merenda/nimkit/themes/peachytheme.nim
@@ -3,7 +3,7 @@ import ./themecore
 import ../foundation/types
 
 proc addRoleRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     fill: StyleValue,
@@ -16,7 +16,7 @@ proc addRoleRule(
   theme[selector, StyleTextColor] = textColor
 
 proc addChoiceRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     fill: StyleValue,
@@ -31,7 +31,7 @@ proc addChoiceRule(
   theme[selector, StyleTextColor] = textColor
 
 proc addLabelRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     className: string,
     fillValue: Fill,
     borderColor: Color,
@@ -145,7 +145,7 @@ func peachyKnobShadows(): seq[BoxShadow] =
     insetShadow(color(1.0, 0.80, 0.60, 0.24), y = 1.0, blur = 3.0),
   ]
 
-proc installPeachyTokens(theme: var Theme) =
+proc installPeachyTokens(theme: var ThemeBuilder) =
   theme["accent"] = color(0.10, 0.92, 1.0, 0.92)
   theme["accent.pressed"] = color(0.78, 0.18, 1.0, 0.82)
   theme["progress.fill"] = styleToken("accent")
@@ -232,7 +232,7 @@ proc installPeachyTokens(theme: var Theme) =
   theme["tab.border.color.selected"] = color(0.78, 0.24, 1.0, 0.74)
   theme["tab.border.color.disabled"] = color(0.22, 0.34, 0.44, 0.32)
 
-proc installPeachyControlStyles(theme: var Theme) =
+proc installPeachyControlStyles(theme: var ThemeBuilder) =
   theme[srButton, StyleCornerRadius] = 9.0
   theme[srButton, StyleTextHighlightColor] = color(0.64, 1.0, 1.0, 0.28)
   theme[srButton, StyleTextShadowColor] = color(0.0, 0.0, 0.0, 0.46)
@@ -277,7 +277,7 @@ proc installPeachyControlStyles(theme: var Theme) =
   theme[srTableView, StyleDropIndicatorFill] = peachySelectionFill()
   theme[srTableView, StyleFocusRingColor] = styleToken("focus.ring.color")
 
-proc installPeachyLabels(theme: var Theme) =
+proc installPeachyLabels(theme: var ThemeBuilder) =
   theme.addLabelRule(
     LabelStyleClass,
     fill(color(0.0, 0.0, 0.0, 0.0)),
@@ -329,7 +329,7 @@ proc installPeachyLabels(theme: var Theme) =
     initSize(0.0, 18.0),
   )
 
-proc installPeachyTables(theme: var Theme) =
+proc installPeachyTables(theme: var ThemeBuilder) =
   theme[srTableHeader, StyleFill] = fill(color(0.04, 0.14, 0.24, 0.66))
   theme[srTableHeader, StyleBorderColor] = color(0.16, 0.80, 1.0, 0.38)
   theme[srTableHeader, StyleInsertionIndicatorFill] = peachySelectionFill()
@@ -341,7 +341,7 @@ proc installPeachyTables(theme: var Theme) =
   theme[srTableHeaderCell, StyleMarkColor] = color(0.66, 0.98, 1.0, 0.96)
   theme[srRowItem, StyleAlternatingFill] = fill(color(0.10, 0.30, 0.42, 0.10))
 
-proc installPeachyRetroPalette(theme: var Theme) =
+proc installPeachyRetroPalette(theme: var ThemeBuilder) =
   theme["accent"] = color(1.0, 0.18, 0.72, 0.94)
   theme["accent.pressed"] = color(1.0, 0.56, 0.12, 0.90)
   theme["focus.ring.color"] = color(0.10, 0.98, 1.0, 0.88)
@@ -610,7 +610,7 @@ proc installPeachyRetroPalette(theme: var Theme) =
     initSize(0.0, 18.0),
   )
 
-proc installPeachyReferencePass(theme: var Theme) =
+proc installPeachyReferencePass(theme: var ThemeBuilder) =
   theme[srView, StyleBackgroundColor] = color(0.20, 0.21, 0.27)
   theme[srView, StyleBackgroundFill] = fill(color(0.20, 0.21, 0.27, 1.0))
 
@@ -768,7 +768,7 @@ proc installPeachyReferencePass(theme: var Theme) =
     initSize(0.0, 18.0),
   )
 
-proc installPeachyTextReadabilityPass(theme: var Theme) =
+proc installPeachyTextReadabilityPass(theme: var ThemeBuilder) =
   theme[srTextField, StyleTextColor] = color(1.0, 0.80, 0.64, 0.98)
   theme[srTextField, {ssFocused}, StyleTextColor] = color(1.0, 0.88, 0.72, 1.0)
   theme[srTextField, {ssDisabled}, StyleTextColor] = styleToken("disabled.text.color")
@@ -813,7 +813,7 @@ proc installPeachyTextReadabilityPass(theme: var Theme) =
       insetShadow(color(0.0, 0.0, 0.0, 0.26), y = -1.0, blur = 3.0),
     ]
 
-proc installPeachyDocumentTabs(theme: var Theme) =
+proc installPeachyDocumentTabs(theme: var ThemeBuilder) =
   theme["documentTab.bar.fill"] = styleToken("tab.panel.fill")
   theme["documentTab.bar.border.color"] = styleToken("tab.panel.border.color")
   theme["documentTab.fill"] = styleToken("tab.fill")
@@ -853,30 +853,32 @@ proc installPeachyDocumentTabs(theme: var Theme) =
   theme[srDocumentTabBar, StyleBorderWidth] = 1.25
 
 proc initPeachyTheme*(): Theme =
-  result = initAquaTheme()
-  result[srDocumentTab, StyleCloseButtonPosition] = styleKeyword("right")
-  result.installPeachyTokens()
-  result.installPeachyControlStyles()
-  result.installPeachyLabels()
-  result.installPeachyTables()
-  result.installPeachyRetroPalette()
-  result.installPeachyReferencePass()
-  result.installPeachyTextReadabilityPass()
-  result.installPeachyDocumentTabs()
-  result.clearBackgroundPinstripes()
+  var builder = initThemeBuilder(initAquaTheme())
+  builder[srDocumentTab, StyleCloseButtonPosition] = styleKeyword("right")
+  builder.installPeachyTokens()
+  builder.installPeachyControlStyles()
+  builder.installPeachyLabels()
+  builder.installPeachyTables()
+  builder.installPeachyRetroPalette()
+  builder.installPeachyReferencePass()
+  builder.installPeachyTextReadabilityPass()
+  builder.installPeachyDocumentTabs()
+  builder.clearBackgroundPinstripes()
 
-  result[srProgressIndicator, StyleFill] = result[srSlider, StyleFill]
-  result[srProgressIndicator, StyleHighlightFill] = styleToken("progress.fill")
-  result[srProgressIndicator, StyleBorderColor] = result[srSlider, StyleBorderColor]
-  result[srProgressIndicator, StyleFocusRingColor] = styleToken("progress.border.color")
-  result[srProgressIndicator, StyleBoxShadows] = result[srSlider, StyleBoxShadows]
+  builder[srProgressIndicator, StyleFill] = builder[srSlider, StyleFill]
+  builder[srProgressIndicator, StyleHighlightFill] = styleToken("progress.fill")
+  builder[srProgressIndicator, StyleBorderColor] = builder[srSlider, StyleBorderColor]
+  builder[srProgressIndicator, StyleFocusRingColor] =
+    styleToken("progress.border.color")
+  builder[srProgressIndicator, StyleBoxShadows] = builder[srSlider, StyleBoxShadows]
 
   for role in [
     srButton, srCheckBox, srRadioButton, srSwitch, srSlider, srProgressIndicator, srTab,
     srTabPanel, srDocumentTab, srDocumentTabBar, srDocumentTabButton, srTextField,
     srMonoTextView, srComboBox,
   ]:
-    result[role, StyleChrome] = styleKeyword(FlatTransparentChromeName)
+    builder[role, StyleChrome] = styleKeyword(FlatTransparentChromeName)
+  builder.finish()
 
 registerThemeFactory("peachy", initPeachyTheme)
 registerThemeFactory("peach", initPeachyTheme)

--- a/src/merenda/nimkit/themes/synthwave83theme.nim
+++ b/src/merenda/nimkit/themes/synthwave83theme.nim
@@ -3,7 +3,7 @@ import ./themecore
 import ../foundation/types
 
 proc addRoleRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     fill: StyleValue,
@@ -16,7 +16,7 @@ proc addRoleRule(
   theme[selector, StyleTextColor] = textColor
 
 proc addChoiceRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     fill: StyleValue,
@@ -31,7 +31,7 @@ proc addChoiceRule(
   theme[selector, StyleTextColor] = textColor
 
 proc addLabelRule(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     className: string,
     fillValue: Fill,
     borderColor: Color,
@@ -136,7 +136,7 @@ func synthwave83KnobShadows(): seq[BoxShadow] =
     insetShadow(color(1.0, 0.80, 0.60, 0.24), y = 1.0, blur = 3.0),
   ]
 
-proc installSynthwave83Tokens(theme: var Theme) =
+proc installSynthwave83Tokens(theme: var ThemeBuilder) =
   theme["accent"] = color(0.10, 0.92, 1.0, 0.92)
   theme["accent.pressed"] = color(0.78, 0.18, 1.0, 0.82)
   theme["progress.fill"] = styleToken("accent")
@@ -222,7 +222,7 @@ proc installSynthwave83Tokens(theme: var Theme) =
   theme["tab.border.color.selected"] = color(0.78, 0.24, 1.0, 0.74)
   theme["tab.border.color.disabled"] = color(0.22, 0.34, 0.44, 0.32)
 
-proc installSynthwave83ControlStyles(theme: var Theme) =
+proc installSynthwave83ControlStyles(theme: var ThemeBuilder) =
   theme[srButton, StyleCornerRadius] = 9.0
   theme[srButton, StyleTextHighlightColor] = color(0.64, 1.0, 1.0, 0.28)
   theme[srButton, StyleTextShadowColor] = color(0.0, 0.0, 0.0, 0.46)
@@ -270,7 +270,7 @@ proc installSynthwave83ControlStyles(theme: var Theme) =
   theme[srTableView, StyleDropIndicatorFill] = synthwave83SelectionFill()
   theme[srTableView, StyleFocusRingColor] = styleToken("focus.ring.color")
 
-proc installSynthwave83Labels(theme: var Theme) =
+proc installSynthwave83Labels(theme: var ThemeBuilder) =
   theme.addLabelRule(
     LabelStyleClass,
     fill(color(0.0, 0.0, 0.0, 0.0)),
@@ -322,7 +322,7 @@ proc installSynthwave83Labels(theme: var Theme) =
     initSize(0.0, 18.0),
   )
 
-proc installSynthwave83Tables(theme: var Theme) =
+proc installSynthwave83Tables(theme: var ThemeBuilder) =
   theme[srTableHeader, StyleFill] = fill(color(0.04, 0.14, 0.24, 0.66))
   theme[srTableHeader, StyleBorderColor] = color(0.16, 0.80, 1.0, 0.38)
   theme[srTableHeader, StyleInsertionIndicatorFill] = synthwave83SelectionFill()
@@ -334,7 +334,7 @@ proc installSynthwave83Tables(theme: var Theme) =
   theme[srTableHeaderCell, StyleMarkColor] = color(0.66, 0.98, 1.0, 0.96)
   theme[srRowItem, StyleAlternatingFill] = fill(color(0.10, 0.30, 0.42, 0.10))
 
-proc installSynthwave83RetroPalette(theme: var Theme) =
+proc installSynthwave83RetroPalette(theme: var ThemeBuilder) =
   theme["accent"] = color(1.0, 0.18, 0.72, 0.94)
   theme["accent.pressed"] = color(1.0, 0.56, 0.12, 0.90)
   theme["focus.ring.color"] = color(0.10, 0.98, 1.0, 0.88)
@@ -575,7 +575,7 @@ proc installSynthwave83RetroPalette(theme: var Theme) =
     initSize(0.0, 18.0),
   )
 
-proc installSynthwave83ReferencePass(theme: var Theme) =
+proc installSynthwave83ReferencePass(theme: var ThemeBuilder) =
   theme[srView, StyleBackgroundColor] = color(0.20, 0.21, 0.27)
 
   theme["accent"] = color(0.88, 0.30, 0.52, 0.92)
@@ -732,7 +732,7 @@ proc installSynthwave83ReferencePass(theme: var Theme) =
     initSize(0.0, 18.0),
   )
 
-proc installSynthwave83VaporwavePass(theme: var Theme) =
+proc installSynthwave83VaporwavePass(theme: var ThemeBuilder) =
   theme[srView, StyleBackgroundColor] = color(0.08, 0.00, 0.16)
   theme[srView, StyleBackgroundFill] = linear(
     color(0.08, 0.00, 0.16, 1.0),
@@ -973,7 +973,7 @@ proc installSynthwave83VaporwavePass(theme: var Theme) =
     initSize(0.0, 18.0),
   )
 
-proc installSynthwave83ReadabilityPass(theme: var Theme) =
+proc installSynthwave83ReadabilityPass(theme: var ThemeBuilder) =
   theme["button.fill"] = linear(
     color(0.10, 0.00, 0.22, 0.90),
     color(0.24, 0.02, 0.40, 0.78),
@@ -1194,7 +1194,7 @@ proc installSynthwave83ReadabilityPass(theme: var Theme) =
     ]
   theme[srTabPanel, StyleChrome] = styleKeyword(FlatTransparentChromeName)
 
-proc installSynthwave83DocumentTabs(theme: var Theme) =
+proc installSynthwave83DocumentTabs(theme: var ThemeBuilder) =
   theme["documentTab.bar.fill"] = styleToken("tab.panel.fill")
   theme["documentTab.bar.border.color"] = styleToken("tab.panel.border.color")
   theme["documentTab.fill"] = styleToken("tab.fill")
@@ -1241,31 +1241,33 @@ proc installSynthwave83DocumentTabs(theme: var Theme) =
     ]
 
 proc initSynthwave83Theme*(): Theme =
-  result = initAquaTheme()
-  result[srDocumentTab, StyleCloseButtonPosition] = styleKeyword("right")
-  result.installSynthwave83Tokens()
-  result.installSynthwave83ControlStyles()
-  result.installSynthwave83Labels()
-  result.installSynthwave83Tables()
-  result.installSynthwave83RetroPalette()
-  result.installSynthwave83ReferencePass()
-  result.installSynthwave83VaporwavePass()
-  result.installSynthwave83ReadabilityPass()
-  result.installSynthwave83DocumentTabs()
-  result.clearBackgroundPinstripes()
+  var builder = initThemeBuilder(initAquaTheme())
+  builder[srDocumentTab, StyleCloseButtonPosition] = styleKeyword("right")
+  builder.installSynthwave83Tokens()
+  builder.installSynthwave83ControlStyles()
+  builder.installSynthwave83Labels()
+  builder.installSynthwave83Tables()
+  builder.installSynthwave83RetroPalette()
+  builder.installSynthwave83ReferencePass()
+  builder.installSynthwave83VaporwavePass()
+  builder.installSynthwave83ReadabilityPass()
+  builder.installSynthwave83DocumentTabs()
+  builder.clearBackgroundPinstripes()
 
-  result[srProgressIndicator, StyleFill] = result[srSlider, StyleFill]
-  result[srProgressIndicator, StyleHighlightFill] = styleToken("progress.fill")
-  result[srProgressIndicator, StyleBorderColor] = result[srSlider, StyleBorderColor]
-  result[srProgressIndicator, StyleFocusRingColor] = styleToken("progress.border.color")
-  result[srProgressIndicator, StyleBoxShadows] = result[srSlider, StyleBoxShadows]
+  builder[srProgressIndicator, StyleFill] = builder[srSlider, StyleFill]
+  builder[srProgressIndicator, StyleHighlightFill] = styleToken("progress.fill")
+  builder[srProgressIndicator, StyleBorderColor] = builder[srSlider, StyleBorderColor]
+  builder[srProgressIndicator, StyleFocusRingColor] =
+    styleToken("progress.border.color")
+  builder[srProgressIndicator, StyleBoxShadows] = builder[srSlider, StyleBoxShadows]
 
   for role in [
     srButton, srCheckBox, srRadioButton, srSwitch, srSlider, srProgressIndicator, srTab,
     srTabPanel, srDocumentTab, srDocumentTabBar, srDocumentTabButton, srTextField,
     srMonoTextView, srComboBox,
   ]:
-    result[role, StyleChrome] = styleKeyword(FlatTransparentChromeName)
+    builder[role, StyleChrome] = styleKeyword(FlatTransparentChromeName)
+  builder.finish()
 
 registerThemeFactory("synthwave83", initSynthwave83Theme)
 registerThemeFactory("synthwave", initSynthwave83Theme)

--- a/src/merenda/nimkit/themes/themecore.nim
+++ b/src/merenda/nimkit/themes/themecore.nim
@@ -1,4 +1,4 @@
-import std/tables
+import std/[atomics, tables]
 
 when defined(useNativeDynlib):
   import std/math
@@ -138,20 +138,23 @@ type
     selector*: StyleSelector
     patch*: StylePatch
 
-  StyleRuleIndex = ref object
-    valid: bool
-    revision: uint64
-    ruleCount: int
-    rulesByRole: array[StyleRole, seq[int]]
-
   Chrome* = ref object of DynamicAgent
 
+  ThemeGeneration* = distinct uint64
+
   Theme* = object
-    tokens*: StyleTokenStore
-    rules*: seq[StyleRule]
-    chromes*: Table[string, Chrome]
-    xRevision: uint64
-    xRuleIndex: StyleRuleIndex
+    xTokens: StyleTokenStore
+    xRules: seq[StyleRule]
+    xChromes: Table[string, Chrome]
+    xRulesByRole: array[StyleRole, seq[int]]
+    xGeneration: ThemeGeneration
+
+  ThemeBuilder* = object
+    xTokens: StyleTokenStore
+    xRules: seq[StyleRule]
+    xChromes: Table[string, Chrome]
+    xBaseGeneration: ThemeGeneration
+    xChanged: bool
 
   Appearance* = object
     theme*: Theme
@@ -233,7 +236,7 @@ type
     panelCornerRadius*: float32
     panelOverlap*: float32
 
-  ThemeInstaller* = proc(theme: var Theme)
+  ThemeInstaller* = proc(builder: var ThemeBuilder)
 
   TextFieldStyle* = object
     box*: ControlBoxStyle
@@ -375,7 +378,9 @@ const
   LabelFormStyleClass* = "label-form"
   IconLabelStyleClass* = "icon-label"
 
-var themeInstallers: seq[ThemeInstaller]
+var
+  themeInstallers: seq[ThemeInstaller]
+  themeGenerationCounter: Atomic[uint64]
 
 func insets*(top, left, bottom, right: float32): EdgeInsets =
   EdgeInsets(top: top, left: left, bottom: bottom, right: right)
@@ -587,66 +592,159 @@ proc newStyleTokenStore*(parent: StyleTokenStore = nil): StyleTokenStore =
 proc newStylePatch*(): StylePatch =
   StylePatch(values: initTable[string, StyleValue]())
 
+proc cloneText(value: string): string =
+  result = newStringOfCap(value.len)
+  result.add value
+
+proc clone(value: StyleValue): StyleValue =
+  case value.kind
+  of svMissing:
+    missingStyleValue()
+  of svColor:
+    styleColor(value.color)
+  of svFill:
+    styleFill(value.fill)
+  of svLength:
+    styleLength(value.length)
+  of svSize:
+    styleSize(value.size)
+  of svInsets:
+    styleInsets(value.insets)
+  of svShadows:
+    styleShadows(value.shadows)
+  of svToken:
+    styleToken(value.token.cloneText)
+  of svKeyword:
+    styleKeyword(value.keyword.cloneText)
+
 proc clone*(tokens: StyleTokenStore): StyleTokenStore =
   if tokens.isNil:
     return
   result = newStyleTokenStore(tokens.parent.clone)
-  result.values = tokens.values
+  for name, value in tokens.values:
+    result.values[name.cloneText] = value.clone
 
 proc clone*(patch: StylePatch): StylePatch =
   if patch.isNil:
     return
   result = newStylePatch()
-  result.values = patch.values
+  for name, value in patch.values:
+    result.values[name.cloneText] = value.clone
+
+proc clone(selector: StyleSelector): StyleSelector =
+  result.role = selector.role
+  result.states = selector.states
+  result.id = selector.id.cloneText
+  for className in selector.classes:
+    result.classes.add className.cloneText
+
+proc cloneRules(rules: openArray[StyleRule]): seq[StyleRule] =
+  for rule in rules:
+    result.add StyleRule(selector: rule.selector.clone, patch: rule.patch.clone)
+
+proc cloneChromes(chromes: Table[string, Chrome]): Table[string, Chrome] =
+  result = initTable[string, Chrome]()
+  for name, chrome in chromes:
+    result[name.cloneText] = chrome
 
 proc clone*(theme: Theme): Theme =
-  result.tokens = theme.tokens.clone
-  for rule in theme.rules:
-    result.rules.add StyleRule(selector: rule.selector, patch: rule.patch.clone)
-  result.chromes = theme.chromes
-  result.xRevision = theme.xRevision
-  result.xRuleIndex = StyleRuleIndex()
+  ## Immutable theme snapshots can be copied without changing their generation.
+  theme
 
-proc noteThemeMutation(theme: var Theme) =
-  if theme.xRuleIndex.isNil:
-    theme.xRuleIndex = StyleRuleIndex()
-  inc theme.xRevision
+proc tokens*(theme: Theme): StyleTokenStore =
+  ## Returns a mutable copy of the snapshot's token store.
+  theme.xTokens.clone
 
-proc sameAppearanceGeneration*(left, right: Appearance): bool =
+proc rules*(theme: Theme): seq[StyleRule] =
+  ## Returns a mutable copy of the snapshot's style rules.
+  theme.xRules.cloneRules()
+
+proc chromes*(theme: Theme): Table[string, Chrome] =
+  ## Returns a value copy of the snapshot's chrome registry.
+  theme.xChromes.cloneChromes
+
+func generation*(theme: Theme): ThemeGeneration =
+  theme.xGeneration
+
+func `==`*(left, right: ThemeGeneration): bool =
+  uint64(left) == uint64(right)
+
+func isInitialized*(theme: Theme): bool =
+  not theme.xTokens.isNil
+
+proc nextThemeGeneration(): ThemeGeneration =
+  ThemeGeneration(themeGenerationCounter.fetchAdd(1'u64, moRelaxed) + 1'u64)
+
+proc initThemeBuilder*(): ThemeBuilder =
+  ## Creates a builder for a new immutable theme snapshot.
+  ThemeBuilder(
+    xTokens: newStyleTokenStore(), xChromes: initTable[string, Chrome](), xChanged: true
+  )
+
+proc initThemeBuilder*(tokens: StyleTokenStore): ThemeBuilder =
+  ## Creates a builder initialized with an isolated copy of `tokens`.
+  result = initThemeBuilder()
+  result.xTokens = tokens.clone
+
+proc initThemeBuilder*(theme: Theme): ThemeBuilder =
+  ## Creates an isolated builder initialized from an immutable snapshot.
+  ThemeBuilder(
+    xTokens: theme.xTokens.clone,
+    xRules: theme.xRules.cloneRules(),
+    xChromes: theme.xChromes.cloneChromes,
+    xBaseGeneration: theme.xGeneration,
+  )
+
+proc finish*(builder: ThemeBuilder): Theme =
+  ## Freezes the builder into an immutable, independently owned snapshot.
+  result.xTokens = builder.xTokens.clone
+  result.xRules = builder.xRules.cloneRules()
+  result.xChromes = builder.xChromes.cloneChromes
+  for index, rule in result.xRules:
+    result.xRulesByRole[rule.selector.role].add index
+  if builder.xChanged or builder.xBaseGeneration == ThemeGeneration(0):
+    result.xGeneration = nextThemeGeneration()
+  else:
+    result.xGeneration = builder.xBaseGeneration
+
+proc noteThemeMutation(builder: var ThemeBuilder) =
+  builder.xChanged = true
+
+func sameAppearanceGeneration*(left, right: Appearance): bool =
   ## Compare immutable cache snapshots without traversing every theme value.
-  left.theme.tokens == right.theme.tokens and
-    left.theme.xRuleIndex == right.theme.xRuleIndex and
-    left.theme.xRevision == right.theme.xRevision
+  left.theme.xGeneration == right.theme.xGeneration
 
 proc registerThemeInstaller*(installer: ThemeInstaller) =
   themeInstallers.add installer
 
-proc installThemeExtensions*(theme: var Theme) =
+proc installThemeExtensions*(theme: var ThemeBuilder) =
   for installer in themeInstallers:
     installer(theme)
 
-proc installChrome*(theme: var Theme, name: string, chrome: Chrome) =
+proc installChrome*(theme: var ThemeBuilder, name: string, chrome: Chrome) =
   if name.len == 0:
     return
   if chrome.isNil:
-    if name in theme.chromes:
-      theme.chromes.del(name)
+    if name in theme.xChromes:
+      theme.xChromes.del(name)
       theme.noteThemeMutation()
   else:
-    if name in theme.chromes and theme.chromes[name] == chrome:
+    if name in theme.xChromes and theme.xChromes[name] == chrome:
       return
-    theme.chromes[name] = chrome
+    theme.xChromes[name] = chrome
     theme.noteThemeMutation()
 
 proc hasChrome*(theme: Theme, name: string): bool =
-  name in theme.chromes
+  name in theme.xChromes
 
 proc chrome*(theme: Theme, name: string): Chrome =
-  if name in theme.chromes:
-    return theme.chromes[name]
+  if name in theme.xChromes:
+    return theme.xChromes[name]
 
 proc installChrome*(appearance: var Appearance, name: string, chrome: Chrome) =
-  appearance.theme.installChrome(name, chrome)
+  var builder = initThemeBuilder(appearance.theme)
+  builder.installChrome(name, chrome)
+  appearance.theme = builder.finish()
 
 proc hasChrome*(appearance: Appearance, name: string): bool =
   appearance.theme.hasChrome(name)
@@ -678,29 +776,29 @@ proc `[]=`*(tokens: StyleTokenStore, name: string, value: EdgeInsets) =
 proc `[]=`*(tokens: StyleTokenStore, name: string, value: openArray[BoxShadow]) =
   tokens[name] = styleShadows(value)
 
-proc `[]=`*(theme: var Theme, name: string, value: StyleValue) =
-  theme.tokens[name] = value
+proc `[]=`*(theme: var ThemeBuilder, name: string, value: StyleValue) =
+  theme.xTokens[name] = value
   theme.noteThemeMutation()
 
-proc `[]=`*(theme: var Theme, name: string, value: Color) =
+proc `[]=`*(theme: var ThemeBuilder, name: string, value: Color) =
   theme[name] = styleColor(value)
 
-proc `[]=`*(theme: var Theme, name: string, value: Fill) =
+proc `[]=`*(theme: var ThemeBuilder, name: string, value: Fill) =
   theme[name] = styleFill(value)
 
-proc `[]=`*(theme: var Theme, name: string, value: float32) =
+proc `[]=`*(theme: var ThemeBuilder, name: string, value: float32) =
   theme[name] = styleLength(value)
 
-proc `[]=`*(theme: var Theme, name: string, value: float) =
+proc `[]=`*(theme: var ThemeBuilder, name: string, value: float) =
   theme[name] = styleLength(value.float32)
 
-proc `[]=`*(theme: var Theme, name: string, value: Size) =
+proc `[]=`*(theme: var ThemeBuilder, name: string, value: Size) =
   theme[name] = styleSize(value)
 
-proc `[]=`*(theme: var Theme, name: string, value: EdgeInsets) =
+proc `[]=`*(theme: var ThemeBuilder, name: string, value: EdgeInsets) =
   theme[name] = styleInsets(value)
 
-proc `[]=`*(theme: var Theme, name: string, value: openArray[BoxShadow]) =
+proc `[]=`*(theme: var ThemeBuilder, name: string, value: openArray[BoxShadow]) =
   theme[name] = styleShadows(value)
 
 proc lookupToken(tokens: StyleTokenStore, name: string, value: var StyleValue): bool =
@@ -830,60 +928,79 @@ func inheritedStyleRole(role: StyleRole): StyleRole =
   of srDocumentTabBar: srTabPanel
   else: role
 
-proc stylePatch*(theme: var Theme, selector: StyleSelector): StylePatch =
-  for rule in theme.rules:
+proc stylePatch(theme: var ThemeBuilder, selector: StyleSelector): StylePatch =
+  for rule in theme.xRules:
     if rule.selector == selector:
       return rule.patch
   result = newStylePatch()
-  theme.rules.add StyleRule(selector: selector, patch: result)
+  theme.xRules.add StyleRule(selector: selector, patch: result)
 
-proc stylePatch*(theme: Theme, selector: StyleSelector): StylePatch =
-  for rule in theme.rules:
+proc stylePatchView(theme: Theme, selector: StyleSelector): StylePatch =
+  for rule in theme.xRules:
     if rule.selector == selector:
       return rule.patch
 
-proc addRule*(theme: var Theme, selector: StyleSelector, patch: StylePatch) =
-  theme.rules.add StyleRule(selector: selector, patch: patch)
+proc stylePatch*(theme: Theme, selector: StyleSelector): StylePatch =
+  ## Returns a mutable copy without exposing snapshot-owned storage.
+  theme.stylePatchView(selector).clone
+
+proc addRule*(theme: var ThemeBuilder, selector: StyleSelector, patch: StylePatch) =
+  theme.xRules.add StyleRule(selector: selector, patch: patch)
   theme.noteThemeMutation()
 
 proc setStyle*[T](
-    theme: var Theme, selector: StyleSelector, key: StyleKey[T], value: StyleValue
+    theme: var ThemeBuilder,
+    selector: StyleSelector,
+    key: StyleKey[T],
+    value: StyleValue,
 ) =
   theme.stylePatch(selector).setStyle(key, value)
   theme.noteThemeMutation()
 
 proc setStyle*(
-    theme: var Theme, selector: StyleSelector, key: StyleKey[Color], value: Color
+    theme: var ThemeBuilder, selector: StyleSelector, key: string, value: StyleValue
 ) =
   theme.stylePatch(selector).setStyle(key, value)
   theme.noteThemeMutation()
 
 proc setStyle*(
-    theme: var Theme, selector: StyleSelector, key: StyleKey[Fill], value: Fill
+    theme: var ThemeBuilder, selector: StyleSelector, key: StyleKey[Color], value: Color
 ) =
   theme.stylePatch(selector).setStyle(key, value)
   theme.noteThemeMutation()
 
 proc setStyle*(
-    theme: var Theme, selector: StyleSelector, key: StyleKey[float32], value: float32
+    theme: var ThemeBuilder, selector: StyleSelector, key: StyleKey[Fill], value: Fill
 ) =
   theme.stylePatch(selector).setStyle(key, value)
   theme.noteThemeMutation()
 
 proc setStyle*(
-    theme: var Theme, selector: StyleSelector, key: StyleKey[float32], value: float
+    theme: var ThemeBuilder,
+    selector: StyleSelector,
+    key: StyleKey[float32],
+    value: float32,
 ) =
   theme.stylePatch(selector).setStyle(key, value)
   theme.noteThemeMutation()
 
 proc setStyle*(
-    theme: var Theme, selector: StyleSelector, key: StyleKey[Size], value: Size
+    theme: var ThemeBuilder,
+    selector: StyleSelector,
+    key: StyleKey[float32],
+    value: float,
 ) =
   theme.stylePatch(selector).setStyle(key, value)
   theme.noteThemeMutation()
 
 proc setStyle*(
-    theme: var Theme,
+    theme: var ThemeBuilder, selector: StyleSelector, key: StyleKey[Size], value: Size
+) =
+  theme.stylePatch(selector).setStyle(key, value)
+  theme.noteThemeMutation()
+
+proc setStyle*(
+    theme: var ThemeBuilder,
     selector: StyleSelector,
     key: StyleKey[EdgeInsets],
     value: EdgeInsets,
@@ -892,7 +1009,7 @@ proc setStyle*(
   theme.noteThemeMutation()
 
 proc setStyle*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     selector: StyleSelector,
     key: StyleKey[seq[BoxShadow]],
     value: openArray[BoxShadow],
@@ -901,36 +1018,45 @@ proc setStyle*(
   theme.noteThemeMutation()
 
 proc setStyle*[T](
-    theme: var Theme, role: StyleRole, key: StyleKey[T], value: StyleValue
-) =
-  theme.setStyle(initStyleSelector(role), key, value)
-
-proc setStyle*(theme: var Theme, role: StyleRole, key: StyleKey[Color], value: Color) =
-  theme.setStyle(initStyleSelector(role), key, value)
-
-proc setStyle*(theme: var Theme, role: StyleRole, key: StyleKey[Fill], value: Fill) =
-  theme.setStyle(initStyleSelector(role), key, value)
-
-proc setStyle*(
-    theme: var Theme, role: StyleRole, key: StyleKey[float32], value: float32
+    theme: var ThemeBuilder, role: StyleRole, key: StyleKey[T], value: StyleValue
 ) =
   theme.setStyle(initStyleSelector(role), key, value)
 
 proc setStyle*(
-    theme: var Theme, role: StyleRole, key: StyleKey[float32], value: float
-) =
-  theme.setStyle(initStyleSelector(role), key, value)
-
-proc setStyle*(theme: var Theme, role: StyleRole, key: StyleKey[Size], value: Size) =
-  theme.setStyle(initStyleSelector(role), key, value)
-
-proc setStyle*(
-    theme: var Theme, role: StyleRole, key: StyleKey[EdgeInsets], value: EdgeInsets
+    theme: var ThemeBuilder, role: StyleRole, key: StyleKey[Color], value: Color
 ) =
   theme.setStyle(initStyleSelector(role), key, value)
 
 proc setStyle*(
-    theme: var Theme,
+    theme: var ThemeBuilder, role: StyleRole, key: StyleKey[Fill], value: Fill
+) =
+  theme.setStyle(initStyleSelector(role), key, value)
+
+proc setStyle*(
+    theme: var ThemeBuilder, role: StyleRole, key: StyleKey[float32], value: float32
+) =
+  theme.setStyle(initStyleSelector(role), key, value)
+
+proc setStyle*(
+    theme: var ThemeBuilder, role: StyleRole, key: StyleKey[float32], value: float
+) =
+  theme.setStyle(initStyleSelector(role), key, value)
+
+proc setStyle*(
+    theme: var ThemeBuilder, role: StyleRole, key: StyleKey[Size], value: Size
+) =
+  theme.setStyle(initStyleSelector(role), key, value)
+
+proc setStyle*(
+    theme: var ThemeBuilder,
+    role: StyleRole,
+    key: StyleKey[EdgeInsets],
+    value: EdgeInsets,
+) =
+  theme.setStyle(initStyleSelector(role), key, value)
+
+proc setStyle*(
+    theme: var ThemeBuilder,
     role: StyleRole,
     key: StyleKey[seq[BoxShadow]],
     value: openArray[BoxShadow],
@@ -938,7 +1064,7 @@ proc setStyle*(
   theme.setStyle(initStyleSelector(role), key, value)
 
 proc setStyle*[T](
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[T],
@@ -947,7 +1073,7 @@ proc setStyle*[T](
   theme.setStyle(initStyleSelector(role, states), key, value)
 
 proc setStyle*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[Color],
@@ -956,7 +1082,7 @@ proc setStyle*(
   theme.setStyle(initStyleSelector(role, states), key, value)
 
 proc setStyle*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[Fill],
@@ -965,7 +1091,7 @@ proc setStyle*(
   theme.setStyle(initStyleSelector(role, states), key, value)
 
 proc setStyle*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[float32],
@@ -974,7 +1100,7 @@ proc setStyle*(
   theme.setStyle(initStyleSelector(role, states), key, value)
 
 proc setStyle*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[Size],
@@ -983,7 +1109,7 @@ proc setStyle*(
   theme.setStyle(initStyleSelector(role, states), key, value)
 
 proc setStyle*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[float32],
@@ -992,7 +1118,7 @@ proc setStyle*(
   theme.setStyle(initStyleSelector(role, states), key, value)
 
 proc setStyle*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[EdgeInsets],
@@ -1001,7 +1127,7 @@ proc setStyle*(
   theme.setStyle(initStyleSelector(role, states), key, value)
 
 proc setStyle*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[seq[BoxShadow]],
@@ -1010,37 +1136,46 @@ proc setStyle*(
   theme.setStyle(initStyleSelector(role, states), key, value)
 
 proc `[]=`*[T](
-    theme: var Theme, selector: StyleSelector, key: StyleKey[T], value: StyleValue
+    theme: var ThemeBuilder,
+    selector: StyleSelector,
+    key: StyleKey[T],
+    value: StyleValue,
 ) =
   theme.setStyle(selector, key, value)
 
 proc `[]=`*(
-    theme: var Theme, selector: StyleSelector, key: StyleKey[Color], value: Color
+    theme: var ThemeBuilder, selector: StyleSelector, key: StyleKey[Color], value: Color
 ) =
   theme.setStyle(selector, key, value)
 
 proc `[]=`*(
-    theme: var Theme, selector: StyleSelector, key: StyleKey[Fill], value: Fill
+    theme: var ThemeBuilder, selector: StyleSelector, key: StyleKey[Fill], value: Fill
 ) =
   theme.setStyle(selector, key, value)
 
 proc `[]=`*(
-    theme: var Theme, selector: StyleSelector, key: StyleKey[float32], value: float32
+    theme: var ThemeBuilder,
+    selector: StyleSelector,
+    key: StyleKey[float32],
+    value: float32,
 ) =
   theme.setStyle(selector, key, value)
 
 proc `[]=`*(
-    theme: var Theme, selector: StyleSelector, key: StyleKey[float32], value: float
+    theme: var ThemeBuilder,
+    selector: StyleSelector,
+    key: StyleKey[float32],
+    value: float,
 ) =
   theme.setStyle(selector, key, value)
 
 proc `[]=`*(
-    theme: var Theme, selector: StyleSelector, key: StyleKey[Size], value: Size
+    theme: var ThemeBuilder, selector: StyleSelector, key: StyleKey[Size], value: Size
 ) =
   theme.setStyle(selector, key, value)
 
 proc `[]=`*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     selector: StyleSelector,
     key: StyleKey[EdgeInsets],
     value: EdgeInsets,
@@ -1048,38 +1183,53 @@ proc `[]=`*(
   theme.setStyle(selector, key, value)
 
 proc `[]=`*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     selector: StyleSelector,
     key: StyleKey[seq[BoxShadow]],
     value: openArray[BoxShadow],
 ) =
   theme.setStyle(selector, key, value)
 
-proc `[]=`*[T](theme: var Theme, role: StyleRole, key: StyleKey[T], value: StyleValue) =
-  theme.setStyle(role, key, value)
-
-proc `[]=`*(theme: var Theme, role: StyleRole, key: StyleKey[Color], value: Color) =
-  theme.setStyle(role, key, value)
-
-proc `[]=`*(theme: var Theme, role: StyleRole, key: StyleKey[Fill], value: Fill) =
-  theme.setStyle(role, key, value)
-
-proc `[]=`*(theme: var Theme, role: StyleRole, key: StyleKey[float32], value: float32) =
-  theme.setStyle(role, key, value)
-
-proc `[]=`*(theme: var Theme, role: StyleRole, key: StyleKey[float32], value: float) =
-  theme.setStyle(role, key, value)
-
-proc `[]=`*(theme: var Theme, role: StyleRole, key: StyleKey[Size], value: Size) =
-  theme.setStyle(role, key, value)
-
-proc `[]=`*(
-    theme: var Theme, role: StyleRole, key: StyleKey[EdgeInsets], value: EdgeInsets
+proc `[]=`*[T](
+    theme: var ThemeBuilder, role: StyleRole, key: StyleKey[T], value: StyleValue
 ) =
   theme.setStyle(role, key, value)
 
 proc `[]=`*(
-    theme: var Theme,
+    theme: var ThemeBuilder, role: StyleRole, key: StyleKey[Color], value: Color
+) =
+  theme.setStyle(role, key, value)
+
+proc `[]=`*(
+    theme: var ThemeBuilder, role: StyleRole, key: StyleKey[Fill], value: Fill
+) =
+  theme.setStyle(role, key, value)
+
+proc `[]=`*(
+    theme: var ThemeBuilder, role: StyleRole, key: StyleKey[float32], value: float32
+) =
+  theme.setStyle(role, key, value)
+
+proc `[]=`*(
+    theme: var ThemeBuilder, role: StyleRole, key: StyleKey[float32], value: float
+) =
+  theme.setStyle(role, key, value)
+
+proc `[]=`*(
+    theme: var ThemeBuilder, role: StyleRole, key: StyleKey[Size], value: Size
+) =
+  theme.setStyle(role, key, value)
+
+proc `[]=`*(
+    theme: var ThemeBuilder,
+    role: StyleRole,
+    key: StyleKey[EdgeInsets],
+    value: EdgeInsets,
+) =
+  theme.setStyle(role, key, value)
+
+proc `[]=`*(
+    theme: var ThemeBuilder,
     role: StyleRole,
     key: StyleKey[seq[BoxShadow]],
     value: openArray[BoxShadow],
@@ -1087,7 +1237,7 @@ proc `[]=`*(
   theme.setStyle(role, key, value)
 
 proc `[]=`*[T](
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[T],
@@ -1096,7 +1246,7 @@ proc `[]=`*[T](
   theme.setStyle(role, states, key, value)
 
 proc `[]=`*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[Color],
@@ -1105,7 +1255,7 @@ proc `[]=`*(
   theme.setStyle(role, states, key, value)
 
 proc `[]=`*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[Fill],
@@ -1114,7 +1264,7 @@ proc `[]=`*(
   theme.setStyle(role, states, key, value)
 
 proc `[]=`*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[float32],
@@ -1123,7 +1273,7 @@ proc `[]=`*(
   theme.setStyle(role, states, key, value)
 
 proc `[]=`*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[float32],
@@ -1132,7 +1282,7 @@ proc `[]=`*(
   theme.setStyle(role, states, key, value)
 
 proc `[]=`*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[Size],
@@ -1141,7 +1291,7 @@ proc `[]=`*(
   theme.setStyle(role, states, key, value)
 
 proc `[]=`*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[EdgeInsets],
@@ -1150,7 +1300,7 @@ proc `[]=`*(
   theme.setStyle(role, states, key, value)
 
 proc `[]=`*(
-    theme: var Theme,
+    theme: var ThemeBuilder,
     role: StyleRole,
     states: set[WidgetState],
     key: StyleKey[seq[BoxShadow]],
@@ -1159,24 +1309,15 @@ proc `[]=`*(
   theme.setStyle(role, states, key, value)
 
 proc `[]`*[T](theme: Theme, role: StyleRole, key: StyleKey[T]): StyleValue =
-  let patch = theme.stylePatch(initStyleSelector(role))
+  let patch = theme.stylePatchView(initStyleSelector(role))
   if patch.isNil or not patch.getStyle(key, result):
     result = missingStyleValue()
 
-proc indexedRules(theme: Theme): StyleRuleIndex =
-  result = theme.xRuleIndex
-  if result.isNil:
-    return
-  if result.valid and result.revision == theme.xRevision and
-      result.ruleCount == theme.rules.len:
-    return
-  for role in StyleRole:
-    result.rulesByRole[role].setLen(0)
-  for index, rule in theme.rules:
-    result.rulesByRole[rule.selector.role].add index
-  result.valid = true
-  result.revision = theme.xRevision
-  result.ruleCount = theme.rules.len
+proc `[]`*[T](theme: ThemeBuilder, role: StyleRole, key: StyleKey[T]): StyleValue =
+  for rule in theme.xRules:
+    if rule.selector == initStyleSelector(role) and rule.patch.getStyle(key, result):
+      return
+  result = missingStyleValue()
 
 proc ruleValue(
     theme: Theme, context: StyleContext, key: string, fallback: StyleValue
@@ -1185,9 +1326,7 @@ proc ruleValue(
   var
     bestSpecificity = -1
     inheritedContext = context
-  let
-    inheritedRole = context.role.inheritedStyleRole()
-    index = theme.indexedRules()
+  let inheritedRole = context.role.inheritedStyleRole()
   inheritedContext.role = inheritedRole
 
   template applyRule(rule: StyleRule, matchContext: StyleContext, roleRank: int) =
@@ -1197,24 +1336,18 @@ proc ruleValue(
         let ruleSpecificity = rule.selector.specificity() * 10 + roleRank
         if ruleSpecificity >= bestSpecificity:
           var resolved: StyleValue
-          if theme.tokens.resolveValue(value, resolved):
+          if theme.xTokens.resolveValue(value, resolved):
             result = resolved
             bestSpecificity = ruleSpecificity
           elif value.kind != svToken:
             result = value
             bestSpecificity = ruleSpecificity
 
-  if index.isNil:
-    for rule in theme.rules:
-      if inheritedRole != context.role:
-        applyRule(rule, inheritedContext, 0)
-      applyRule(rule, context, 1)
-  else:
-    if inheritedRole != context.role:
-      for ruleIndex in index.rulesByRole[inheritedRole]:
-        applyRule(theme.rules[ruleIndex], inheritedContext, 0)
-    for ruleIndex in index.rulesByRole[context.role]:
-      applyRule(theme.rules[ruleIndex], context, 1)
+  if inheritedRole != context.role:
+    for ruleIndex in theme.xRulesByRole[inheritedRole]:
+      applyRule(theme.xRules[ruleIndex], inheritedContext, 0)
+  for ruleIndex in theme.xRulesByRole[context.role]:
+    applyRule(theme.xRules[ruleIndex], context, 1)
 
 proc colorRule(
     theme: Theme, context: StyleContext, key: StyleKey[Color], fallback: Color
@@ -1274,9 +1407,9 @@ proc keywordRule(
   if value.kind == svKeyword: value.keyword else: fallback
 
 proc styleValue*(theme: Theme, name: string, fallback: StyleValue): StyleValue =
-  if theme.tokens.isNil:
+  if theme.xTokens.isNil:
     return fallback
-  if not theme.tokens.resolveToken(name, result):
+  if not theme.xTokens.resolveToken(name, result):
     result = fallback
 
 proc colorToken*(theme: Theme, name: string, fallback: Color): Color =
@@ -1340,7 +1473,7 @@ proc fontName*(theme: Theme, role: FontRole): string =
   else:
     defaultFontName(role)
 
-proc setFontName*(theme: var Theme, role: FontRole, name: string) =
+proc setFontName*(theme: var ThemeBuilder, role: FontRole, name: string) =
   ## Sets a font role, or restores its environment/bundled default when empty.
   let resolved =
     if name.len > 0:
@@ -1463,13 +1596,20 @@ proc resolveTextStyle*(
 ): TextStyle =
   appearance.theme.resolveTextStyle(context, colorFallback, insetsFallback)
 
+template editAppearanceTheme(appearance: var Appearance, body: untyped) =
+  block:
+    var builder {.inject.} = initThemeBuilder(appearance.theme)
+    body
+    appearance.theme = builder.finish()
+
 proc setStyle*[T](
     appearance: var Appearance,
     selector: StyleSelector,
     key: StyleKey[T],
     value: StyleValue,
 ) =
-  appearance.theme.setStyle(selector, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(selector, key, value)
 
 proc setStyle*(
     appearance: var Appearance,
@@ -1477,7 +1617,8 @@ proc setStyle*(
     key: StyleKey[Color],
     value: Color,
 ) =
-  appearance.theme.setStyle(selector, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(selector, key, value)
 
 proc setStyle*(
     appearance: var Appearance,
@@ -1485,7 +1626,8 @@ proc setStyle*(
     key: StyleKey[Fill],
     value: Fill,
 ) =
-  appearance.theme.setStyle(selector, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(selector, key, value)
 
 proc setStyle*(
     appearance: var Appearance,
@@ -1493,7 +1635,8 @@ proc setStyle*(
     key: StyleKey[float32],
     value: float32,
 ) =
-  appearance.theme.setStyle(selector, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(selector, key, value)
 
 proc setStyle*(
     appearance: var Appearance,
@@ -1501,7 +1644,8 @@ proc setStyle*(
     key: StyleKey[Size],
     value: Size,
 ) =
-  appearance.theme.setStyle(selector, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(selector, key, value)
 
 proc setStyle*(
     appearance: var Appearance,
@@ -1509,7 +1653,8 @@ proc setStyle*(
     key: StyleKey[float32],
     value: float,
 ) =
-  appearance.theme.setStyle(selector, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(selector, key, value)
 
 proc setStyle*(
     appearance: var Appearance,
@@ -1517,7 +1662,8 @@ proc setStyle*(
     key: StyleKey[EdgeInsets],
     value: EdgeInsets,
 ) =
-  appearance.theme.setStyle(selector, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(selector, key, value)
 
 proc setStyle*(
     appearance: var Appearance,
@@ -1525,37 +1671,44 @@ proc setStyle*(
     key: StyleKey[seq[BoxShadow]],
     value: openArray[BoxShadow],
 ) =
-  appearance.theme.setStyle(selector, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(selector, key, value)
 
 proc setStyle*[T](
     appearance: var Appearance, role: StyleRole, key: StyleKey[T], value: StyleValue
 ) =
-  appearance.theme.setStyle(role, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(role, key, value)
 
 proc setStyle*(
     appearance: var Appearance, role: StyleRole, key: StyleKey[Color], value: Color
 ) =
-  appearance.theme.setStyle(role, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(role, key, value)
 
 proc setStyle*(
     appearance: var Appearance, role: StyleRole, key: StyleKey[Fill], value: Fill
 ) =
-  appearance.theme.setStyle(role, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(role, key, value)
 
 proc setStyle*(
     appearance: var Appearance, role: StyleRole, key: StyleKey[float32], value: float32
 ) =
-  appearance.theme.setStyle(role, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(role, key, value)
 
 proc setStyle*(
     appearance: var Appearance, role: StyleRole, key: StyleKey[float32], value: float
 ) =
-  appearance.theme.setStyle(role, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(role, key, value)
 
 proc setStyle*(
     appearance: var Appearance, role: StyleRole, key: StyleKey[Size], value: Size
 ) =
-  appearance.theme.setStyle(role, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(role, key, value)
 
 proc setStyle*(
     appearance: var Appearance,
@@ -1563,7 +1716,8 @@ proc setStyle*(
     key: StyleKey[EdgeInsets],
     value: EdgeInsets,
 ) =
-  appearance.theme.setStyle(role, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(role, key, value)
 
 proc setStyle*(
     appearance: var Appearance,
@@ -1571,7 +1725,8 @@ proc setStyle*(
     key: StyleKey[seq[BoxShadow]],
     value: openArray[BoxShadow],
 ) =
-  appearance.theme.setStyle(role, key, value)
+  editAppearanceTheme(appearance):
+    builder.setStyle(role, key, value)
 
 proc `[]=`*[T](
     appearance: var Appearance,
@@ -1579,7 +1734,8 @@ proc `[]=`*[T](
     key: StyleKey[T],
     value: StyleValue,
 ) =
-  appearance.theme[selector, key] = value
+  editAppearanceTheme(appearance):
+    builder[selector, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1587,7 +1743,8 @@ proc `[]=`*(
     key: StyleKey[Color],
     value: Color,
 ) =
-  appearance.theme[selector, key] = value
+  editAppearanceTheme(appearance):
+    builder[selector, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1595,7 +1752,8 @@ proc `[]=`*(
     key: StyleKey[Fill],
     value: Fill,
 ) =
-  appearance.theme[selector, key] = value
+  editAppearanceTheme(appearance):
+    builder[selector, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1603,7 +1761,8 @@ proc `[]=`*(
     key: StyleKey[float32],
     value: float32,
 ) =
-  appearance.theme[selector, key] = value
+  editAppearanceTheme(appearance):
+    builder[selector, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1611,7 +1770,8 @@ proc `[]=`*(
     key: StyleKey[float32],
     value: float,
 ) =
-  appearance.theme[selector, key] = value
+  editAppearanceTheme(appearance):
+    builder[selector, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1619,7 +1779,8 @@ proc `[]=`*(
     key: StyleKey[Size],
     value: Size,
 ) =
-  appearance.theme[selector, key] = value
+  editAppearanceTheme(appearance):
+    builder[selector, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1627,7 +1788,8 @@ proc `[]=`*(
     key: StyleKey[EdgeInsets],
     value: EdgeInsets,
 ) =
-  appearance.theme[selector, key] = value
+  editAppearanceTheme(appearance):
+    builder[selector, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1635,7 +1797,8 @@ proc `[]=`*(
     key: StyleKey[seq[BoxShadow]],
     value: openArray[BoxShadow],
 ) =
-  appearance.theme[selector, key] = value
+  editAppearanceTheme(appearance):
+    builder[selector, key] = value
 
 proc `[]=`*[T](
     appearance: var Appearance, role: StyleRole, key: StyleKey[T], value: StyleValue
@@ -1690,7 +1853,8 @@ proc `[]=`*[T](
     key: StyleKey[T],
     value: StyleValue,
 ) =
-  appearance.theme[role, states, key] = value
+  editAppearanceTheme(appearance):
+    builder[role, states, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1699,7 +1863,8 @@ proc `[]=`*(
     key: StyleKey[Color],
     value: Color,
 ) =
-  appearance.theme[role, states, key] = value
+  editAppearanceTheme(appearance):
+    builder[role, states, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1708,7 +1873,8 @@ proc `[]=`*(
     key: StyleKey[Fill],
     value: Fill,
 ) =
-  appearance.theme[role, states, key] = value
+  editAppearanceTheme(appearance):
+    builder[role, states, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1717,7 +1883,8 @@ proc `[]=`*(
     key: StyleKey[float32],
     value: float32,
 ) =
-  appearance.theme[role, states, key] = value
+  editAppearanceTheme(appearance):
+    builder[role, states, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1726,7 +1893,8 @@ proc `[]=`*(
     key: StyleKey[float32],
     value: float,
 ) =
-  appearance.theme[role, states, key] = value
+  editAppearanceTheme(appearance):
+    builder[role, states, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1735,7 +1903,8 @@ proc `[]=`*(
     key: StyleKey[Size],
     value: Size,
 ) =
-  appearance.theme[role, states, key] = value
+  editAppearanceTheme(appearance):
+    builder[role, states, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1744,7 +1913,8 @@ proc `[]=`*(
     key: StyleKey[EdgeInsets],
     value: EdgeInsets,
 ) =
-  appearance.theme[role, states, key] = value
+  editAppearanceTheme(appearance):
+    builder[role, states, key] = value
 
 proc `[]=`*(
     appearance: var Appearance,
@@ -1753,7 +1923,8 @@ proc `[]=`*(
     key: StyleKey[seq[BoxShadow]],
     value: openArray[BoxShadow],
 ) =
-  appearance.theme[role, states, key] = value
+  editAppearanceTheme(appearance):
+    builder[role, states, key] = value
 
 proc `[]`*[T](appearance: Appearance, role: StyleRole, key: StyleKey[T]): StyleValue =
   appearance.theme[role, key]

--- a/src/merenda/nimkit/view/viewprotos.nim
+++ b/src/merenda/nimkit/view/viewprotos.nim
@@ -449,7 +449,7 @@ proc effectiveAppearance*(view: View): Appearance =
     return superview.effectiveAppearance()
   if view.xHasInheritedAppearance:
     return view.xInheritedAppearance
-  if view.xInheritedAppearance.theme.tokens.isNil:
+  if not view.xInheritedAppearance.theme.isInitialized:
     view.xInheritedAppearance = initAppearance()
   view.xInheritedAppearance
 

--- a/tests/nimkit/cascadingviews.nim
+++ b/tests/nimkit/cascadingviews.nim
@@ -592,26 +592,28 @@ suite "NimKit CascadingView":
       selectedFill = color(0.80, 0.10, 0.72, 1.0)
       selectedText = color(0.94, 0.98, 1.0, 1.0)
 
-    var theme = initTheme()
-    theme[initStyleSelector(srCascadingView, classes = @["project-browser"]), StyleFill] =
-      surfaceFill
+    var builder = initThemeBuilder(initTheme())
 
-    theme[
+    builder[
+      initStyleSelector(srCascadingView, classes = @["project-browser"]), StyleFill
+    ] = surfaceFill
+
+    builder[
       initStyleSelector(srCascadingColumn, classes = @["project-browser"]), StyleFill
     ] = columnFill
 
-    theme[
+    builder[
       initStyleSelector(srCascadingScroller, classes = @["project-browser"]), StyleFill
     ] = scrollerFill
 
-    theme[
+    builder[
       initStyleSelector(
         srCascadingRowItem, {ssSelected}, classes = @["project-browser"]
       ),
       StyleFill,
     ] = selectedFill
 
-    theme[
+    builder[
       initStyleSelector(
         srCascadingRowItem, {ssSelected}, classes = @["project-browser"]
       ),
@@ -631,7 +633,7 @@ suite "NimKit CascadingView":
     firstColumn.scrollView().autohidesScrollers = false
 
     let
-      renders = buildRenders(root, initAppearance(theme))
+      renders = buildRenders(root, initAppearance(builder.finish()))
       list = renders.layers[DefaultDrawLevel]
       surfaceRect = view.rectToWindow(view.bounds())
       firstColumnRect = firstColumn.rectToWindow(firstColumn.bounds())

--- a/tests/nimkit/documenttabs.nim
+++ b/tests/nimkit/documenttabs.nim
@@ -355,11 +355,11 @@ suite "nimkit document tabs":
       short = newDocumentTabItem("Log", "log")
       long = newDocumentTabItem("sam_inference_server", "server")
 
-    var theme = initTheme()
-    theme[srDocumentTab, StyleFontSize] = DefaultFontSize
-    theme[srDocumentTab, {ssSelected}, StyleFontSize] = 32.0
+    var builder = initThemeBuilder(initTheme())
+    builder[srDocumentTab, StyleFontSize] = DefaultFontSize
+    builder[srDocumentTab, {ssSelected}, StyleFontSize] = 32.0
     let
-      appearance = initAppearance(theme)
+      appearance = initAppearance(builder.finish())
       selectedContext = controlStyle(srDocumentTab, {ssSelected})
       selectedTextStyle = appearance.resolveTextStyle(
         selectedContext, color(0.0, 0.0, 0.0, 1.0), insets(0.0)
@@ -480,10 +480,10 @@ suite "nimkit document tabs":
     discard tabs.addDocumentTabItem(selected)
     discard tabs.addDocumentTabItem(modified)
 
-    var theme = initTheme()
-    theme["accent"] = themeAccent
+    var builder = initThemeBuilder(initTheme())
+    builder["accent"] = themeAccent
     let
-      renders = buildRenders(tabs, initAppearance(theme))
+      renders = buildRenders(tabs, initAppearance(builder.finish()))
       selectedAccentFill = fill(
         color(themeAccent.r, themeAccent.g, themeAccent.b, themeAccent.a * 0.72'f32)
       )
@@ -516,15 +516,15 @@ suite "nimkit document tabs":
     discard tabs.addDocumentTabItem(selected)
 
     for position in [dtipTop, dtipBottom, dtipLeft, dtipRight, dtipNone]:
-      var theme = initTheme()
-      theme[srDocumentTab, StyleSelectionIndicatorPosition] = styleKeyword(position)
-      theme[srDocumentTab, StyleSelectionIndicatorFill] = indicatorFill
-      theme[srDocumentTab, StyleSelectionIndicatorInsets] = indicatorInsets
-      theme[srDocumentTab, StyleSelectionIndicatorSize] = indicatorSize
-      theme[srDocumentTab, StyleSelectionIndicatorCornerRadius] = 0.5
+      var builder = initThemeBuilder(initTheme())
+      builder[srDocumentTab, StyleSelectionIndicatorPosition] = styleKeyword(position)
+      builder[srDocumentTab, StyleSelectionIndicatorFill] = indicatorFill
+      builder[srDocumentTab, StyleSelectionIndicatorInsets] = indicatorInsets
+      builder[srDocumentTab, StyleSelectionIndicatorSize] = indicatorSize
+      builder[srDocumentTab, StyleSelectionIndicatorCornerRadius] = 0.5
 
       let
-        renders = buildRenders(tabs, initAppearance(theme))
+        renders = buildRenders(tabs, initAppearance(builder.finish()))
         tabRect = tabs.documentTabRect(0)
         available = tabRect.inset(indicatorInsets)
       var indicatorRect: nimkitTypes.Rect
@@ -580,9 +580,9 @@ suite "nimkit document tabs":
     for theme in [initTheme(), initMacOSTheme(), initMacOSDarkTheme()]:
       check closeSymbolRect(theme).center().x < tabRect.center().x
 
-    var rightTheme = initTheme()
-    rightTheme[srDocumentTab, StyleCloseButtonPosition] = styleKeyword(dtcbRight)
-    check closeSymbolRect(rightTheme).center().x > tabRect.center().x
+    var builder = initThemeBuilder(initTheme())
+    builder[srDocumentTab, StyleCloseButtonPosition] = styleKeyword(dtcbRight)
+    check closeSymbolRect(builder.finish()).center().x > tabRect.center().x
 
   test "delegates can veto selection closing and moving while signals fire":
     let
@@ -720,12 +720,12 @@ suite "nimkit document tabs":
       discard tabs.addDocumentTabItem(newDocumentTabItem("Document " & $index))
     tabs.scrollOffset = 10.0'f32
 
-    var theme = initTheme()
-    theme[srDocumentTabButton, StyleChrome] = styleKeyword(DefaultChromeName)
-    theme[srDocumentTabButton, StyleFill] = DocumentTabButtonThemeFill
+    var builder = initThemeBuilder(initTheme())
+    builder[srDocumentTabButton, StyleChrome] = styleKeyword(DefaultChromeName)
+    builder[srDocumentTabButton, StyleFill] = DocumentTabButtonThemeFill
 
     let
-      renders = buildRenders(tabs, initAppearance(theme))
+      renders = buildRenders(tabs, initAppearance(builder.finish()))
       previousRect = tabs.scrollButtonRect(dtsbPrevious)
       nextRect = tabs.scrollButtonRect(dtsbNext)
     var
@@ -766,15 +766,15 @@ suite "nimkit document tabs":
     discard tabs.addDocumentTabItem(first)
     discard tabs.addDocumentTabItem(special)
 
-    var theme = initAquaTheme()
-    theme.installChrome(DocumentTabChromeName, newDocumentTabChromeSpy())
-    theme[srDocumentTab, StyleChrome] = styleKeyword(DocumentTabChromeName)
-    theme[srDocumentTabBar, StyleChrome] = styleKeyword(DocumentTabChromeName)
-    theme[srDocumentTabButton, StyleChrome] = styleKeyword(DocumentTabChromeName)
-    theme[initStyleSelector(srDocumentTab, id = "special-doc"), StyleFill] =
+    var builder = initThemeBuilder(initAquaTheme())
+    builder.installChrome(DocumentTabChromeName, newDocumentTabChromeSpy())
+    builder[srDocumentTab, StyleChrome] = styleKeyword(DocumentTabChromeName)
+    builder[srDocumentTabBar, StyleChrome] = styleKeyword(DocumentTabChromeName)
+    builder[srDocumentTabButton, StyleChrome] = styleKeyword(DocumentTabChromeName)
+    builder[initStyleSelector(srDocumentTab, id = "special-doc"), StyleFill] =
       SpecialDocumentTabFill
 
-    let renders = buildRenders(tabs, initAppearance(theme))
+    let renders = buildRenders(tabs, initAppearance(builder.finish()))
     var
       selectedChromeFound = false
       specialFillFound = false

--- a/tests/nimkit/font_layout.nim
+++ b/tests/nimkit/font_layout.nim
@@ -144,10 +144,10 @@ suite "nimkit font layout":
     )
 
   test "theme keeps interface and monospace font roles independent":
-    var theme = initTheme()
-    theme.setFontName(frUI, "Ubuntu.ttf")
-    theme.setFontName(frMonospace, "HackNerdFont-Regular.ttf")
-    let appearance = initAppearance(theme)
+    var builder = initThemeBuilder(initTheme())
+    builder.setFontName(frUI, "Ubuntu.ttf")
+    builder.setFontName(frMonospace, "HackNerdFont-Regular.ttf")
+    let appearance = initAppearance(builder.finish())
 
     check appearance.fontName(frUI) == "Ubuntu.ttf"
     check appearance.fontName(frMonospace) == "HackNerdFont-Regular.ttf"

--- a/tests/nimkit/monotextviews.nim
+++ b/tests/nimkit/monotextviews.nim
@@ -27,10 +27,10 @@ proc clickView(window: Window, view: View): bool =
 
 suite "nimkit mono text views":
   test "monospace font follows the theme until explicitly overridden":
-    var theme = initTheme()
-    theme.setFontName(frMonospace, "Ubuntu.ttf")
+    var builder = initThemeBuilder(initTheme())
+    builder.setFontName(frMonospace, "Ubuntu.ttf")
     let view = newMonoTextViewer("theme font")
-    view.appearance = initAppearance(theme)
+    view.appearance = initAppearance(builder.finish())
 
     check view.fontName == "Ubuntu.ttf"
     view.fontName = DefaultMonoFontName
@@ -314,14 +314,14 @@ suite "nimkit mono text views":
       surfaceFill = color(0.12, 0.16, 0.20, 1.0)
       surfaceBorder = color(0.70, 0.80, 0.90, 1.0)
       view = newMonoTextViewer("theme", frame = rect(0, 0, 220, 80))
-    var theme = initTheme()
-    theme[srMonoTextView, StyleFill] = fill(surfaceFill)
-    theme[srMonoTextView, StyleBorderColor] = surfaceBorder
-    theme[srMonoTextView, StyleBorderWidth] = 2.0
-    theme[srMonoTextView, StyleCornerRadius] = 5.0
-    theme[srMonoTextView, StyleChrome] = styleKeyword(DefaultChromeName)
+    var builder = initThemeBuilder(initTheme())
+    builder[srMonoTextView, StyleFill] = fill(surfaceFill)
+    builder[srMonoTextView, StyleBorderColor] = surfaceBorder
+    builder[srMonoTextView, StyleBorderWidth] = 2.0
+    builder[srMonoTextView, StyleCornerRadius] = 5.0
+    builder[srMonoTextView, StyleChrome] = styleKeyword(DefaultChromeName)
 
-    let list = buildRenders(view, initAppearance(theme))[DefaultDrawLevel]
+    let list = buildRenders(view, initAppearance(builder.finish()))[DefaultDrawLevel]
 
     var foundSurface = false
     for node in list.nodes:

--- a/tests/nimkit/outlineviews.nim
+++ b/tests/nimkit/outlineviews.nim
@@ -165,23 +165,24 @@ suite "NimKit OutlineView":
 
     outlineView.styleClasses = @["project-outline"]
 
-    var theme = initTheme()
-    theme[initStyleSelector(srTableView, classes = @["project-outline"]), StyleFill] =
+    var builder = initThemeBuilder(initTheme())
+
+    builder[initStyleSelector(srTableView, classes = @["project-outline"]), StyleFill] =
       surfaceFill
 
-    theme[
+    builder[
       initStyleSelector(srTableView, classes = @["project-outline"]), StyleBorderColor
     ] = borderColor
 
-    theme[
+    builder[
       initStyleSelector(srTableView, classes = @["project-outline"]), StyleBorderWidth
     ] = 2.0'f32
 
-    theme[
+    builder[
       initStyleSelector(srTableView, classes = @["project-outline"]), StyleCornerRadius
     ] = 5.0'f32
 
-    let renders = buildRenders(outlineView, initAppearance(theme))
+    let renders = buildRenders(outlineView, initAppearance(builder.finish()))
     check DefaultDrawLevel in renders
 
     var surfaceFound = false

--- a/tests/nimkit/rendering.nim
+++ b/tests/nimkit/rendering.nim
@@ -252,12 +252,13 @@ suite "nimkit rendering":
       highlightColor = color(1.0, 1.0, 1.0, 0.4)
       stripeColor = color(0.2, 0.3, 0.4, 0.2)
 
-    var theme = initAquaTheme()
-    theme[srView, StyleBackgroundFill] = baseFill
-    theme[srView, StyleBackgroundPinstripeHighlightColor] = highlightColor
-    theme[srView, StyleBackgroundPinstripeColor] = stripeColor
-    theme[srView, StyleBackgroundPinstripePeriod] = 4.0
-    theme[srView, StyleBackgroundPinstripeHeight] = 1.0
+    var builder = initThemeBuilder(initAquaTheme())
+    builder[srView, StyleBackgroundFill] = baseFill
+    builder[srView, StyleBackgroundPinstripeHighlightColor] = highlightColor
+    builder[srView, StyleBackgroundPinstripeColor] = stripeColor
+    builder[srView, StyleBackgroundPinstripePeriod] = 4.0
+    builder[srView, StyleBackgroundPinstripeHeight] = 1.0
+    let theme = builder.finish()
 
     root.addSubview(child)
 
@@ -322,23 +323,23 @@ suite "nimkit rendering":
           insetShadow(color(1, 1, 1, 0.20), y = -1.0, blur = 1.0),
         ]
 
-    var theme = initTheme()
-    theme[srButton, StyleFill] = buttonFill
-    theme[srButton, StyleBorderColor] = buttonBorder
-    theme[srButton, StyleBorderWidth] = 3.0
-    theme[srButton, StyleCornerRadius] = 6.0
-    theme[srButton, StyleTextInsets] = insets(1.0, 9.0)
-    theme[srButton, StyleBoxShadows] = buttonShadows
-    theme[srTextField, StyleFill] = fieldFill
-    theme[srTextField, StyleBorderColor] = fieldBorder
-    theme[srTextField, StyleBorderWidth] = 2.0
-    theme[srTextField, StyleCornerRadius] = 5.0
-    theme[srTextField, StyleTextInsets] = insets(2.0, 7.0)
+    var builder = initThemeBuilder(initTheme())
+    builder[srButton, StyleFill] = buttonFill
+    builder[srButton, StyleBorderColor] = buttonBorder
+    builder[srButton, StyleBorderWidth] = 3.0
+    builder[srButton, StyleCornerRadius] = 6.0
+    builder[srButton, StyleTextInsets] = insets(1.0, 9.0)
+    builder[srButton, StyleBoxShadows] = buttonShadows
+    builder[srTextField, StyleFill] = fieldFill
+    builder[srTextField, StyleBorderColor] = fieldBorder
+    builder[srTextField, StyleBorderWidth] = 2.0
+    builder[srTextField, StyleCornerRadius] = 5.0
+    builder[srTextField, StyleTextInsets] = insets(2.0, 7.0)
 
     root.addSubview(field)
     root.addSubview(button)
 
-    let renders = buildRenders(root, initAppearance(theme))
+    let renders = buildRenders(root, initAppearance(builder.finish()))
     let list = renders[DefaultDrawLevel]
 
     var
@@ -488,18 +489,18 @@ suite "nimkit rendering":
       expectedKnobFill = fill(color(0.35, 0.35, 0.55, 0.85))
       expectedKnobRect = rect(45.0, 25.0, 20.0, 20.0)
 
-    var theme = initAquaTheme()
-    theme[srSlider, StyleChrome] = styleKeyword(DefaultChromeName)
-    theme[srSlider, StyleKnobSize] = 20.0
-    theme[srSlider, StyleIndicatorSize] = 6.0
-    theme[srSlider, StyleKnobFill] = knobFill
-    theme[srSlider, StyleHighlightFill] = activeFill
-    theme[srSlider, StyleKnobBorderColor] = color(0.0, 0.0, 0.0, 0.0)
-    theme[srSlider, StyleKnobShadows] = newSeq[BoxShadow]()
+    var builder = initThemeBuilder(initAquaTheme())
+    builder[srSlider, StyleChrome] = styleKeyword(DefaultChromeName)
+    builder[srSlider, StyleKnobSize] = 20.0
+    builder[srSlider, StyleIndicatorSize] = 6.0
+    builder[srSlider, StyleKnobFill] = knobFill
+    builder[srSlider, StyleHighlightFill] = activeFill
+    builder[srSlider, StyleKnobBorderColor] = color(0.0, 0.0, 0.0, 0.0)
+    builder[srSlider, StyleKnobShadows] = newSeq[BoxShadow]()
 
     root.addSubview(slider)
 
-    let list = buildRenders(root, initAppearance(theme))[DefaultDrawLevel]
+    let list = buildRenders(root, initAppearance(builder.finish()))[DefaultDrawLevel]
 
     var knobFound = false
     for node in list.nodes:
@@ -596,10 +597,11 @@ suite "nimkit rendering":
       root = newView(frame = rect(0, 0, 180, 90))
       button = newButton("OK", frame = rect(20, 24, 120, 32))
 
-    var theme = initTheme()
-    theme[srButton, StyleChrome] = styleKeyword(DefaultChromeName)
-    theme[srButton, StyleTextHighlightColor] = color(0.0, 0.0, 0.0, 0.0)
-    theme[srButton, StyleTextShadowColor] = color(0.0, 0.0, 0.0, 0.0)
+    var builder = initThemeBuilder(initTheme())
+    builder[srButton, StyleChrome] = styleKeyword(DefaultChromeName)
+    builder[srButton, StyleTextHighlightColor] = color(0.0, 0.0, 0.0, 0.0)
+    builder[srButton, StyleTextShadowColor] = color(0.0, 0.0, 0.0, 0.0)
+    let theme = builder.finish()
     root.addSubview(button)
 
     let
@@ -663,13 +665,13 @@ suite "nimkit rendering":
     root.addSubview(normalButton)
     root.addSubview(specialButton)
 
-    var theme = initTheme()
-    theme.installChrome(ExtraChromeName, newExtraChrome())
-    theme[initStyleSelector(srButton, id = "special"), StyleChrome] =
+    var builder = initThemeBuilder(initTheme())
+    builder.installChrome(ExtraChromeName, newExtraChrome())
+    builder[initStyleSelector(srButton, id = "special"), StyleChrome] =
       styleKeyword(ExtraChromeName)
 
     let
-      list = buildRenders(root, initAppearance(theme))[DefaultDrawLevel]
+      list = buildRenders(root, initAppearance(builder.finish()))[DefaultDrawLevel]
       expectedExtraRect =
         specialButton.rectToWindow(specialButton.bounds).inset(insets(5.0))
 
@@ -694,15 +696,15 @@ suite "nimkit rendering":
     root.addSubview(checkbox)
     root.addSubview(combo)
 
-    var theme = initTheme()
-    theme.installChrome(ExtraChromeName, newExtraChrome())
-    theme[initStyleSelector(srCheckBox, id = "special-choice"), StyleChrome] =
+    var builder = initThemeBuilder(initTheme())
+    builder.installChrome(ExtraChromeName, newExtraChrome())
+    builder[initStyleSelector(srCheckBox, id = "special-choice"), StyleChrome] =
       styleKeyword(ExtraChromeName)
-    theme[initStyleSelector(srComboBox, id = "special-combo"), StyleChrome] =
+    builder[initStyleSelector(srComboBox, id = "special-combo"), StyleChrome] =
       styleKeyword(ExtraChromeName)
 
     let
-      appearance = initAppearance(theme)
+      appearance = initAppearance(builder.finish())
       checkStyle = appearance.resolveChoiceButtonStyle(
         controlStyle(srCheckBox, id = checkbox.styleId, classes = checkbox.styleClasses)
       )
@@ -1040,18 +1042,18 @@ suite "nimkit rendering":
       selectedText = color(1.0, 1.0, 1.0, 1.0)
       focusColor = color(0.91, 0.38, 0.18, 0.66)
 
-    var theme = initTheme()
-    theme[srTableView, StyleFill] = tableFill
-    theme[srTableView, StyleBorderColor] = tableBorder
-    theme[srTableView, StyleBorderWidth] = 2.0
-    theme[srTableView, StyleCornerRadius] = 4.0
-    theme[srTableView, StyleFocusRingWidth] = 3.0
-    theme[srTableView, StyleFocusRingInset] = -1.0
-    theme[srTableView, StyleFocusRingColor] = focusColor
-    theme[srRowItem, {ssSelected}, StyleFill] = selectedFill
-    theme[srRowItem, {ssSelected}, StyleTextColor] = selectedText
-    theme[srRowItem, {ssHovered}, StyleFill] = hoverFill
-    theme[srRowItem, StyleTextInsets] = insets(0.0, 5.0)
+    var builder = initThemeBuilder(initTheme())
+    builder[srTableView, StyleFill] = tableFill
+    builder[srTableView, StyleBorderColor] = tableBorder
+    builder[srTableView, StyleBorderWidth] = 2.0
+    builder[srTableView, StyleCornerRadius] = 4.0
+    builder[srTableView, StyleFocusRingWidth] = 3.0
+    builder[srTableView, StyleFocusRingInset] = -1.0
+    builder[srTableView, StyleFocusRingColor] = focusColor
+    builder[srRowItem, {ssSelected}, StyleFill] = selectedFill
+    builder[srRowItem, {ssSelected}, StyleTextColor] = selectedText
+    builder[srRowItem, {ssHovered}, StyleFill] = hoverFill
+    builder[srRowItem, StyleTextInsets] = insets(0.0, 5.0)
 
     tableView.rowHeight = 20.0
     tableView.selectedIndex = 1
@@ -1059,7 +1061,7 @@ suite "nimkit rendering":
     tableView.focusVisible = true
     root.addSubview(tableView)
 
-    let list = buildRenders(root, initAppearance(theme))[DefaultDrawLevel]
+    let list = buildRenders(root, initAppearance(builder.finish()))[DefaultDrawLevel]
 
     var
       selectedRowFound = false
@@ -1111,12 +1113,12 @@ suite "nimkit rendering":
     tableView.visibleRows = 3
     root.addSubview(tableView)
 
-    var theme = initTheme()
-    theme[srTableView, StyleBorderWidth] = 1.0
-    theme[srTableView, StyleCornerRadius] = 6.0
-    theme[srRowItem, StyleFill] = rowFill
+    var builder = initThemeBuilder(initTheme())
+    builder[srTableView, StyleBorderWidth] = 1.0
+    builder[srTableView, StyleCornerRadius] = 6.0
+    builder[srRowItem, StyleFill] = rowFill
 
-    let list = buildRenders(root, initAppearance(theme))[DefaultDrawLevel]
+    let list = buildRenders(root, initAppearance(builder.finish()))[DefaultDrawLevel]
     var
       firstRowFound = false
       middleRowFound = false
@@ -1158,13 +1160,13 @@ suite "nimkit rendering":
     tableView.addColumn(newTableColumn("value", "Value", width = 120.0))
     tableView.focusVisible = true
 
-    var theme = initTheme()
-    theme[srTableView, StyleFocusRingWidth] = 3.0
-    theme[srTableView, StyleFocusRingInset] = -1.0
-    theme[srTableView, StyleFocusRingColor] = focusColor
+    var builder = initThemeBuilder(initTheme())
+    builder[srTableView, StyleFocusRingWidth] = 3.0
+    builder[srTableView, StyleFocusRingInset] = -1.0
+    builder[srTableView, StyleFocusRingColor] = focusColor
     root.addSubview(tableView)
 
-    let renders = buildRenders(root, initAppearance(theme))
+    let renders = buildRenders(root, initAppearance(builder.finish()))
     let list = renders[FocusRingDrawLevel]
     var
       bodyFocusRingFound = false
@@ -1205,13 +1207,13 @@ suite "nimkit rendering":
     tableView.showsHeader = false
     tableView.focusVisible = true
 
-    var theme = initTheme()
-    theme[srTableView, StyleFocusRingWidth] = 3.0
-    theme[srTableView, StyleFocusRingInset] = -5.0
-    theme[srTableView, StyleFocusRingColor] = focusColor
+    var builder = initThemeBuilder(initTheme())
+    builder[srTableView, StyleFocusRingWidth] = 3.0
+    builder[srTableView, StyleFocusRingInset] = -5.0
+    builder[srTableView, StyleFocusRingColor] = focusColor
     root.addSubview(tableView)
 
-    let list = buildRenders(root, initAppearance(theme))[FocusRingDrawLevel]
+    let list = buildRenders(root, initAppearance(builder.finish()))[FocusRingDrawLevel]
     var focusRingFound = false
 
     for node in list.nodes:
@@ -1243,13 +1245,13 @@ suite "nimkit rendering":
     tableView.showsHeader = false
     tableView.focusVisible = true
 
-    var theme = initTheme()
-    theme[srTableView, StyleFocusRingWidth] = 4.0
-    theme[srTableView, StyleFocusRingInset] = 12.0
-    theme[srTableView, StyleFocusRingColor] = focusColor
+    var builder = initThemeBuilder(initTheme())
+    builder[srTableView, StyleFocusRingWidth] = 4.0
+    builder[srTableView, StyleFocusRingInset] = 12.0
+    builder[srTableView, StyleFocusRingColor] = focusColor
     root.addSubview(tableView)
 
-    let list = buildRenders(root, initAppearance(theme))[FocusRingDrawLevel]
+    let list = buildRenders(root, initAppearance(builder.finish()))[FocusRingDrawLevel]
     var focusRingFound = false
 
     for node in list.nodes:
@@ -1285,11 +1287,11 @@ suite "nimkit rendering":
     clipView.addSubview(tableView)
     root.addSubview(clipView)
 
-    var theme = initTheme()
-    theme[srTableView, StyleFocusRingWidth] = 3.0
-    theme[srTableView, StyleFocusRingColor] = focusColor
+    var builder = initThemeBuilder(initTheme())
+    builder[srTableView, StyleFocusRingWidth] = 3.0
+    builder[srTableView, StyleFocusRingColor] = focusColor
 
-    let list = buildRenders(root, initAppearance(theme))[FocusRingDrawLevel]
+    let list = buildRenders(root, initAppearance(builder.finish()))[FocusRingDrawLevel]
     var focusRingFound = false
 
     for node in list.nodes:
@@ -1323,11 +1325,11 @@ suite "nimkit rendering":
     scrollView.hasHorizontalScroller = true
     scrollView.contentOffset = initPoint(40, 0)
 
-    var theme = initTheme()
-    theme[srTableView, StyleFocusRingWidth] = 3.0
-    theme[srTableView, StyleFocusRingColor] = focusColor
+    var builder = initThemeBuilder(initTheme())
+    builder[srTableView, StyleFocusRingWidth] = 3.0
+    builder[srTableView, StyleFocusRingColor] = focusColor
 
-    let list = buildRenders(root, initAppearance(theme))[FocusRingDrawLevel]
+    let list = buildRenders(root, initAppearance(builder.finish()))[FocusRingDrawLevel]
     var focusRingFound = false
 
     for node in list.nodes:
@@ -1380,14 +1382,14 @@ suite "nimkit rendering":
       button = newButton("Button", frame = rect(10, 20, 80, 24))
 
     let activeFill = color(0.8, 0.2, 0.1, 1.0)
-    var theme = initTheme()
-    theme[srButton, StyleFill] = color(0.1, 0.1, 0.1, 1.0)
-    theme[srButton, {ssActive}, StyleFill] = activeFill
+    var builder = initThemeBuilder(initTheme())
+    builder[srButton, StyleFill] = color(0.1, 0.1, 0.1, 1.0)
+    builder[srButton, {ssActive}, StyleFill] = activeFill
 
     root.addSubview(button)
     button.active = true
 
-    let list = buildRenders(root, initAppearance(theme))[DefaultDrawLevel]
+    let list = buildRenders(root, initAppearance(builder.finish()))[DefaultDrawLevel]
 
     var activeFillFound = false
     for node in list.nodes:
@@ -1407,12 +1409,12 @@ suite "nimkit rendering":
       disabledFill = color(0.3, 0.3, 0.3, 1.0)
       pressedFill = color(0.1, 0.2, 0.8, 1.0)
 
-    var theme = initTheme()
-    theme[srStepper, StyleFill] = baseFill
-    theme[srStepper, {ssDisabled}, StyleFill] = disabledFill
-    theme[srStepper, {ssPressed}, StyleFill] = pressedFill
+    var builder = initThemeBuilder(initTheme())
+    builder[srStepper, StyleFill] = baseFill
+    builder[srStepper, {ssDisabled}, StyleFill] = disabledFill
+    builder[srStepper, {ssPressed}, StyleFill] = pressedFill
 
-    root.appearance = initAppearance(theme)
+    root.appearance = initAppearance(builder.finish())
     root.addSubview(stepper)
     window.setContentView(root)
 
@@ -1447,14 +1449,14 @@ suite "nimkit rendering":
     matrix.active = true
     matrix.cellAtIndex(1).setHighlighted(true)
 
-    var theme = initTheme()
-    theme[srButton, StyleFill] = baseFill
-    theme[srButton, {ssActive}, StyleFill] = activeFill
-    theme[srButton, {ssHighlighted}, StyleFill] = pressedFill
-    theme[srButton, {ssPressed}, StyleFill] = pressedFill
+    var builder = initThemeBuilder(initTheme())
+    builder[srButton, StyleFill] = baseFill
+    builder[srButton, {ssActive}, StyleFill] = activeFill
+    builder[srButton, {ssHighlighted}, StyleFill] = pressedFill
+    builder[srButton, {ssPressed}, StyleFill] = pressedFill
 
     root.addSubview(matrix)
-    let list = buildRenders(root, initAppearance(theme))[DefaultDrawLevel]
+    let list = buildRenders(root, initAppearance(builder.finish()))[DefaultDrawLevel]
 
     var
       baseCount = 0
@@ -1479,17 +1481,17 @@ suite "nimkit rendering":
       button = newButton("Button", frame = rect(10, 20, 80, 24))
       focusColor = color(0.24, 0.48, 0.92, 0.58)
 
-    var theme = initTheme()
-    theme[srButton, StyleFocusRingWidth] = 4.0
-    theme[srButton, StyleFocusRingInset] = -2.0
-    theme[srButton, StyleFocusRingColor] = focusColor
-    theme[srButton, StyleCornerRadius] = 5.0
+    var builder = initThemeBuilder(initTheme())
+    builder[srButton, StyleFocusRingWidth] = 4.0
+    builder[srButton, StyleFocusRingInset] = -2.0
+    builder[srButton, StyleFocusRingColor] = focusColor
+    builder[srButton, StyleCornerRadius] = 5.0
 
     root.addSubview(button)
     button.focused = true
     button.focusVisible = true
 
-    let list = buildRenders(root, initAppearance(theme))[DefaultDrawLevel]
+    let list = buildRenders(root, initAppearance(builder.finish()))[DefaultDrawLevel]
 
     var focusRingFound = false
     for node in list.nodes:
@@ -1515,22 +1517,22 @@ suite "nimkit rendering":
       selectedFill = color(0.23, 0.45, 0.67, 1.0)
       markFill = color(0.91, 0.82, 0.13, 1.0)
 
-    var theme = initTheme()
+    var builder = initThemeBuilder(initTheme())
     for role in [srCheckBox, srRadioButton]:
-      theme[role, {ssSelected}, StyleFill] = selectedFill
-      theme[role, {ssSelected}, StyleMarkColor] = markFill
-      theme[role, StyleChrome] = styleKeyword(DefaultChromeName)
-      theme[role, StyleIndicatorSize] = 12.0
-      theme[role, StyleCornerRadius] = if role == srRadioButton: 6.0 else: 3.0
-      theme[role, StyleIndicatorSpacing] = 5.0
-      theme[role, StyleTextInsets] = insets(0.0, 3.0)
+      builder[role, {ssSelected}, StyleFill] = selectedFill
+      builder[role, {ssSelected}, StyleMarkColor] = markFill
+      builder[role, StyleChrome] = styleKeyword(DefaultChromeName)
+      builder[role, StyleIndicatorSize] = 12.0
+      builder[role, StyleCornerRadius] = if role == srRadioButton: 6.0 else: 3.0
+      builder[role, StyleIndicatorSpacing] = 5.0
+      builder[role, StyleTextInsets] = insets(0.0, 3.0)
 
     checkbox.state = bsOn
     radio.state = bsOn
     root.addSubview(checkbox)
     root.addSubview(radio)
 
-    let list = buildRenders(root, initAppearance(theme))[DefaultDrawLevel]
+    let list = buildRenders(root, initAppearance(builder.finish()))[DefaultDrawLevel]
 
     var
       selectedIndicatorCount = 0
@@ -1643,8 +1645,9 @@ suite "nimkit rendering":
     check invalidatedRenders != firstRenders
     check customDrawCount == 2
 
-    var theme = initTheme()
-    theme[srView, StyleFill] = color(0.1, 0.2, 0.3, 1.0)
+    var builder = initThemeBuilder(initTheme())
+    builder[srView, StyleFill] = color(0.1, 0.2, 0.3, 1.0)
+    let theme = builder.finish()
     let themedRenders = buildRenders(root, initAppearance(theme))
     check themedRenders != invalidatedRenders
     check customDrawCount == 3
@@ -1655,7 +1658,30 @@ suite "nimkit rendering":
     check rebuiltRenders != themedRenders
     check customDrawCount == 4
 
-  test "buildRenders invalidates a cached appearance after theme mutation":
+  test "buildRenders reuses cache across copies of one theme snapshot":
+    let
+      root = newView(frame = rect(0, 0, 120, 90))
+      custom = newCustomDrawView(rect(10, 12, 50, 30))
+      snapshot = initTheme()
+      firstAppearance = initAppearance(snapshot)
+      copiedAppearance = initAppearance(snapshot.clone())
+
+    customDrawCount = 0
+    root.addSubview(custom)
+    let firstRenders = buildRenders(root, firstAppearance)
+    let copiedRenders = buildRenders(root, copiedAppearance)
+
+    check copiedRenders == firstRenders
+    check customDrawCount == 1
+
+    var builder = initThemeBuilder(snapshot)
+    builder[srView, StyleFill] = color(0.22, 0.34, 0.46, 1.0)
+    let changedRenders = buildRenders(root, initAppearance(builder.finish()))
+
+    check changedRenders != firstRenders
+    check customDrawCount == 2
+
+  test "buildRenders invalidates a cached appearance after snapshot replacement":
     let
       root = newView(frame = rect(0, 0, 120, 90))
       custom = newCustomDrawView(rect(10, 12, 50, 30))

--- a/tests/nimkit/tableviews.nim
+++ b/tests/nimkit/tableviews.nim
@@ -987,12 +987,12 @@ suite "NimKit TableView":
 
     tableView.scrollView().contentOffset = initPoint(20.0, 0.0)
     tableView.focusVisible = true
-    var theme = initTheme()
-    theme[srTableView, StyleFocusRingWidth] = 3.0
-    theme[srTableView, StyleFocusRingInset] = -1.0
-    theme[srTableView, StyleFocusRingColor] = focusColor
+    var builder = initThemeBuilder(initTheme())
+    builder[srTableView, StyleFocusRingWidth] = 3.0
+    builder[srTableView, StyleFocusRingInset] = -1.0
+    builder[srTableView, StyleFocusRingColor] = focusColor
     check root.renderedFocusedCellStroke(
-      initAppearance(theme),
+      initAppearance(builder.finish()),
       3.0,
       42.0'f32 .. 46.0'f32,
       22.0'f32 .. 26.0'f32,
@@ -2289,11 +2289,12 @@ suite "NimKit TableView":
       selectedColumnFill = fill(color(0.22, 0.58, 1.0, 0.18))
       cellFocusColor = color(0.96, 0.32, 0.18, 0.90)
 
-    var theme = initTheme()
-    theme[srRowItem, {ssSelected}, StyleFill] = selectedFill
-    theme[srTableView, StyleColumnSelectionFill] = selectedColumnFill
-    theme[srRowItem, StyleFocusRingColor] = cellFocusColor
-    theme[srRowItem, StyleFocusRingWidth] = 2.0
+    var builder = initThemeBuilder(initTheme())
+    builder[srRowItem, {ssSelected}, StyleFill] = selectedFill
+    builder[srTableView, StyleColumnSelectionFill] = selectedColumnFill
+    builder[srRowItem, StyleFocusRingColor] = cellFocusColor
+    builder[srRowItem, StyleFocusRingWidth] = 2.0
+    let appearance = initAppearance(builder.finish())
 
     tableView.showsHeader = false
     tableView.rowCount = 2
@@ -2312,7 +2313,7 @@ suite "NimKit TableView":
     check tableView.focusedColumn == state
     check tableView.selectedColumns == @[state]
     check root.renderedRectangleFillIn(
-      initAppearance(theme),
+      appearance,
       selectedColumnFill,
       68.0'f32 .. 72.0'f32,
       0.0'f32 .. 2.0'f32,
@@ -2320,7 +2321,7 @@ suite "NimKit TableView":
       22.0'f32 .. 26.0'f32,
     )
     check root.renderedFocusedCellStroke(
-      initAppearance(theme),
+      appearance,
       cellFocusColor,
       2.0,
       66.0'f32 .. 78.0'f32,
@@ -2339,11 +2340,11 @@ suite "NimKit TableView":
       owner = newTableColumn("owner", "Owner", width = 80.0)
       cellFocusColor = color(0.96, 0.32, 0.18, 0.90)
 
-    var theme = initTheme()
-    theme[srRowItem, StyleFocusRingColor] = cellFocusColor
-    theme[srRowItem, StyleFocusRingWidth] = 2.0
-    theme[srTableView, StyleFocusRingColor] = cellFocusColor
-    theme[srTableView, StyleFocusRingWidth] = 2.0
+    var builder = initThemeBuilder(initTheme())
+    builder[srRowItem, StyleFocusRingColor] = cellFocusColor
+    builder[srRowItem, StyleFocusRingWidth] = 2.0
+    builder[srTableView, StyleFocusRingColor] = cellFocusColor
+    builder[srTableView, StyleFocusRingWidth] = 2.0
 
     tableView.showsHeader = false
     tableView.rowCount = 2
@@ -2360,7 +2361,7 @@ suite "NimKit TableView":
     check tableView.editingState.active
     check tableView.focusedColumn == state
     check root.renderedFocusedCellStroke(
-      initAppearance(theme),
+      initAppearance(builder.finish()),
       2.0,
       66.0'f32 .. 78.0'f32,
       0.0'f32 .. 8.0'f32,

--- a/tests/nimkit/theme.nim
+++ b/tests/nimkit/theme.nim
@@ -357,15 +357,16 @@ suite "nimkit theme":
     check not initStyleSelector(srButton, id = "secondary").matches(context)
 
   test "style rule specificity beats insertion order":
-    var theme = initTheme()
+    var builder = initThemeBuilder(initTheme())
     let
       fallback = color(0.0, 0.0, 0.0, 1.0)
       broadText = color(0.12, 0.13, 0.14, 1.0)
       highlightedText = color(0.82, 0.40, 0.12, 1.0)
       highlightedContext = controlStyle(srButton, {ssHighlighted})
 
-    theme[srButton, {ssHighlighted}, StyleTextColor] = highlightedText
-    theme[srButton, StyleTextColor] = broadText
+    builder[srButton, {ssHighlighted}, StyleTextColor] = highlightedText
+    builder[srButton, StyleTextColor] = broadText
+    let theme = builder.finish()
 
     check theme.resolveColor(controlStyle(srButton), StyleTextColor, fallback) ==
       broadText
@@ -373,28 +374,31 @@ suite "nimkit theme":
       highlightedText
 
   test "style rules prefer more matching states over later weaker states":
-    var theme = initTheme()
+    var builder = initThemeBuilder(initTheme())
     let
       fallback = color(0.0, 0.0, 0.0, 1.0)
       pressedText = color(0.16, 0.38, 0.82, 1.0)
       highlightedPressedText = color(0.90, 0.24, 0.74, 1.0)
       context = controlStyle(srButton, {ssHighlighted, ssPressed})
 
-    theme[srButton, {ssHighlighted, ssPressed}, StyleTextColor] = highlightedPressedText
-    theme[srButton, {ssPressed}, StyleTextColor] = pressedText
+    builder[srButton, {ssHighlighted, ssPressed}, StyleTextColor] =
+      highlightedPressedText
+    builder[srButton, {ssPressed}, StyleTextColor] = pressedText
+    let theme = builder.finish()
 
     check theme.resolveColor(context, StyleTextColor, fallback) == highlightedPressedText
 
   test "style rules keep last-write-wins for equal specificity":
-    var theme = initTheme()
+    var builder = initThemeBuilder(initTheme())
     let
       fallback = color(0.0, 0.0, 0.0, 1.0)
       firstText = color(0.18, 0.24, 0.30, 1.0)
       secondText = color(0.44, 0.52, 0.62, 1.0)
       context = controlStyle(srButton, {ssHighlighted, ssPressed})
 
-    theme[srButton, {ssHighlighted}, StyleTextColor] = firstText
-    theme[srButton, {ssPressed}, StyleTextColor] = secondText
+    builder[srButton, {ssHighlighted}, StyleTextColor] = firstText
+    builder[srButton, {ssPressed}, StyleTextColor] = secondText
+    let theme = builder.finish()
 
     check theme.resolveColor(context, StyleTextColor, fallback) == secondText
 
@@ -418,12 +422,13 @@ suite "nimkit theme":
     }
 
   test "chrome delegates install by name and selectors choose per widget":
-    var theme = initAquaTheme()
-    theme.installChrome(CustomChromeName, newCustomFillChrome())
-    theme[initStyleSelector(srButton, id = "special"), StyleChrome] =
+    var builder = initThemeBuilder(initAquaTheme())
+    builder.installChrome(CustomChromeName, newCustomFillChrome())
+    builder[initStyleSelector(srButton, id = "special"), StyleChrome] =
       styleKeyword(CustomChromeName)
 
     let
+      theme = builder.finish()
       appearance = initAppearance(theme)
       normalContext = controlStyle(srButton)
       specialContext = controlStyle(srButton, id = "special")
@@ -460,13 +465,83 @@ suite "nimkit theme":
     check value.kind == svColor
     check value.color == accent
 
-    let appearance = Appearance(theme: Theme(tokens: child))
+    let appearance = Appearance(theme: initThemeBuilder(child).finish())
     check appearance.colorToken("nested.accent", color(0, 0, 0, 1)) == accent
     check appearance.lengthToken("space", 0.0) == 6.0
     check appearance.sizeToken("minimum.size", initSize(0, 0)) == minSize
     check appearance.insetsToken("padding", insets(0)) == padding
     check appearance.shadowsToken("shadow", @[]) == shadows
     check appearance.colorToken("missing", accent) == accent
+
+  test "theme builder freezes independently owned snapshots":
+    let
+      firstAccent = color(0.18, 0.42, 0.76, 1.0)
+      secondAccent = color(0.82, 0.24, 0.36, 1.0)
+      fallback = color(0.0, 0.0, 0.0, 1.0)
+      button = controlStyle(srButton)
+
+    var builder = initThemeBuilder(initTheme())
+    builder["snapshot.accent"] = firstAccent
+    builder[srButton, StyleTextColor] = firstAccent
+    let first = builder.finish()
+
+    builder["snapshot.accent"] = secondAccent
+    builder[srButton, StyleTextColor] = secondAccent
+    let second = builder.finish()
+
+    check first.generation != second.generation
+    check first.colorToken("snapshot.accent", fallback) == firstAccent
+    check second.colorToken("snapshot.accent", fallback) == secondAccent
+    check first.resolveColor(button, StyleTextColor, fallback) == firstAccent
+    check second.resolveColor(button, StyleTextColor, fallback) == secondAccent
+
+  test "theme snapshot accessors cannot mutate frozen storage":
+    let
+      accent = color(0.16, 0.38, 0.72, 1.0)
+      replacement = color(0.86, 0.26, 0.44, 1.0)
+      fallback = color(0.0, 0.0, 0.0, 1.0)
+      shadows = @[dropShadow(color(0.0, 0.0, 0.0, 0.4), blur = 5.0)]
+      selector = initStyleSelector(srButton, classes = @["primary"])
+      context = controlStyle(srButton, classes = @["primary"])
+
+    var builder = initThemeBuilder(initTheme())
+    builder["snapshot.accent"] = accent
+    builder["snapshot.shadows"] = shadows
+    builder[selector, StyleTextColor] = accent
+    builder[selector, StyleBoxShadows] = shadows
+    let snapshot = builder.finish()
+
+    let tokenCopy = snapshot.tokens
+    tokenCopy["snapshot.accent"] = replacement
+    var tokenShadows: StyleValue
+    check tokenCopy.resolveToken("snapshot.shadows", tokenShadows)
+    tokenShadows.shadows[0].blur = 99.0
+
+    let patchCopy = snapshot.stylePatch(selector)
+    patchCopy[StyleTextColor] = replacement
+    var patchShadows: StyleValue
+    check patchCopy.getStyle(StyleBoxShadows, patchShadows)
+    patchShadows.shadows[0].blur = 99.0
+
+    var rulesCopy = snapshot.rules
+    rulesCopy[^1].selector.classes[0][0] = 'x'
+
+    check snapshot.colorToken("snapshot.accent", fallback) == accent
+    check snapshot.shadowsToken("snapshot.shadows", @[]) == shadows
+    check snapshot.resolveColor(context, StyleTextColor, fallback) == accent
+    var frozenShadows: StyleValue
+    check snapshot.stylePatch(selector).getStyle(StyleBoxShadows, frozenShadows)
+    check frozenShadows.shadows == shadows
+
+  test "unchanged snapshots retain their cache generation":
+    let
+      snapshot = initTheme()
+      rebuilt = initThemeBuilder(snapshot).finish()
+      firstAppearance = initAppearance(snapshot)
+      secondAppearance = initAppearance(snapshot.clone())
+
+    check rebuilt.generation == snapshot.generation
+    check firstAppearance.sameAppearanceGeneration(secondAppearance)
 
   test "appearance tokens and style patches resolve into concrete styles":
     var appearance = initAppearance()
@@ -484,7 +559,9 @@ suite "nimkit theme":
           insetShadow(color(1, 1, 1, 0.18), y = -1.0, blur = 1.0),
         ]
 
-    appearance.theme["field.text.override"] = fieldText
+    var builder = initThemeBuilder(appearance.theme)
+    builder["field.text.override"] = fieldText
+    appearance.theme = builder.finish()
     appearance[srButton, StyleFill] = buttonFill
     appearance[srButton, StyleCornerRadius] = 9.0
     appearance[srButton, StyleFocusRingColor] = focusRing
@@ -528,7 +605,9 @@ suite "nimkit theme":
       baseStyle = theme.resolveButtonStyle(controlStyle(srButton))
       overrideFill = color(0.67, 0.18, 0.22, 1.0)
 
-    firstAppearance.theme["button.fill"] = overrideFill
+    var builder = initThemeBuilder(firstAppearance.theme)
+    builder["button.fill"] = overrideFill
+    firstAppearance.theme = builder.finish()
     firstAppearance[srButton, StyleCornerRadius] = 11.0
 
     check firstAppearance.resolveButtonStyle(controlStyle(srButton)).box.fill ==

--- a/tests/nimkit/tooltips.nim
+++ b/tests/nimkit/tooltips.nim
@@ -23,9 +23,11 @@ suite "NimKit tooltips":
       border = color(0.52, 0.68, 0.84, 0.88)
       textColor = color(0.92, 0.96, 1.0, 1.0)
 
-    appearance.theme["comboBox.item.fill"] = surface
-    appearance.theme["comboBox.border.color"] = border
-    appearance.theme["comboBox.item.text.color"] = textColor
+    var builder = initThemeBuilder(appearance.theme)
+    builder["comboBox.item.fill"] = surface
+    builder["comboBox.border.color"] = border
+    builder["comboBox.item.text.color"] = textColor
+    appearance.theme = builder.finish()
 
     let style = appearance.resolveTooltipStyle()
     check style.box.fill == surface


### PR DESCRIPTION
## Summary

- make Theme an immutable snapshot with private, independently owned token, rule, and chrome storage
- add ThemeBuilder for new and derived themes, with eager role indexes and stable snapshot generations
- migrate built-in themes, resource construction, settings, chrome installers, documentation, and tests to the builder flow
- key render-cache reuse and invalidation to immutable theme generations

## Testing

- atlas-run tests
- atlas-run tests --compile-only examples/all_compile.nim
- git diff --check