### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,8 +645,11 @@ Settings refreshes the list, so new themes appear without restarting Kosmo.
 Kosmo's sidebar uses compact SVG tabs for the lazy file tree and regular-expression
 find-in-files results. A single click on a result opens it as a temporary preview;
 double-clicking promotes it to a permanent editor tab. Git-ignored files and
-dot-directories remain visible in the file tree with muted gray text. Holding
-Control while scrolling over an editor accelerates the wheel movement threefold.
+dot-directories remain visible in the file tree with muted gray text. Find in Files
+searches Git tracked and untracked non-ignored files and skips binary or unsupported
+text encodings by default; both filters are configurable through `FileSearchOptions`.
+Holding Control while scrolling over an editor accelerates the wheel movement
+threefold.
 
 Markdown files open in Kosmo's native pretty viewer by default. A compact
 floating control group in the document switches between the rendered preview

--- a/src/merenda/kosmo/filesearchpanel.nim
+++ b/src/merenda/kosmo/filesearchpanel.nim
@@ -42,6 +42,7 @@ type
     progressIndicator*: nimkit.ProgressIndicator
     cancelButton*: nimkit.Button
     xRootPath: string
+    xSearchOptions: nimkit.FileSearchOptions
     xService: nimkit.FileSearchService
     xActiveSearch: nimkit.FileSearchHandle
 
@@ -382,9 +383,7 @@ proc performSearch*(panel: KosmoFileSearchPanel): bool {.discardable.} =
   try:
     panel.ensureSearchService()
     panel.xActiveSearch = panel.xService.search(
-      nimkit.initFileSearchQuery(
-        panel.xRootPath, pattern, nimkit.initFileSearchOptions(caseSensitive = false)
-      )
+      nimkit.initFileSearchQuery(panel.xRootPath, pattern, panel.xSearchOptions)
     )
     result = true
   except CatchableError as error:
@@ -471,6 +470,14 @@ proc `rootPath=`*(panel: KosmoFileSearchPanel, rootPath: string) =
 proc activeSearch*(panel: KosmoFileSearchPanel): nimkit.FileSearchHandle =
   panel.xActiveSearch
 
+proc searchOptions*(panel: KosmoFileSearchPanel): nimkit.FileSearchOptions =
+  ## Return the options applied to future searches from this panel.
+  panel.xSearchOptions
+
+proc `searchOptions=`*(panel: KosmoFileSearchPanel, options: nimkit.FileSearchOptions) =
+  ## Configure future searches without interrupting the current search.
+  panel.xSearchOptions = options
+
 proc waitForSearch*(
     panel: KosmoFileSearchPanel, timeoutMilliseconds: Natural = 5_000
 ): bool {.discardable.} =
@@ -515,6 +522,7 @@ proc newKosmoFileSearchPanel*(rootPath = ""): KosmoFileSearchPanel =
     statusLabel: statusLabel,
     progressIndicator: progressIndicator,
     cancelButton: cancelButton,
+    xSearchOptions: nimkit.initFileSearchOptions(caseSensitive = false),
   )
   result.initViewFields()
   result.addSubview(queryField)

--- a/src/merenda/nimkit/foundation/filesearch.nim
+++ b/src/merenda/nimkit/foundation/filesearch.nim
@@ -1,6 +1,10 @@
 ## Asynchronous, memory-mapped regular-expression search for local files.
 
-import std/[algorithm, atomics, monotimes, os, tables, times]
+import
+  std/[
+    algorithm, atomics, mimetypes, monotimes, os, osproc, sets, streams, strutils,
+    tables, times, unicode,
+  ]
 
 import faststreams/inputs
 import regex
@@ -12,6 +16,7 @@ const
   DefaultFileSearchMaxMatchesPerFile* = 1_000
   DefaultFileSearchMaxFiles* = 100_000
   DefaultFileSearchMaxFileSizeBytes* = 16'i64 * 1024 * 1024
+  FileSearchEncodingSampleSize = 8 * 1024
   FileSearchMatchBatchSize = 64
   FileSearchMatchBatchMaxDelayMilliseconds = 50
 
@@ -25,6 +30,8 @@ type
   FileSearchOptions* = object
     recursive*: bool
     includeHidden*: bool
+    respectGitIgnore*: bool
+    includeBinaryFiles*: bool
     caseSensitive*: bool
     maxResults*: int
     maxMatchesPerFile*: int
@@ -49,6 +56,7 @@ type
     searchedFileCount*: int
     mappedFileCount*: int
     skippedLargeFileCount*: int
+    skippedNonTextFileCount*: int
     failedFileCount*: int
     limitedFileCount*: int
     bytesSearched*: int64
@@ -129,11 +137,15 @@ func initFileSearchOptions*(
     maxMatchesPerFile: Positive = DefaultFileSearchMaxMatchesPerFile,
     maxFiles: Positive = DefaultFileSearchMaxFiles,
     maxFileSizeBytes: Positive = DefaultFileSearchMaxFileSizeBytes,
+    respectGitIgnore = true,
+    includeBinaryFiles = false,
 ): FileSearchOptions =
-  ## Configure traversal and resource limits for one search.
+  ## Configure traversal, content filtering, and resource limits for one search.
   FileSearchOptions(
     recursive: recursive,
     includeHidden: includeHidden,
+    respectGitIgnore: respectGitIgnore,
+    includeBinaryFiles: includeBinaryFiles,
     caseSensitive: caseSensitive,
     maxResults: maxResults,
     maxMatchesPerFile: maxMatchesPerFile,
@@ -196,6 +208,74 @@ func hiddenPath(path: string): bool =
   let name = path.extractFilename()
   name.len > 0 and name[0] == '.'
 
+func hiddenPathComponent(path: string): bool =
+  var componentStart = true
+  for value in path:
+    if componentStart and value == '.':
+      return true
+    componentStart = value == DirSep or value == AltSep
+
+func nestedPath(path: string): bool =
+  DirSep in path or AltSep in path
+
+func nextNulField(value: string, cursor: var int): string =
+  if cursor >= value.len:
+    return
+  let fieldEnd = value.find('\0', cursor)
+  if fieldEnd < 0:
+    result = value[cursor ..^ 1]
+    cursor = value.len
+  else:
+    result = value[cursor ..< fieldEnd]
+    cursor = fieldEnd + 1
+
+type GitFileList = object
+  succeeded: bool
+  paths: seq[string]
+
+proc gitSearchFiles(
+    rootPath: string, options: FileSearchOptions, control: SharedPtr[FileSearchControl]
+): GitFileList =
+  var process: Process
+  try:
+    process = startProcess(
+      "git",
+      workingDir = rootPath,
+      args = [
+        "--no-optional-locks", "ls-files", "--cached", "--others", "--exclude-standard",
+        "-z", "--", ".",
+      ],
+      options = {poUsePath, poStdErrToStdOut},
+    )
+    let output = process.outputStream().readAll()
+    if process.waitForExit() != 0:
+      return
+    result.succeeded = true
+
+    var
+      cursor = 0
+      seen = initHashSet[string]()
+    while cursor < output.len and not control.cancellationRequested():
+      let relativePath = output.nextNulField(cursor)
+      if relativePath.len == 0 or relativePath in seen:
+        continue
+      if not options.includeHidden and relativePath.hiddenPathComponent():
+        continue
+      if not options.recursive and relativePath.nestedPath():
+        continue
+      let path = rootPath / relativePath
+      if fileExists(path) and not symlinkExists(path):
+        seen.incl relativePath
+        result.paths.add path
+        if result.paths.len > options.maxFiles:
+          break
+    result.paths.sort()
+  except CatchableError:
+    discard
+  finally:
+    if not process.isNil:
+      process.close()
+
 type FileSearchTraversalState = object
   options: FileSearchOptions
   control: SharedPtr[FileSearchControl]
@@ -206,9 +286,14 @@ type FileSearchTraversalState = object
 proc initFileSearchTraversal(
     rootPath: string, options: FileSearchOptions, control: SharedPtr[FileSearchControl]
 ): FileSearchTraversalState =
-  FileSearchTraversalState(
-    options: options, control: control, pendingDirectories: @[absolutePath(rootPath)]
-  )
+  result = FileSearchTraversalState(options: options, control: control)
+  let root = absolutePath(rootPath)
+  if options.respectGitIgnore:
+    let gitFiles = gitSearchFiles(root, options, control)
+    if gitFiles.succeeded:
+      result.pendingFiles = gitFiles.paths
+      return
+  result.pendingDirectories = @[root]
 
 proc nextSearchFile(
     traversal: var FileSearchTraversalState,
@@ -293,11 +378,71 @@ proc addLineMatches(
       return false
   true
 
+func mediaTypeIsKnownBinary(mediaType: string): bool =
+  (mediaType.startsWith("image/") and not mediaType.endsWith("+xml")) or
+    mediaType.startsWith("audio/") or mediaType.startsWith("video/") or
+    mediaType.startsWith("font/") or
+    mediaType in [
+      "application/gzip", "application/java-archive", "application/java-vm",
+      "application/msword", "application/octet-stream", "application/pdf",
+      "application/vnd.rar", "application/wasm", "application/x-7z-compressed",
+      "application/x-bzip", "application/x-bzip2", "application/x-rar-compressed",
+      "application/x-tar", "application/zip",
+    ]
+
+func validUtf8Sample(sample: string, complete: bool): bool =
+  let invalidIndex = sample.validateUtf8()
+  if invalidIndex < 0:
+    return true
+  if complete or invalidIndex < sample.len - 3:
+    return false
+
+  let firstByte = ord(sample[invalidIndex])
+  let expectedLength =
+    if (firstByte and 0xe0) == 0xc0:
+      2
+    elif (firstByte and 0xf0) == 0xe0:
+      3
+    elif (firstByte and 0xf8) == 0xf0:
+      4
+    else:
+      0
+  if expectedLength == 0 or sample.len - invalidIndex >= expectedLength:
+    return false
+  for index in invalidIndex + 1 ..< sample.len:
+    if (ord(sample[index]) and 0xc0) != 0x80:
+      return false
+  true
+
+proc readEncodingSample(path: string, fileSize: int64): string =
+  let sampleLength = min(fileSize, FileSearchEncodingSampleSize.int64).int
+  if sampleLength == 0:
+    return
+  var file: File
+  if not open(file, path, fmRead):
+    raise newException(IOError, "unable to open file for type detection: " & path)
+  defer:
+    file.close()
+  result = newString(sampleLength)
+  result.setLen(file.readBuffer(addr result[0], sampleLength))
+
+proc isSearchableTextFile(path: string, fileSize: int64, mimeTypes: MimeDB): bool =
+  let mediaType = mimeTypes.getMimetype(splitFile(path).ext, default = "")
+  if mediaType.mediaTypeIsKnownBinary():
+    return
+  let sample = path.readEncodingSample(fileSize)
+  if sample.len == 0:
+    return true
+  if '\0' in sample:
+    return
+  sample.validUtf8Sample(complete = sample.len.int64 == fileSize)
+
 proc searchMappedFile(
     batchState: var FileSearchBatchState,
     path: string,
     pattern: Regex2,
     options: FileSearchOptions,
+    mimeTypes: MimeDB,
     control: SharedPtr[FileSearchControl],
     searchResult: var FileSearchResult,
 ) =
@@ -307,6 +452,10 @@ proc searchMappedFile(
     return
   if control.cancellationRequested():
     searchResult.reason = fsfrCancelled
+    return
+  if not options.includeBinaryFiles and
+      not path.isSearchableTextFile(fileSize, mimeTypes):
+    inc searchResult.stats.skippedNonTextFileCount
     return
 
   var stream =
@@ -369,12 +518,15 @@ proc performFileSearch(
   result.reason = fsfrCompleted
   result.stats.workerThreadId = getThreadId()
   let pattern = query.searchPattern()
+  let mimeTypes = newMimetypes()
   var
     traversal = initFileSearchTraversal(query.rootPath, query.options, control)
     path: string
   while traversal.nextSearchFile(result.stats, result.reason, path):
     try:
-      searchMappedFile(batchState, path, pattern, query.options, control, result)
+      searchMappedFile(
+        batchState, path, pattern, query.options, mimeTypes, control, result
+      )
     except IOError, OSError:
       inc result.stats.failedFileCount
     if result.reason != fsfrCompleted:

--- a/src/merenda/nimkit/text/markdownviews.nim
+++ b/src/merenda/nimkit/text/markdownviews.nim
@@ -587,6 +587,10 @@ proc renderList(
   attributes: TextAttributes,
 )
 
+func endsWithCodeBlock(builder: MarkdownBuilder): bool =
+  builder.codeBlockRanges.len > 0 and
+    builder.codeBlockRanges[^1].maxIndex == builder.runeLength
+
 proc renderListItem(
     builder: var MarkdownBuilder,
     item: markdownParser.Li,
@@ -604,10 +608,16 @@ proc renderListItem(
   var first = true
   for child in item.children:
     if child of markdownParser.Ul or child of markdownParser.Ol:
-      builder.add("\n", attributes)
+      if builder.endsWithCodeBlock():
+        builder.addBlockBreak(attributes)
+      else:
+        builder.add("\n", attributes)
       builder.renderList(child, depth + 1, attributes)
     else:
-      if not first:
+      if child of markdownParser.CodeBlock or builder.endsWithCodeBlock():
+        builder.addBlockBreak(attributes)
+        builder.add(continuation, attributes)
+      elif not first:
         builder.add("\n" & continuation, attributes)
       builder.renderBlock(child, attributes)
     first = false
@@ -627,7 +637,10 @@ proc renderList(
   for child in token.children:
     if child of markdownParser.Li:
       if not first:
-        builder.add("\n", attributes)
+        if builder.endsWithCodeBlock():
+          builder.addBlockBreak(attributes)
+        else:
+          builder.add("\n", attributes)
       let marker =
         if token of markdownParser.Ol:
           $index & "."

--- a/tests/nimkit/filesearch.nim
+++ b/tests/nimkit/filesearch.nim
@@ -1,4 +1,4 @@
-import std/[os, strutils, tempfiles, unittest]
+import std/[os, osproc, strutils, tempfiles, unittest]
 
 import regex
 import sigils/core
@@ -75,6 +75,82 @@ suite "nimkit memory-mapped file search":
       check searchResult.stats.mappedFileCount == 2
       check searchResult.stats.bytesSearched > 0
       check spy.finishedIdentifiers == @[handle.identifier()]
+    finally:
+      service.close()
+      removeDir(root)
+
+  test "uses Git tracked and untracked non-ignored files by default":
+    let
+      root = createTempDir("merenda-file-search-git-ignore-", "")
+      ignoredDirectory = root / "build"
+      service = newFileSearchService(workers = 1)
+    createDir(ignoredDirectory)
+    writeFile(root / ".gitignore", "build/\n")
+    writeFile(root / "tracked.nim", "tracked needle\n")
+    writeFile(root / "untracked.nim", "untracked needle\n")
+    writeFile(ignoredDirectory / "generated.nim", "ignored needle\n")
+    discard execProcess(
+      "git",
+      workingDir = root,
+      args = ["init", "-q"],
+      options = {poUsePath, poStdErrToStdOut},
+    )
+    discard execProcess(
+      "git",
+      workingDir = root,
+      args = ["add", "tracked.nim"],
+      options = {poUsePath, poStdErrToStdOut},
+    )
+    require dirExists(root / ".git")
+
+    try:
+      block defaultOptions:
+        let searchResult = service.runSearch(root, "needle").result()
+        check searchResult.reason == fsfrCompleted
+        check searchResult.matches.len == 2
+        check searchResult.matches[0].path == root / "tracked.nim"
+        check searchResult.matches[1].path == root / "untracked.nim"
+
+      block includeIgnored:
+        let
+          options = initFileSearchOptions(respectGitIgnore = false)
+          searchResult = service.runSearch(root, "needle", options).result()
+        check searchResult.reason == fsfrCompleted
+        check searchResult.matches.len == 3
+        check searchResult.matches[^1].path == ignoredDirectory / "generated.nim"
+    finally:
+      service.close()
+      removeDir(root)
+
+  test "skips non-text MIME types and unsupported encodings by default":
+    let
+      root = createTempDir("merenda-file-search-content-type-", "")
+      service = newFileSearchService(workers = 1)
+    writeFile(root / "plain.txt", "plain needle\n")
+    writeFile(root / "source.dart", "source needle\n")
+    writeFile(root / "misleading.png", "image needle\n")
+    writeFile(root / "binary.dat", "blob\0needle\n")
+    writeFile(root / "invalid.txt", "\xffneedle\n")
+
+    try:
+      block defaultOptions:
+        let searchResult = service.runSearch(root, "needle").result()
+        check searchResult.reason == fsfrCompleted
+        check searchResult.matches.len == 2
+        check searchResult.matches[0].path == root / "plain.txt"
+        check searchResult.matches[1].path == root / "source.dart"
+        check searchResult.stats.discoveredFileCount == 5
+        check searchResult.stats.searchedFileCount == 2
+        check searchResult.stats.skippedNonTextFileCount == 3
+
+      block includeBinaryFiles:
+        let
+          options = initFileSearchOptions(includeBinaryFiles = true)
+          searchResult = service.runSearch(root, "needle", options).result()
+        check searchResult.reason == fsfrCompleted
+        check searchResult.matches.len == 5
+        check searchResult.stats.searchedFileCount == 5
+        check searchResult.stats.skippedNonTextFileCount == 0
     finally:
       service.close()
       removeDir(root)

--- a/tests/nimkit/markdownviews.nim
+++ b/tests/nimkit/markdownviews.nim
@@ -622,6 +622,63 @@ echo "fenced"
         check node.screenBox.h > 20.0'f32
     check panelCount == 2
 
+  test "code block panels in ordered lists do not overlap item labels":
+    var style = initMarkdownStyle()
+    style.codeBlockStyle.padding = insets(7.0'f32, 10.0'f32)
+    let source =
+      """
+1. Install dependencies:
+
+   ```bash
+   atlas install
+   ```
+
+2. Build:
+
+   ```bash
+   nim build
+   ```
+
+3. Run tests:
+
+   ```bash
+   nim test
+   ```
+"""
+    let view = newMarkdownView(source, frame = rect(0, 0, 520, 480), style = style)
+    require view.waitForMarkdownParsing()
+    let renders = buildRenders(view)
+    require DefaultDrawLevel in renders
+
+    var panelFrames: seq[Rect]
+    for node in renders[DefaultDrawLevel].nodes:
+      if node.kind == nkRectangle and node.fill.kind == flColor and
+          node.fill.color == style.codeBlockStyle.backgroundColor.rgba:
+        panelFrames.add rect(
+          node.screenBox.x, node.screenBox.y, node.screenBox.w, node.screenBox.h
+        )
+    require panelFrames.len == 3
+
+    let storage = view.textStorage()
+    proc renderedTextFrame(text: string): Rect =
+      let index = storage.stringValue().runeIndexOf(text)
+      require index >= 0
+      for selectionRect in view.textView().selectionRects(
+        initTextRange(index, text.runeLen)
+      ):
+        if result.isEmpty:
+          result = selectionRect
+        else:
+          result = result.union(selectionRect)
+
+    let labels = ["Install dependencies:", "Build:", "Run tests:"]
+    for index, label in labels:
+      let labelFrame = renderedTextFrame(label)
+      check panelFrames[index].minY >= labelFrame.maxY
+      if index < labels.high:
+        let nextLabelFrame = renderedTextFrame(labels[index + 1])
+        check nextLabelFrame.minY >= panelFrames[index].maxY
+
   test "raw inline and block HTML remain inert and visibly muted":
     let
       style = initMarkdownStyle()

--- a/tests/tnimkit.nim
+++ b/tests/tnimkit.nim
@@ -3,6 +3,7 @@ import merenda/nimkit
 
 import nimkit/application_icon
 import nimkit/backrefs_arc
+import nimkit/filesearch
 import nimkit/font_layout
 import nimkit/markdownviews
 import nimkit/resources


### PR DESCRIPTION
## Summary

- preserve block separation around fenced code blocks nested in Markdown lists
- prevent code panel padding from overlapping neighboring item labels
- make Find in Files enumerate Git tracked and untracked non-ignored files
- skip known binary MIME types and unsupported text encodings by default
- expose `respectGitIgnore` and `includeBinaryFiles` through `FileSearchOptions` and the Kosmo search panel

## Tests

- `atlas-run tests`
- `atlas-run tests --compile-only examples/all_compile.nim`