### PR TITLE
Require the Kosmo feature for Kosmo imports

### DIFF
--- a/merenda.nimble
+++ b/merenda.nimble
@@ -1,4 +1,4 @@
-version       = "0.15.4"
+version       = "0.15.5"
 author        = "Jaremy Creechley"
 description   = "Nim-native UI toolkit"
 license       = "BSD-3-Clause"

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -1,5 +1,15 @@
 ## A synchronous NimKit frontend for the Moe editor engine.
 
+when not defined(features.merenda.kosmo):
+  {.
+    error:
+      """
+Kosmo requires the "kosmo" feature. Enable it with Atlas:
+
+  atlas install -tuk --features:kosmo
+"""
+  .}
+
 import std/[math, options, os, strutils, unicode]
 
 import ../nimkit as nimkit


### PR DESCRIPTION
## Summary
- fail Kosmo imports with a clear compile-time error when the `kosmo` feature is disabled
- include the exact Atlas command needed to enable the feature
- bump the Merenda package version from `0.15.4` to `0.15.5`

## Validation
- `atlas install -tuk --features:kosmo`
- missing-feature compile fails with the intended message and Atlas command
- `atlas-run tests kosmo`
- `nph src/merenda/kosmo/kosmo.nim`
- `git diff --check`