### PR TITLE
Support nimble setup alongside atlas

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -127,3 +127,7 @@ task download_references, "download local study copies of reference docs":
   downloadReference(openStepSpecUrl, openStepSpecPdf)
   echo "Downloaded ", openStepSpecPdf
   echo "OpenStep UI guidelines remain link-only; their notice restricts copying."
+# begin Nimble config (version 2)
+when withDir(thisDir(), system.fileExists("nimble.paths")):
+  include "nimble.paths"
+# end Nimble config

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -10,13 +10,14 @@ requires "msgpack4nim"
 requires "chronicles >= 0.4"
 requires "crunchy >= 0.1.11"
 requires "siwin#96ca695"
-requires "figdraw >= 0.35.2 [siwin, sharedlib, harfbuzz]"
-requires "sigils >= 0.27.4 [sigNameAsString, closures, siwin, chronos]"
+requires "figdraw[siwin,sharedlib,harfbuzz] >= 0.35.2"
+requires "sigils[sigNameAsString,closures,siwin,chronos] >= 0.27.4"
 requires "gh:elcritch/kiwiberry"
 requires "cborious"
 requires "unicodedb >= 0.14.0"
 requires "faststreams >= 0.5.1"
-requires "gh:elcritch/nim-markdown#devel[regex]"
+requires "gh:elcritch/nim-markdown[regex]#devel"
+requires "regex >= 0.26.3" # markdown[regex] backend; see nim-lang/nimble#1832
 
 feature "libbacktrace":
   requires "libbacktrace"


### PR DESCRIPTION
Lets `nimble setup -l` (or plain `nimble install`) resolve and install merenda's deps, as an alternative to `atlas install`.

## Changes

- **merenda.nimble**: dependency features now use nimble's suffix syntax, `figdraw[siwin,sharedlib,harfbuzz] >= 0.35.2`, instead of the legacy `figdraw >= 0.35.2 [siwin, sharedlib, harfbuzz]`. Atlas accepts both (it warns that the legacy placement is deprecated, see `usesLegacyRequirementFeatureSyntax` in atlas), while nimble's declarative parser only handles the suffix form correctly (nim-lang/nimble#1832). Same for `sigils[...]` and `nim-markdown[regex]#devel`.
- **merenda.nimble**: `regex >= 0.26.3` is required directly as a workaround for nim-lang/nimble#1832: feature deps of *remote* packages (`nim-markdown[regex]` at `#devel`) are dropped during nimble's SAT resolution. The explicit require is harmless under both tools; it can be dropped once the nimble fix lands (nim-lang/nimble#1836).
- **config.nims**: include `nimble.paths` when it exists (the standard snippet `nimble setup` appends itself; committed here so it works on first clone). `nimble.paths` itself stays gitignored, and atlas' `deps/` + `nim.cfg` flow is untouched.

## Verification

`nimble setup -l` (with nim-lang/nimble#1836 applied) resolves 37 packages and `nim c examples/all_compile.nim` builds the whole 51-module example bundle. Atlas parsing of the rewritten requires lines was checked against atlas' own `nimbleparser`/`versions` sources.