### PR TITLE
Add modifier-click terminal links

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,9 +431,12 @@ backend currently supports POSIX platforms (macOS, Linux, and FreeBSD).
 
 OSC 52 clipboard writes are disabled by default because terminal output should
 not silently replace user clipboard contents. Enable them for a trusted child
-with `terminal.allowsClipboardWrites = true`. Title, working-directory, bell,
-process-exit, and hyperlink activation changes are available as NimKit signals.
-The complete runnable example is `examples/terminal_demo.nim`.
+with `terminal.allowsClipboardWrites = true`. Holding Command on macOS or Control
+on other platforms reveals OSC 8 hyperlinks and plain HTTP(S) URLs; clicking
+emits `terminalHyperlinkWasActivated`, even when the child has enabled mouse
+tracking. Set `terminal.allowsLinkActivation = false` to disable this behavior.
+Title, working-directory, bell, and process-exit changes are also available as
+NimKit signals. The complete runnable example is `examples/terminal_demo.nim`.
 
 Controls use Cocoa-style target/action for commands:
 
@@ -656,7 +659,8 @@ editor group. Terminal and text tabs share selection, closing, reordering,
 split-pane dragging, detached windows, and tab-navigation shortcuts. Other
 content can use the same lifecycle by constructing a `KosmoPaneDocument` with
 a content view, preferred first responder, and optional save and close
-callbacks.
+callbacks. Kosmo opens terminal links in the system browser; this can be enabled
+or disabled from the Terminal settings page.
 
 ## Workspace And Services
 

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -238,6 +238,7 @@ type
     dockController: KosmoDockController
     xSettingsWindow: KosmoSettingsWindow
     xTerminalOptionAsMeta: bool
+    xTerminalLinksEnabled: bool
     xWindowManager: WeakRef[KosmoWindowManager]
     xWindowLifecycle: KosmoWindowLifecycle
     xHasFileBrowser: bool
@@ -3254,12 +3255,24 @@ proc openPaneDocument(
   controller.activatePaneTab(group, document.identifier)
   true
 
+proc openTerminalLink(lifecycle: KosmoWindowLifecycle, link: string) {.slot.} =
+  if lifecycle.isNil or lifecycle.frontend.isNil:
+    return
+  let frontend = lifecycle.frontend[]
+  if not frontend.isNil and not frontend.application.isNil:
+    discard frontend.application.workspace().openUrl(link)
+
 proc newTerminalDocument(
     controller: KosmoDockController, options: nimkit.TerminexSpawnOptions
 ): KosmoPaneDocument =
   let terminalView = nimkit.newTerminalView()
   if not controller.frontend.isNil:
-    terminalView.optionAsMeta = controller.frontend[].xTerminalOptionAsMeta
+    let frontend = controller.frontend[]
+    terminalView.optionAsMeta = frontend.xTerminalOptionAsMeta
+    terminalView.allowsLinkActivation = frontend.xTerminalLinksEnabled
+    terminalView.connect(
+      nimkit.terminalHyperlinkWasActivated, frontend.xWindowLifecycle, openTerminalLink
+    )
   try:
     terminalView.start(options)
   except nimkit.TerminexSessionError:
@@ -3476,6 +3489,24 @@ proc `terminalOptionAsMeta=`*(frontend: KosmoApplication, enabled: bool) =
       if document.contentView of nimkit.TerminalView:
         nimkit.TerminalView(document.contentView).optionAsMeta = enabled
 
+func terminalLinksEnabled*(frontend: KosmoApplication): bool =
+  ## Return whether modifier-hover and modifier-click terminal links are enabled.
+  not frontend.isNil and frontend.xTerminalLinksEnabled
+
+proc `terminalLinksEnabled=`*(frontend: KosmoApplication, enabled: bool) =
+  ## Apply terminal link activation to current and future terminals.
+  if frontend.isNil:
+    return
+  frontend.xTerminalLinksEnabled = enabled
+  if not frontend.xSettingsWindow.isNil:
+    frontend.xSettingsWindow.terminalLinksEnabled = enabled
+  if frontend.dockController.isNil:
+    return
+  for group in frontend.dockController.groups:
+    for document in group.documents:
+      if document.contentView of nimkit.TerminalView:
+        nimkit.TerminalView(document.contentView).allowsLinkActivation = enabled
+
 func moeThemeSettings(themes: openArray[KosmoMoeTheme]): seq[KosmoMoeThemeSetting] =
   for theme in themes:
     result.add KosmoMoeThemeSetting(
@@ -3589,6 +3620,11 @@ proc showSettings*(frontend: KosmoApplication): bool {.discardable.} =
         if not weakFrontend.isNil:
           weakFrontend[].terminalOptionAsMeta = enabled
       ,
+      terminalLinksEnabled = frontend.xTerminalLinksEnabled,
+      terminalLinksHandler = proc(enabled: bool) =
+        if not weakFrontend.isNil:
+          weakFrontend[].terminalLinksEnabled = enabled
+      ,
       shortcutProfile = frontend.dockController.shortcutProfile,
       shortcutProfileHandler = proc(profile: KosmoShortcutProfile) =
         if not weakFrontend.isNil:
@@ -3609,6 +3645,7 @@ proc showSettings*(frontend: KosmoApplication): bool {.discardable.} =
     )
   else:
     frontend.xSettingsWindow.optionAsMeta = frontend.xTerminalOptionAsMeta
+    frontend.xSettingsWindow.terminalLinksEnabled = frontend.xTerminalLinksEnabled
     frontend.updateShortcutSettingsWindow()
     frontend.xSettingsWindow.updateMoeThemes(
       moeThemeSettings, selectedMoeThemeIdentifier
@@ -3965,6 +4002,7 @@ proc newKosmoApplication*(
     contentView: contentView,
     documentView: documentView,
     xTerminalOptionAsMeta: true,
+    xTerminalLinksEnabled: true,
     xWindowManager: manager.unsafeWeakRef(),
     xHasFileBrowser: hasFileBrowser,
   )

--- a/src/merenda/kosmo/settings.nim
+++ b/src/merenda/kosmo/settings.nim
@@ -12,6 +12,7 @@ const
   KosmoShortcutsSettingsTabIdentifier* = "kosmo.settings.shortcuts"
   KosmoMoeThemesSettingsTabIdentifier* = "kosmo.settings.moeThemes"
   KosmoOptionAsMetaIdentifier* = "kosmo.settings.terminal.optionAsMeta"
+  KosmoTerminalLinksIdentifier* = "kosmo.settings.terminal.links"
   KosmoShortcutsTableIdentifier* = "kosmo.settings.shortcuts.table"
   KosmoShortcutProfileIdentifier* = "kosmo.settings.shortcuts.profile"
   KosmoEditorInputPolicyIdentifier* = "kosmo.settings.shortcuts.editorInput"
@@ -29,6 +30,7 @@ const
 
 type
   KosmoOptionAsMetaHandler* = proc(enabled: bool) {.closure.}
+  KosmoTerminalLinksHandler* = proc(enabled: bool) {.closure.}
   KosmoMoeThemeHandler* = proc(identifier: string): bool {.closure.}
   KosmoShortcutProfileHandler* = proc(profile: KosmoShortcutProfile) {.closure.}
   KosmoEditorInputPolicyHandler* = proc(policy: KosmoEditorInputPolicy) {.closure.}
@@ -60,6 +62,8 @@ type
     xFirstResponder: nimkit.Responder
     xOptionAsMetaButton: nimkit.Button
     xOptionAsMetaHandler: KosmoOptionAsMetaHandler
+    xTerminalLinksButton: nimkit.Button
+    xTerminalLinksHandler: KosmoTerminalLinksHandler
     xTabs: nimkit.TabView
     xShortcutsTable: nimkit.TableView
     xShortcutsSource: KosmoShortcutsTableSource
@@ -281,6 +285,15 @@ proc `optionAsMeta=`*(settings: KosmoSettingsWindow, enabled: bool) =
   if not settings.isNil:
     settings.xOptionAsMetaButton.state = if enabled: nimkit.bsOn else: nimkit.bsOff
 
+proc terminalLinksEnabled*(settings: KosmoSettingsWindow): bool =
+  ## Return whether modifier-hover and modifier-click terminal links are enabled.
+  not settings.isNil and settings.xTerminalLinksButton.state == nimkit.bsOn
+
+proc `terminalLinksEnabled=`*(settings: KosmoSettingsWindow, enabled: bool) =
+  ## Synchronize terminal link activation without invoking its action.
+  if not settings.isNil:
+    settings.xTerminalLinksButton.state = if enabled: nimkit.bsOn else: nimkit.bsOff
+
 proc `shortcuts=`*(
     settings: KosmoSettingsWindow, shortcuts: openArray[KosmoShortcutSetting]
 ) =
@@ -355,6 +368,8 @@ proc updateMoeThemes*(
 proc newKosmoSettingsWindow*(
     optionAsMeta = true,
     optionAsMetaHandler: KosmoOptionAsMetaHandler = nil,
+    terminalLinksEnabled = true,
+    terminalLinksHandler: KosmoTerminalLinksHandler = nil,
     shortcutProfile = defaultKosmoShortcutProfile(),
     shortcutProfileHandler: KosmoShortcutProfileHandler = nil,
     editorInputPolicy = defaultKosmoEditorInputPolicy(),
@@ -372,6 +387,7 @@ proc newKosmoSettingsWindow*(
     xWindow: nimkit.newPanel("Kosmo Settings", nimkit.rect(180, 160, 760, 420)),
     xContentView: nimkit.newView(),
     xOptionAsMetaHandler: optionAsMetaHandler,
+    xTerminalLinksHandler: terminalLinksHandler,
     xShortcutProfileHandler: shortcutProfileHandler,
     xEditorInputPolicyHandler: editorInputPolicyHandler,
     xShortcutsSource: shortcutsSource,
@@ -386,14 +402,22 @@ proc newKosmoSettingsWindow*(
     shortcutsPage = newSettingsPage()
     moeThemesPage = newSettingsPage()
     optionButton = nimkit.newCheckBox("Use Option/Alt as Meta")
+    terminalLinksButton = nimkit.newCheckBox(
+      when defined(macosx) or defined(macos):
+        "Open terminal links with Command-click"
+      else:
+        "Open terminal links with Control-click"
+    )
     shortcutProfileChoice = nimkit.newComboBox(["Platform", "macOS-style"])
     editorInputPolicyChoice = nimkit.newComboBox(["Vim", "Native", "Hybrid"])
     shortcutsTable = nimkit.newTableView()
     moeThemesTable = nimkit.newTableView()
     optionChanged = nimkit.actionSelector("kosmo.optionAsMetaChanged")
+    terminalLinksChanged = nimkit.actionSelector("kosmo.terminalLinksChanged")
     shortcutProfileChanged = nimkit.actionSelector("kosmo.shortcutProfileChanged")
     editorInputPolicyChanged = nimkit.actionSelector("kosmo.editorInputPolicyChanged")
   result.xOptionAsMetaButton = optionButton
+  result.xTerminalLinksButton = terminalLinksButton
   result.xFirstResponder = optionButton
   result.xTabs = tabs
   result.xShortcutsTable = shortcutsTable
@@ -412,12 +436,27 @@ proc newKosmoSettingsWindow*(
       settings.xOptionAsMetaHandler(settings.optionAsMeta())
   optionButton.action = optionChanged
 
+  terminalLinksButton.identifier = KosmoTerminalLinksIdentifier
+  terminalLinksButton.accessibilityLabel = "Open links from terminal output"
+  terminalLinksButton.state = if terminalLinksEnabled: nimkit.bsOn else: nimkit.bsOff
+  terminalLinksButton.target = nimkit.newActionTarget(terminalLinksChanged) do(
+    sender: nimkit.DynamicAgent
+  ):
+    discard sender
+    if not settings.xTerminalLinksHandler.isNil:
+      settings.xTerminalLinksHandler(settings.terminalLinksEnabled())
+  terminalLinksButton.action = terminalLinksChanged
+
   terminalPage.stack.addArrangedSubview(
     nimkit.newHeadingLabel("Terminal"),
     optionButton,
     nimkit.newLabel(
       "Send Option/Alt-B and Option/Alt-F as Bash backward-word and forward-word " &
         "shortcuts."
+    ),
+    terminalLinksButton,
+    nimkit.newLabel(
+      "Hold the platform link modifier while hovering a URL to reveal and open it."
     ),
   )
   terminalPage.stack.addFlexibleSpacer()

--- a/src/merenda/nimkit/terminal/terminalviews.nim
+++ b/src/merenda/nimkit/terminal/terminalviews.nim
@@ -7,7 +7,7 @@ import terminex/[ringbuffer, terminput, termscreen, termsessions]
 
 import ../app/[animations, pasteboards]
 import ../app/windows except performKeyEquivalent
-import ../foundation/[events, selectors, types]
+import ../foundation/[events, selectors, types, urls]
 import ../responder/responders
 from ../text/textviews import isInsertableText
 import ../text/monotextviews
@@ -26,6 +26,10 @@ type
   TerminalSelection* = object
     anchor*, extent*: TerminexPosition
 
+  TerminalLink = object
+    target: string
+    row, firstColumn, lastColumn: int
+
   TerminalView* = ref object of MonoTextView
     xSession: TerminexSession[TerminexCell, TerminexLine, RingBuffer[TerminexLine]]
     xPalette: TerminalPalette
@@ -42,8 +46,13 @@ type
     xLastBellCount: uint64
     xExitNotified: bool
     xAllowsClipboardWrites: bool
+    xAllowsLinkActivation: bool
     xOptionAsMeta: bool
     xSuppressOptionTextInput: bool
+    xHasHoverPosition: bool
+    xLinkModifierHeld: bool
+    xHoverRow, xHoverColumn: int
+    xHoveredLink: TerminalLink
     xLastInputError: string
     xBlinkElapsed: Duration
     xBlinkVisible: bool
@@ -236,6 +245,16 @@ func terminalShortcutModifiers*(): set[KeyModifier] =
   else:
     {kmControl, kmShift}
 
+func terminalLinkModifiers*(): set[KeyModifier] =
+  ## Modifier that reveals and activates links in a terminal.
+  when defined(macosx) or defined(macos):
+    {kmCommand}
+  else:
+    {kmControl}
+
+func hasTerminalLinkModifier(modifiers: set[KeyModifier]): bool =
+  terminalLinkModifiers() <= modifiers
+
 func toTerminexMouseButton(button: MouseButton): TerminexMouseButton =
   case button
   of mbPrimary: tmbPrimary
@@ -268,6 +287,7 @@ func session*(
   view.xSession
 
 proc syncTerminalScreen(view: TerminalView)
+proc refreshHoveredLink(view: TerminalView): bool
 proc startTerminalPolling(view: TerminalView)
 proc stopTerminalPolling(view: TerminalView)
 
@@ -310,6 +330,19 @@ func allowsClipboardWrites*(view: TerminalView): bool =
 
 proc `allowsClipboardWrites=`*(view: TerminalView, value: bool) =
   view.xAllowsClipboardWrites = value
+
+func allowsLinkActivation*(view: TerminalView): bool =
+  ## Whether modifier-hover and modifier-click reveal and activate terminal links.
+  not view.isNil and view.xAllowsLinkActivation
+
+proc `allowsLinkActivation=`*(view: TerminalView, value: bool) =
+  ## Enable or disable modifier-hover and modifier-click terminal links.
+  if view.isNil or view.xAllowsLinkActivation == value:
+    return
+  view.xAllowsLinkActivation = value
+  if view.refreshHoveredLink():
+    view.xLastGeneration = high(uint64)
+    view.syncTerminalScreen()
 
 func optionAsMeta*(view: TerminalView): bool =
   ## Whether Option/Alt prefixes terminal input with Escape (Meta).
@@ -412,6 +445,98 @@ proc viewportStart(view: TerminalView): int =
   let info = view.xSession.screenInfo()
   max(info.totalLineCount - info.rows - view.viewportOffset(), 0)
 
+func isTerminalLinkSeparator(cell: TerminexCell): bool =
+  cell.text.len == 0 or cell.text.strip().len == 0
+
+func terminalLinkText(line: TerminexLine, firstColumn, lastColumn: int): string =
+  for column in firstColumn ..< lastColumn:
+    if not line[column].continuation:
+      result.add line[column].text
+
+func contains(link: TerminalLink, row, column: int): bool =
+  link.target.len > 0 and link.row == row and
+    column in link.firstColumn ..< link.lastColumn
+
+proc terminalLinkAt(view: TerminalView, row, column: int): TerminalLink =
+  if view.isNil or view.xSession.isNil:
+    return
+  let info = view.xSession.screenInfo()
+  if row notin 0 ..< info.totalLineCount:
+    return
+  let line = view.xSession.lineAtAbsolute(row)
+  if column notin 0 ..< line.len:
+    return
+
+  let explicitTarget = line[column].style.hyperlink
+  if explicitTarget.len > 0:
+    var
+      firstColumn = column
+      lastColumn = column + 1
+    while firstColumn > 0 and line[firstColumn - 1].style.hyperlink == explicitTarget:
+      dec firstColumn
+    while lastColumn < line.len and line[lastColumn].style.hyperlink == explicitTarget:
+      inc lastColumn
+    return TerminalLink(
+      target: explicitTarget, row: row, firstColumn: firstColumn, lastColumn: lastColumn
+    )
+  if line[column].isTerminalLinkSeparator():
+    return
+
+  var
+    tokenFirst = column
+    tokenLast = column + 1
+  while tokenFirst > 0 and not line[tokenFirst - 1].isTerminalLinkSeparator():
+    dec tokenFirst
+  while tokenLast < line.len and not line[tokenLast].isTerminalLinkSeparator():
+    inc tokenLast
+  const
+    LeadingLinkPunctuation = {'(', '[', '{', '<', '"'}
+    TrailingLinkPunctuation = {'.', ',', ';', ':', '!', '?', ')', ']', '}', '>', '"'}
+  while tokenFirst < tokenLast and line[tokenFirst].text.len == 1 and
+      line[tokenFirst].text[0] in LeadingLinkPunctuation:
+    inc tokenFirst
+  while tokenLast > tokenFirst and line[tokenLast - 1].text.len == 1 and
+      line[tokenLast - 1].text[0] in TrailingLinkPunctuation:
+    dec tokenLast
+  if column notin tokenFirst ..< tokenLast:
+    return
+  for firstColumn in tokenFirst .. column:
+    let target = line.terminalLinkText(firstColumn, tokenLast)
+    if (target.startsWith("http://") or target.startsWith("https://")) and
+        target.initUrl().isHttpUrl():
+      return TerminalLink(
+        target: target, row: row, firstColumn: firstColumn, lastColumn: tokenLast
+      )
+
+proc refreshHoveredLink(view: TerminalView): bool =
+  let next =
+    if view.xAllowsLinkActivation and view.xHasHoverPosition and view.xLinkModifierHeld:
+      view.terminalLinkAt(view.viewportStart() + view.xHoverRow, view.xHoverColumn)
+    else:
+      TerminalLink()
+  if view.xHoveredLink == next:
+    return
+  view.xHoveredLink = next
+  true
+
+proc updateHoveredLink(
+    view: TerminalView, row, column: int, modifiers: set[KeyModifier]
+) =
+  view.xHasHoverPosition = true
+  view.xHoverRow = row
+  view.xHoverColumn = column
+  view.xLinkModifierHeld = modifiers.hasTerminalLinkModifier()
+  if view.refreshHoveredLink():
+    view.xLastGeneration = high(uint64)
+    view.syncTerminalScreen()
+
+proc clearHoveredLink(view: TerminalView) =
+  view.xHasHoverPosition = false
+  view.xLinkModifierHeld = false
+  if view.refreshHoveredLink():
+    view.xLastGeneration = high(uint64)
+    view.syncTerminalScreen()
+
 proc terminalRowsToMonoTextCells(
     view: TerminalView,
     session: TerminexSession[TerminexCell, TerminexLine, RingBuffer[TerminexLine]],
@@ -423,7 +548,7 @@ proc terminalRowsToMonoTextCells(
       absoluteRow = firstRow + row
       line = session.lineAtAbsolute(absoluteRow)
     for column in 0 ..< columns:
-      result[row * columns + column] = terminalCellToMonoTextCell(
+      var cell = terminalCellToMonoTextCell(
         if column < line.len:
           line[column]
         else:
@@ -432,6 +557,9 @@ proc terminalRowsToMonoTextCells(
         selected = view.xHasSelection and view.xSelection.contains(absoluteRow, column),
         blinkVisible = view.xBlinkVisible,
       )
+      if view.xHoveredLink.contains(absoluteRow, column):
+        cell.decorations.incl mtdUnderline
+      result[row * columns + column] = cell
 
 proc renderedGridDimensionsMatch(view: TerminalView, rows, columns: int): bool =
   if view.xRenderedRows != rows or view.xRenderedColumns != columns or
@@ -500,6 +628,8 @@ proc syncTerminalScreen(view: TerminalView) =
   view.xLastScrollbackCount = nextScrollbackCount
   view.xScrollPosition =
     clamp(view.xScrollPosition, 0.0'f32, nextScrollbackCount.float32)
+  if view.refreshHoveredLink():
+    view.xLastGeneration = high(uint64)
 
   let
     start = max(info.totalLineCount - info.rows - view.viewportOffset(), 0)
@@ -628,11 +758,10 @@ proc handleLocalMouse(view: TerminalView, event: MonoTextRawEvent): bool =
     if owner of Window:
       discard Window(owner).makeFirstResponder(view, focusVisible = false)
     let position = view.absolutePosition(event.row, event.column)
-    if kmCommand in mouse.modifiers:
-      let line = view.xSession.lineAtAbsolute(position.row)
-      if position.column in 0 ..< line.len and
-          line[position.column].style.hyperlink.len > 0:
-        emit view.terminalHyperlinkWasActivated(line[position.column].style.hyperlink)
+    if view.xAllowsLinkActivation and mouse.modifiers.hasTerminalLinkModifier():
+      let link = view.terminalLinkAt(position.row, position.column)
+      if link.target.len > 0:
+        emit view.terminalHyperlinkWasActivated(link.target)
         return true
     if mouse.clickCount >= 3:
       view.selectLine(position)
@@ -679,8 +808,11 @@ proc mouseTrackingAccepts(modes: TerminexModes, kind: MonoTextRawEventKind): boo
     false
 
 proc handleTrackedMouse(view: TerminalView, event: MonoTextRawEvent): bool =
-  if kmShift in event.mouseEvent.modifiers or
-      not view.xSession.screenInfo().modes.mouseTrackingAccepts(event.kind):
+  let position = view.absolutePosition(event.row, event.column)
+  if kmShift in event.mouseEvent.modifiers or (
+    view.xAllowsLinkActivation and event.mouseEvent.modifiers.hasTerminalLinkModifier() and
+    view.terminalLinkAt(position.row, position.column).target.len > 0
+  ) or not view.xSession.screenInfo().modes.mouseTrackingAccepts(event.kind):
     return false
   let input = view.xSession.encodeMouseInput(
     event.row,
@@ -779,6 +911,10 @@ proc handleTerminalRawEvent(view: TerminalView, event: MonoTextRawEvent): bool =
   of mtreKeyDown:
     view.handleTerminalKeyDown(event.keyEvent)
   of mtreFlagsChanged:
+    view.xLinkModifierHeld = event.keyEvent.modifiers.hasTerminalLinkModifier()
+    if view.refreshHoveredLink():
+      view.xLastGeneration = high(uint64)
+      view.syncTerminalScreen()
     true
 
 proc terminalTicked(view: TerminalView, delta: Duration) {.slot.} =
@@ -892,6 +1028,18 @@ protocol TerminalViewLayout of ViewLayoutProtocol:
   method layoutSubviews(view: TerminalView) =
     view.resizeToFit()
 
+protocol TerminalViewHoverEvents of ResponderEventProtocol:
+  method mouseMoved(view: TerminalView, event: MouseEvent): bool =
+    let position = view.rowColumnAtPoint(event.location)
+    view.updateHoveredLink(position.row, position.column, event.modifiers)
+    view.xHoveredLink.target.len > 0
+
+  method mouseExited(view: TerminalView, event: MouseEvent): bool =
+    discard event
+    let hadLink = view.xHoveredLink.target.len > 0
+    view.clearHoveredLink()
+    hadLink
+
 protocol TerminalViewLifecycle of ViewLifecycleProtocol:
   proc terminalViewWillMoveToWindow(
       view: TerminalView, window: Responder
@@ -917,6 +1065,7 @@ proc initTerminalViewFields*(
     else:
       session
   view.xPalette = palette
+  view.xAllowsLinkActivation = true
   view.xOptionAsMeta = true
   view.xLastGeneration = high(uint64)
   view.xLastScrollbackCount = view.xSession.screenInfo().scrollbackCount
@@ -941,6 +1090,7 @@ proc initTerminalViewFields*(
   discard view.withProtocol(TerminalViewEditingCommands)
   discard view.withProtocol(TerminalViewFocus)
   discard view.withProtocol(TerminalViewLayout)
+  discard view.withProtocol(TerminalViewHoverEvents)
   view.observeProtocol(view, TerminalViewLifecycle)
   view.syncTerminalScreen()
   view.applyInitialFrame(frame)

--- a/tests/kosmo/search.nim
+++ b/tests/kosmo/search.nim
@@ -349,19 +349,34 @@ suite "Kosmo":
       settingsPanel.contentView().viewWithIdentifier(KosmoOptionAsMetaIdentifier)
     require not optionView.isNil
     require optionView of Button
-    let optionButton = Button(optionView)
+    let
+      optionButton = Button(optionView)
+      terminalLinksView =
+        settingsPanel.contentView().viewWithIdentifier(KosmoTerminalLinksIdentifier)
+    require not terminalLinksView.isNil
+    require terminalLinksView of Button
+    let terminalLinksButton = Button(terminalLinksView)
     check frontend.terminalOptionAsMeta
     check optionButton.state == bsOn
+    check frontend.terminalLinksEnabled
+    check terminalLinksButton.state == bsOn
 
     let terminalView = newTerminalView()
     check frontend.openDocument(
       newKosmoPaneDocument("kosmo.test.terminal", "Terminal", terminalView)
     )
     check terminalView.optionAsMeta
+    check terminalView.allowsLinkActivation
     check optionButton.tryToPerform(performClick(), DynamicAgent(optionButton))
     check optionButton.state == bsOff
     check not frontend.terminalOptionAsMeta
     check not terminalView.optionAsMeta
+    check terminalLinksButton.tryToPerform(
+      performClick(), DynamicAgent(terminalLinksButton)
+    )
+    check terminalLinksButton.state == bsOff
+    check not frontend.terminalLinksEnabled
+    check not terminalView.allowsLinkActivation
     settingsPanel.close()
     frontend.window.close()
 
@@ -847,7 +862,9 @@ suite "Kosmo":
       check frontend.window.makeFirstResponder(frontend.editorView)
 
       check frontend.terminalOptionAsMeta
+      check frontend.terminalLinksEnabled
       frontend.terminalOptionAsMeta = false
+      frontend.terminalLinksEnabled = false
       check terminalItem.perform(Responder(frontend.editorView))
       check frontend.editorGroups().len == 1
       check frontend.editorGroups()[0].documents.len == 1
@@ -856,6 +873,7 @@ suite "Kosmo":
       check frontend.editorPane.contentView of TerminalView
       let terminalView = TerminalView(frontend.editorPane.contentView)
       check not terminalView.optionAsMeta
+      check not terminalView.allowsLinkActivation
       check terminalView.session().running()
       check frontend.window.firstResponder() == Responder(terminalView)
       check terminalView.focusVisible

--- a/tests/nimkit/terminals.nim
+++ b/tests/nimkit/terminals.nim
@@ -680,6 +680,12 @@ suite "nimkit terminal views":
     else:
       check terminalShortcutModifiers() == {kmControl, kmShift}
 
+  test "terminal links use the platform link modifier":
+    when defined(macosx) or defined(macos):
+      check terminalLinkModifiers() == {kmCommand}
+    else:
+      check terminalLinkModifiers() == {kmControl}
+
   test "view renders an idle session and resizes its screen to cell geometry":
     let
       session = newTerminalSession(columns = 12, rows = 3)
@@ -702,6 +708,7 @@ suite "nimkit terminal views":
   test "terminal views suppress the outer focus ring":
     let view = newTerminalView(frame = rect(0, 0, 240, 100))
     check view.focusRingType == frtNone
+    check view.allowsLinkActivation
     check view.optionAsMeta
     view.optionAsMeta = false
     check not view.optionAsMeta
@@ -1849,7 +1856,7 @@ suite "nimkit terminal views":
       check session.pollUntilExit()
       check "1b 5b 49 1b 5b 4f" in session.normalizedTerminalOutput()
 
-  test "Command-click activates terminal hyperlinks through mouse dispatch":
+  test "modifier-click activates OSC hyperlinks through mouse dispatch":
     let
       session = newTerminalSession(columns = 24, rows = 2)
       view = newTerminalView(session, frame = rect(0, 0, 300, 80))
@@ -1863,8 +1870,49 @@ suite "nimkit terminal views":
     window.setContentView(view)
     let point = view.terminalCellPoint(0, 3)
 
-    check window.mouseDownAt(point, clickCount = 1, modifiers = {kmCommand})
-    check window.mouseUpAt(point, clickCount = 1, modifiers = {kmCommand})
+    discard window.mouseMovedAt(point, modifiers = terminalLinkModifiers())
+    check mtdUnderline in view.cellAt(0, 3).decorations
+    check window.mouseDownAt(point, clickCount = 1, modifiers = terminalLinkModifiers())
+    check window.mouseUpAt(point, clickCount = 1, modifiers = terminalLinkModifiers())
+    check spy.links == @["https://example.com/docs"]
+
+  test "modifier-hover reveals plain URLs and link activation can be disabled":
+    let
+      session = newTerminalSession(columns = 40, rows = 2)
+      view = newTerminalView(session, frame = rect(0, 0, 480, 80))
+      window = newWindow("Terminal URL", frame = rect(0, 0, 480, 80))
+      spy = TerminalInteractionSpy()
+    session.processOutput("\x1b[?1000;1006hSee (https://example.com/docs).")
+    discard view.poll()
+    view.connect(terminalHyperlinkWasActivated, spy, rememberTerminalLink)
+    window.setContentView(view)
+    check window.makeFirstResponder(view)
+    let
+      point = view.terminalCellPoint(0, 10)
+      modifierKey =
+        when defined(macosx) or defined(macos): keyLeftCommand else: keyLeftControl
+
+    discard window.mouseMovedAt(point)
+    check mtdUnderline notin view.cellAt(0, 10).decorations
+    check window.dispatchFlagsChanged(
+      KeyEvent(
+        key: modifierKey, keyCode: modifierKey.ord, modifiers: terminalLinkModifiers()
+      )
+    )
+    check mtdUnderline notin view.cellAt(0, 4).decorations
+    check mtdUnderline in view.cellAt(0, 5).decorations
+    check mtdUnderline in view.cellAt(0, 28).decorations
+    check mtdUnderline notin view.cellAt(0, 29).decorations
+    check window.mouseDownAt(point, clickCount = 1, modifiers = terminalLinkModifiers())
+    check window.mouseUpAt(point, clickCount = 1, modifiers = terminalLinkModifiers())
+    check spy.links == @["https://example.com/docs"]
+
+    view.allowsLinkActivation = false
+    check not view.allowsLinkActivation
+    check mtdUnderline notin view.cellAt(0, 10).decorations
+    discard window.mouseMovedAt(point, modifiers = terminalLinkModifiers())
+    check mtdUnderline notin view.cellAt(0, 10).decorations
+    check window.mouseDownAt(point, clickCount = 1, modifiers = terminalLinkModifiers())
     check spy.links == @["https://example.com/docs"]
 
   test "OSC clipboard writes remain opt-in":


### PR DESCRIPTION
## Summary

- recognize OSC 8 hyperlinks and plain HTTP(S) URLs in TerminalView
- underline links while Command is held on macOS or Control is held elsewhere
- activate links without forwarding the click to terminal mouse tracking
- expose an allowsLinkActivation option and wire it into Kosmo settings
- open activated Kosmo terminal links through the system workspace

## Tests

- atlas-run tests
- atlas-run tests --compile-only examples/all_compile.nim