### PR TITLE
Fix consolidated Kosmo test hangs

### DIFF
--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -3848,9 +3848,14 @@ proc configureKosmoWorkspaceMenu(frontend: KosmoApplication) =
   discard windowMenu.addItem(focusMenuItem)
 
 proc newKosmoApplication*(
-    manager: KosmoWindowManager, filePath = "", hasFileBrowser = true
+    manager: KosmoWindowManager,
+    filePath = "",
+    hasFileBrowser = true,
+    monitorsGitStatus = true,
 ): KosmoApplication =
   ## Create an unpresented Kosmo window owned by `manager`.
+  ## Disable `monitorsGitStatus` for short-lived frontends that do not need repository
+  ## decorations.
   let
     app = manager.application
     keyBindingsPath = manager.keyBindingsPath
@@ -4103,16 +4108,18 @@ proc newKosmoApplication*(
     statusLabel.text = absolutePath(filePath)
   if keyBindingErrors.len > 0:
     statusLabel.text = keyBindingErrors.join("; ")
-  discard fileTree.startGitStatusMonitoring()
+  if monitorsGitStatus:
+    discard fileTree.startGitStatusMonitoring()
 
 proc newKosmoApplication*(
     app = nimkit.sharedApplication(),
     filePath = "",
     keyBindingsPath = "",
     hasFileBrowser = true,
+    monitorsGitStatus = true,
 ): KosmoApplication =
   let manager = newKosmoWindowManager(app, keyBindingsPath)
-  result = newKosmoApplication(manager, filePath, hasFileBrowser)
+  result = newKosmoApplication(manager, filePath, hasFileBrowser, monitorsGitStatus)
 
 proc openProject*(
     manager: KosmoWindowManager, path: string

--- a/tests/kosmo/panelshortcuts.nim
+++ b/tests/kosmo/panelshortcuts.nim
@@ -25,14 +25,16 @@ suite "Kosmo synthetic panel shortcuts":
       secondRoot = createTempDir("merenda-kosmo-panel-second-", "")
       app = newApplication("Kosmo Panel Focus Test")
       manager = newKosmoWindowManager(app)
-      first = newKosmoApplication(manager, firstRoot)
-      second = newKosmoApplication(manager, secondRoot)
+      first = newKosmoApplication(manager, firstRoot, monitorsGitStatus = false)
+      second = newKosmoApplication(manager, secondRoot, monitorsGitStatus = false)
     defer:
       manager.close()
       removeDir(firstRoot)
       removeDir(secondRoot)
     require not first.isNil
     require not second.isNil
+    check not first.fileTree.refreshGitStatus()
+    check not second.fileTree.refreshGitStatus()
     app.presentSyntheticWindow(first)
     app.presentSyntheticWindow(second)
     check first.window.firstResponderIs(first.editorView)
@@ -50,8 +52,8 @@ suite "Kosmo synthetic panel shortcuts":
       secondRoot = createTempDir("merenda-kosmo-editor-second-", "")
       app = newApplication("Kosmo Editor Focus Test")
       manager = newKosmoWindowManager(app)
-      first = newKosmoApplication(manager, firstRoot)
-      second = newKosmoApplication(manager, secondRoot)
+      first = newKosmoApplication(manager, firstRoot, monitorsGitStatus = false)
+      second = newKosmoApplication(manager, secondRoot, monitorsGitStatus = false)
     defer:
       manager.close()
       removeDir(firstRoot)

--- a/tests/kosmo/terminalclipboard.nim
+++ b/tests/kosmo/terminalclipboard.nim
@@ -27,12 +27,13 @@ suite "Kosmo terminal clipboard commands":
     test "Edit menu copy rejoins a wrapped terminal line":
       let
         app = newApplication("Kosmo Wrapped Terminal Clipboard Test")
-        frontend = newKosmoApplication(app)
+        frontend = newKosmoApplication(app, monitorsGitStatus = false)
         session = newTerminalSession(columns = 12, rows = 4)
         terminal = newTerminalView(session, frame = rect(0, 0, 400, 120))
         pasteboard = generalPasteboard()
         previousClipboard = pasteboard.plainText()
       defer:
+        terminal.close()
         discard pasteboard.setPlainText(previousClipboard)
         frontend.close()
         frontend.window.close()
@@ -70,7 +71,7 @@ suite "Kosmo terminal clipboard commands":
     test "Edit menu copy and paste target the focused terminal":
       let
         app = newApplication("Kosmo Terminal Clipboard Test")
-        frontend = newKosmoApplication(app)
+        frontend = newKosmoApplication(app, monitorsGitStatus = false)
         session = spawnTerminalSession(
           initTerminalSpawnOptions(
             command =
@@ -84,6 +85,7 @@ suite "Kosmo terminal clipboard commands":
         pasteboard = generalPasteboard()
         previousClipboard = pasteboard.plainText()
       defer:
+        terminal.close()
         discard pasteboard.setPlainText(previousClipboard)
         frontend.close()
         frontend.window.close()


### PR DESCRIPTION
## Summary

- let short-lived Kosmo frontends opt out of Git-status worker and timer threads
- disable those background workers in synthetic panel and terminal clipboard tests
- close terminal sessions explicitly during test teardown
- preserve normal application behavior by default

## Context

The timed-out Linux job had already compiled `tkosmo` with `--opt:none --debugger:off`. It hung at runtime with a live `tkosmo -> bash -> dd` PTY process, pointing to a lifecycle race rather than the previous pathological GCC optimization.

## Verification

- baseline `tkosmo` stress reproduction: 22 failures in 40 runs, primarily `EBADF`
- patched `tkosmo`: 40/40 concurrent stress runs passed without failures or timeouts
- `tkosmo`, `tnimkit`, `ttekton`, and `tintegrations` passed in amd64 Ubuntu Docker with `--opt:none --debugger:off`