### PR TITLE
Add per-view fragment caching and fragment-native rendering

### DIFF
--- a/TODO-fragments.md
+++ b/TODO-fragments.md
@@ -5,7 +5,8 @@
 Implementation began with [FigDraw PR #72](https://github.com/elcritch/figdraw/pull/72)
 and the initial NimKit scene foundation on `feature/incremental-render-fragments`.
 Checked items below are covered by those branches; unchecked items remain follow-up
-work, including per-view contribution caching and renderer-thread deltas.
+work, primarily fragment-native renderer integration and renderer-thread deltas.
+Per-view contribution caching continues on `feature/per-view-render-fragment-cache`.
 
 ## Recommendation
 
@@ -206,7 +207,7 @@ diagnostic scene.
 - [x] Assign stable view IDs without retaining removed views.
 - [x] Mark entries encountered during each scene reconciliation.
 - [x] Detach and sweep entries not encountered in the completed traversal.
-- [ ] Reuse a view ID in a different scene by creating scene-local fragments.
+- [x] Reuse a view ID in a different scene by creating scene-local fragments.
 
 ### Composite view contribution
 
@@ -256,11 +257,11 @@ Temporary internal anchor nodes are an acceptable first implementation if they
 are removed while finalizing each captured `RenderList`. Existing public drawing
 helpers should continue to return usable local `FigIdx` values during the draw.
 
-- [ ] Build or reuse the shell during scene reconciliation.
-- [ ] Run `view.draw` only when its local contribution is dirty or its render
+- [x] Build or reuse the shell during scene reconciliation.
+- [x] Run `view.draw` only when its local contribution is dirty or its render
       context changed.
-- [ ] Replace each affected output fragment atomically after a successful draw.
-- [ ] Reconcile child, sibling, root, and layer slots independently of redrawing
+- [x] Replace each affected output fragment atomically after a successful draw.
+- [x] Reconcile child, sibling, root, and layer slots independently of redrawing
       clean view content.
 
 ### Display invalidation
@@ -278,12 +279,12 @@ Replace recursive blanket dirty-flag clearing with revision acknowledgement:
 capture the revision before drawing and mark only that revision as rendered. An
 invalidation raised during layout or drawing must remain pending.
 
-- [ ] Make local invalidation advance only the target view's drawing revision.
-- [ ] Propagate damage/descendant state without advancing ancestor drawing
+- [x] Make local invalidation advance only the target view's drawing revision.
+- [x] Propagate damage/descendant state without advancing ancestor drawing
       revisions.
-- [ ] Include effective appearance, absolute origin, visible rectangle, draw
+- [x] Include effective appearance, absolute origin, visible rectangle, draw
       level, and relevant geometry in the view cache key.
-- [ ] Invalidate/reconcile descendants when an ancestor changes an inherited
+- [x] Invalidate/reconcile descendants when an ancestor changes an inherited
       render context.
 
 Keep absolute coordinates for the first implementation. Local coordinates and
@@ -300,7 +301,7 @@ counts initially.
 
 - [x] Add manifest merge support.
 - [x] Associate fragment/resource versions with the scene frame generation.
-- [ ] Exclude manifests belonging only to removed or replaced fragments from the
+- [x] Exclude manifests belonging only to removed or replaced fragments from the
       new live merge.
 - [x] Retain replaced manifests until the frame that could reference them has
       completed or been acknowledged.
@@ -319,10 +320,13 @@ storage across threads.
 
 Initial behavior:
 
-- Direct static rendering consumes the scene's `RenderFragments` synchronously.
-- Public/diagnostic `buildRenders` materializes a fresh monolithic value.
-- The dedicated renderer continues receiving moved monolithic snapshots.
-- The UI retains and incrementally updates its own scene after submission.
+- Direct static rendering reconciles the scene and consumes its cached
+  monolithic materialization synchronously.
+- Public/diagnostic `buildRenders` retains compatibility by returning the cached
+  monolithic materialization.
+- The dedicated renderer continues receiving moved monolithic snapshots and
+  invalidates the submitted root cache.
+- No mutable fragment graph crosses the renderer-thread boundary.
 
 This path captures the main CPU benefit while retaining the existing safe thread
 ownership boundary.
@@ -372,19 +376,19 @@ Fig indexes.
 - [x] Nested view updates and sibling ordering.
 - [x] Same-layer versus cross-layer descendants.
 - [ ] Clips, transforms, shadows, and inherited visibility.
-- [ ] Exterior focus rings and other escaped sibling content.
-- [ ] Inline popups, tooltip layers, focus-ring layers, and overlay ordering.
-- [ ] Hidden, removed, reinserted, and reordered views.
-- [ ] Appearance-generation and ancestor-geometry changes.
+- [x] Exterior focus rings and other escaped sibling content.
+- [x] Inline popups, tooltip layers, focus-ring layers, and overlay ordering.
+- [x] Hidden, removed, reinserted, and reordered views.
+- [x] Appearance-generation and ancestor-geometry changes.
 - [ ] Font and image replacement and removed-view resources.
 - [ ] Atlas recovery using only the current live manifest.
 
 ### Operation counts and threads
 
-- [ ] Initial frame draws every participating view once.
+- [x] Initial frame draws every participating view once.
 - [x] A clean frame invokes no view `draw` methods.
-- [ ] A leaf display invalidation rebuilds only the leaf's own dirty fragments.
-- [ ] Structural reconciliation does not redraw unaffected view content.
+- [x] A leaf display invalidation rebuilds only the leaf's own dirty fragments.
+- [x] Structural reconciliation does not redraw unaffected view content.
 - [ ] Fragment-backed and monolithic rendering emit equivalent renderer
       operations.
 - [ ] Coalesced thread updates apply the newest valid replacement.
@@ -422,10 +426,24 @@ single-fragment scene. A chain 5,000 nested fragments deep materialized in 0.69
 ms (139 ns/node). Replacing one leaf fragment remained roughly 0.14--0.20 us as
 the sibling population grew from 100 to 10,000.
 
-Leaf invalidation remains a full-tree redraw in this foundation PR: at 10,000
-views the branch took 61.18 ms through `buildRenders` and 62.83 ms through
-`buildRenderScene`, versus 63.61 ms on `main`. Per-view contribution caching is
-still required to turn that operation into a narrow fragment replacement.
+The per-view cache follow-up keeps the same linear frame cost while narrowing
+`draw` calls and fragment replacement to the dirty contributions. On the same
+class of machine, a follow-up run produced these medians for empty views:
+
+| Views | monolithic dirty | scene root dirty | scene leaf dirty | scene cached |
+|------:|-----------------:|-----------------:|-----------------:|-------------:|
+| 100 | 476 us | 427 us | 425 us | 3 us |
+| 1,000 | 4.80 ms | 4.28 ms | 4.31 ms | 5 us |
+| 5,000 | 29.60 ms | 26.93 ms | 27.38 ms | 29 us |
+| 10,000 | 62.41 ms | 58.80 ms | 57.15 ms | 52 us |
+
+The root- and leaf-dirty timings remain similar for these deliberately empty
+views because both still traverse the view hierarchy, merge live manifests, and
+materialize a renderer-compatible snapshot. The leaf path now runs `draw` only
+for the leaf, so views with text layout, images, SVGs, or other meaningful draw
+work avoid rebuilding those clean contributions. The benchmark shows no new
+complexity cliff through 10,000 view fragments and remains in the same order of
+magnitude as monolithic rebuilding.
 
 The benchmark exposed two FigDraw usage cliffs and drove API changes before the
 dependency pin was advanced:

--- a/TODO-fragments.md
+++ b/TODO-fragments.md
@@ -5,8 +5,8 @@
 Implementation began with [FigDraw PR #72](https://github.com/elcritch/figdraw/pull/72)
 and the initial NimKit scene foundation on `feature/incremental-render-fragments`.
 Checked items below are covered by those branches; unchecked items remain follow-up
-work, primarily fragment-native renderer integration and renderer-thread deltas.
-Per-view contribution caching continues on `feature/per-view-render-fragment-cache`.
+work, primarily renderer-thread deltas. Per-view contribution caching and direct
+fragment-native rendering continue on `feature/per-view-render-fragment-cache`.
 
 ## Recommendation
 
@@ -305,8 +305,8 @@ counts initially.
       new live merge.
 - [x] Retain replaced manifests until the frame that could reference them has
       completed or been acknowledged.
-- [ ] Replay the current merged live manifest after atlas recovery.
-- [ ] Keep atlas generation separate from UI fragment-handle generations.
+- [x] Replay the current merged live manifest after atlas recovery.
+- [x] Keep atlas generation separate from UI fragment-handle generations.
 
 For direct synchronous rendering, old resources can be released after the frame
 boundary. For threaded rendering, use the existing render-ID acknowledgement and
@@ -320,10 +320,10 @@ storage across threads.
 
 Initial behavior:
 
-- Direct static rendering reconciles the scene and consumes its cached
-  monolithic materialization synchronously.
-- Public/diagnostic `buildRenders` retains compatibility by returning the cached
-  monolithic materialization.
+- Direct static rendering reconciles and renders the mutable application-thread
+  fragment graph synchronously without materializing `Renders`.
+- Public/diagnostic `buildRenders` retains compatibility by materializing lazily
+  and caching the monolithic result until the scene changes.
 - The dedicated renderer continues receiving moved monolithic snapshots and
   invalidates the submitted root cache.
 - No mutable fragment graph crosses the renderer-thread boundary.
@@ -375,13 +375,13 @@ Fig indexes.
 
 - [x] Nested view updates and sibling ordering.
 - [x] Same-layer versus cross-layer descendants.
-- [ ] Clips, transforms, shadows, and inherited visibility.
+- [x] Clips, transforms, shadows, and inherited visibility.
 - [x] Exterior focus rings and other escaped sibling content.
 - [x] Inline popups, tooltip layers, focus-ring layers, and overlay ordering.
 - [x] Hidden, removed, reinserted, and reordered views.
 - [x] Appearance-generation and ancestor-geometry changes.
-- [ ] Font and image replacement and removed-view resources.
-- [ ] Atlas recovery using only the current live manifest.
+- [x] Font and image replacement and removed-view resources.
+- [x] Atlas recovery using only the current live manifest.
 
 ### Operation counts and threads
 
@@ -389,7 +389,7 @@ Fig indexes.
 - [x] A clean frame invokes no view `draw` methods.
 - [x] A leaf display invalidation rebuilds only the leaf's own dirty fragments.
 - [x] Structural reconciliation does not redraw unaffected view content.
-- [ ] Fragment-backed and monolithic rendering emit equivalent renderer
+- [x] Fragment-backed and monolithic rendering emit equivalent renderer
       operations.
 - [ ] Coalesced thread updates apply the newest valid replacement.
 - [ ] Clear and target-replacement barriers discard stale queued updates.
@@ -406,44 +406,29 @@ and fragment reordering.
 On an Apple M3 Pro (12 cores), macOS 15.6, Nim 2.2.10, ARC with threads enabled,
 the following medians were observed. Times are microseconds per operation:
 
-| Views | `main` cached | branch cached | `main` dirty | branch dirty | scene dirty | materialize |
-|------:|--------------:|--------------:|-------------:|-------------:|------------:|------------:|
-| 100 | 14.17 | 13.72 | 482.25 | 478.65 | 486.19 | 7.90 |
-| 1,000 | 116.38 | 113.08 | 5,145.57 | 4,757.77 | 4,948.35 | 71.05 |
-| 5,000 | 775.84 | 748.62 | 30,782.15 | 28,560.73 | 30,617.60 | 413.71 |
-| 10,000 | 3,039.03 | 1,502.67 | 63,707.30 | 61,254.53 | 63,341.55 | 1,149.50 |
+| Views | monolithic cached | monolithic root dirty | monolithic leaf dirty | scene cached | scene root dirty | scene leaf dirty | materialize |
+|------:|------------------:|----------------------:|----------------------:|-------------:|-----------------:|-----------------:|------------:|
+| 100 | 13.87 | 471.83 | 467.30 | 2.97 | 411.43 | 413.58 | 12.35 |
+| 1,000 | 114.31 | 5,002.16 | 4,761.46 | 4.73 | 4,190.01 | 4,207.23 | 109.66 |
+| 5,000 | 725.07 | 29,584.12 | 29,409.19 | 28.18 | 26,306.13 | 25,819.05 | 629.54 |
+| 10,000 | 1,527.02 | 61,390.76 | 61,047.55 | 55.23 | 54,694.61 | 55,140.80 | 1,383.33 |
 
-The important result is scaling, not the favorable absolute variation between
-separate branch runs. The existing monolithic path did not regress in these
-samples. Updating the opt-in scene added at most about 7% over the branch's
-monolithic dirty path, and materialization remained linear at roughly 71--115
-ns per node. Replacing a 10,000-node scene took 1.11 ms with one layer and 0.90
-ms with 32 layers, showing no layer-count cliff at that scale.
-
-Fragment density did not change the complexity: 10,000 independent one-node
-fragment slots materialized in 1.39 ms (139 ns/node), versus 1.17 ms for the
-single-fragment scene. A chain 5,000 nested fragments deep materialized in 0.69
-ms (139 ns/node). Replacing one leaf fragment remained roughly 0.14--0.20 us as
-the sibling population grew from 100 to 10,000.
-
-The per-view cache follow-up keeps the same linear frame cost while narrowing
-`draw` calls and fragment replacement to the dirty contributions. On the same
-class of machine, a follow-up run produced these medians for empty views:
-
-| Views | monolithic dirty | scene root dirty | scene leaf dirty | scene cached |
-|------:|-----------------:|-----------------:|-----------------:|-------------:|
-| 100 | 476 us | 427 us | 425 us | 3 us |
-| 1,000 | 4.80 ms | 4.28 ms | 4.31 ms | 5 us |
-| 5,000 | 29.60 ms | 26.93 ms | 27.38 ms | 29 us |
-| 10,000 | 62.41 ms | 58.80 ms | 57.15 ms | 52 us |
+The completed direct-renderer path keeps the same linear reconciliation cost
+while narrowing `draw` calls and fragment replacement to dirty contributions.
+Scene-update timings no longer include monolithic materialization.
 
 The root- and leaf-dirty timings remain similar for these deliberately empty
-views because both still traverse the view hierarchy, merge live manifests, and
-materialize a renderer-compatible snapshot. The leaf path now runs `draw` only
-for the leaf, so views with text layout, images, SVGs, or other meaningful draw
-work avoid rebuilding those clean contributions. The benchmark shows no new
-complexity cliff through 10,000 view fragments and remains in the same order of
-magnitude as monolithic rebuilding.
+views because both still traverse the view hierarchy and merge live manifests.
+The leaf path runs `draw` only for the leaf, so views with text layout, images,
+SVGs, or other meaningful draw work avoid rebuilding those clean contributions.
+The benchmark shows no new complexity cliff through 10,000 view fragments,
+remains in the same order of magnitude as monolithic rebuilding, and removes the
+71--138 ns/node materialization pass from normal synchronous rendering.
+
+On this run, replacing a 10,000-node compatibility scene took 1.10 ms with one
+layer and 0.84 ms with 32 layers. Materializing 10,000 independent fragment
+slots took 1.24 ms, a 5,000-deep nested fragment chain took 0.80 ms, and replacing
+one leaf remained 0.14--0.20 us across populations of 100 through 10,000.
 
 The benchmark exposed two FigDraw usage cliffs and drove API changes before the
 dependency pin was advanced:
@@ -452,9 +437,9 @@ dependency pin was advanced:
   visited node. It now traverses borrowed internal topology and is linear.
 - Reversing every sibling with individual `moveFragment` calls is quadratic,
   because each isolated move performs a linear sequence edit. At 5,000 slots a
-  two-way reversal took 1,251.12 ms. The new `reorderChildFragments` and
+  two-way reversal took 1,169.11 ms. The new `reorderChildFragments` and
   `reorderRootFragments` operations reconcile the complete sibling order in a
-  single linear pass; the same 5,000-slot two-way reversal took 0.90 ms.
+  single linear pass; the same 5,000-slot two-way reversal took 0.94 ms.
 
 NimKit reconciliation should therefore use an isolated move for isolated
 changes and the bulk APIs whenever it already knows a complete sibling order.
@@ -479,6 +464,5 @@ changes and the bulk APIs whenever it already knows a complete sibling order.
 
 - Rasterized view/texture caching.
 - Local-coordinate and transform-based movement optimization.
-- Partial GPU redraw or damage-only rendering.
 - Mutable fragment graphs shared across threads.
 - Dynlib fragment integration.

--- a/TODO-fragments.md
+++ b/TODO-fragments.md
@@ -219,24 +219,26 @@ Use a composite entry:
 
 ```text
 view slot
-└── stable shell node              background, shadow, clipping
-    ├── replaceable self fragment
-    ├── child view slot
-    ├── child view slot
-    └── ...
+└── stable placement transform fragment
+    ├── stable shell fragment      background, shadow, clipping
+    │   ├── replaceable self fragment
+    │   ├── child view slot
+    │   └── child view slot
+    └── escaped fragment           exterior focus ring or chrome
 
-escaped sibling fragment           exterior focus ring or chrome
-layer-root fragments               popup, focus, tooltip, future overlays
+layer-root transform fragments     popup, focus, tooltip, future overlays
 ```
 
-The stable shell remains the structural and clipping parent. Its Fig can be
-updated through the controlled node API. Rebuilding a view's own drawing replaces
-the self fragment without disturbing its child-view slots.
+The placement fragment contains one `nkTransform` node updated through the
+controlled node API. Its fragment ID, shell, self drawing, escaped drawing, and
+child slots remain attached when a view or ancestor moves. The shell remains the
+background and clipping parent. Rebuilding a view's own drawing replaces the self
+fragment without disturbing its child-view slots.
 
 Preserve these existing semantics:
 
 - Normal view content and same-layer descendants are children of the shell and
-  inherit its clipping and transform state.
+  inherit its clipping and placement transform.
 - Exterior focus rings and similar content using `renderViewParent` remain
   siblings following the view slot, outside the view's own clip.
 - A view whose effective draw level differs from its parent is a layer root.
@@ -284,15 +286,17 @@ invalidation raised during layout or drawing must remain pending.
 - [x] Make local invalidation advance only the target view's drawing revision.
 - [x] Propagate damage/descendant state without advancing ancestor drawing
       revisions.
-- [x] Include effective appearance, absolute origin, visible rectangle, draw
-      level, and relevant geometry in the view cache key.
+- [x] Include effective appearance, local placement, draw level, and relevant
+      geometry in the view cache key. Include the visible rectangle only for
+      drawing that reads it.
 - [x] Invalidate/reconcile descendants when an ancestor changes an inherited
       render context.
 
-Keep absolute coordinates for the first implementation. Local coordinates and
-view transforms may later reduce rebuilds when ancestors move, but combining that
-change with initial fragment adoption would make equivalence substantially harder
-to establish.
+The completed implementation captures drawing in view-local coordinates and keeps
+placement in the stable transform fragment. `DrawContext.visibleRect` records a
+dependency when drawing reads it, so virtualized drawing is recaptured as its clip
+moves while ordinary drawing remains cached. Explicit-layer output is rooted under
+an equivalent absolute placement transform.
 
 ## Resource manifests
 
@@ -329,8 +333,10 @@ Implemented behavior:
 - The application scene builds a cumulative update from the last acknowledged
   scene generation. Every update contains the complete view placement order and
   node payloads only for contributions changed after that baseline.
-- Updates are move-only and carry copied node sequences plus font/image IDs. They
-  never carry application-thread resource handles or FigDraw fragment handles.
+- Updates are move-only and carry copied dirty node sequences plus font/image IDs.
+  Placement-only updates carry value-type cache keys and mutate the renderer's
+  retained transform nodes. They never carry application-thread resource handles
+  or FigDraw fragment handles.
 - The dedicated renderer owns a separate `RenderScene` and moves received node
   payloads into its own fragment graph before rendering it directly.
 - The bounded two-entry channel coalesces superseded frames. Because the newest
@@ -393,6 +399,8 @@ Fig indexes.
 - [x] Inline popups, tooltip layers, focus-ring layers, and overlay ordering.
 - [x] Hidden, removed, reinserted, and reordered views.
 - [x] Appearance-generation and ancestor-geometry changes.
+- [x] Scrolling updates placement transforms without recapturing drawing that does
+      not read `visibleRect`, while visibility-dependent drawing is recaptured.
 - [x] Font and image replacement and removed-view resources.
 - [x] Atlas recovery using only the current live manifest.
 
@@ -503,6 +511,5 @@ renderer-replica application.
 ## Deferred work
 
 - Rasterized view/texture caching.
-- Local-coordinate and transform-based movement optimization.
 - Mutable fragment graphs shared across threads.
 - Dynlib fragment integration.

--- a/TODO-fragments.md
+++ b/TODO-fragments.md
@@ -4,9 +4,11 @@
 
 Implementation began with [FigDraw PR #72](https://github.com/elcritch/figdraw/pull/72)
 and the initial NimKit scene foundation on `feature/incremental-render-fragments`.
-Checked items below are covered by those branches; unchecked items remain follow-up
-work, primarily renderer-thread deltas. Per-view contribution caching and direct
-fragment-native rendering continue on `feature/per-view-render-fragment-cache`.
+FigDraw support shipped in 0.36.0, and the initial NimKit scene foundation was
+merged on `feature/incremental-render-fragments`. Per-view contribution caching,
+direct fragment rendering, and the dedicated-renderer update protocol are complete
+on `feature/per-view-render-fragment-cache`. The unchecked FigDraw validator and
+items under Deferred Work are not part of the NimKit implementation.
 
 ## Recommendation
 
@@ -19,9 +21,9 @@ render cache.
   many roots.
 - NimKit should cache vector/render-tree fragments at this stage. It should not
   add a separate rasterized-view or texture cache yet.
-- Enable fragment-native rendering first on the direct static renderer.
+- Enable fragment-native rendering on both direct and dedicated static renderers.
 - Preserve monolithic `Renders` through a flattening/materialization API for
-  compatibility, diagnostics, and the initial renderer-thread implementation.
+  compatibility and diagnostics.
 - Do not share a mutable fragment graph between the application and renderer
   threads.
 - Dynlib integration is outside the scope of this work.
@@ -186,7 +188,7 @@ preserve exact layer, root, sibling, clipping, and transform order.
 - [x] Make materialization deterministic.
 - [x] Keep the returned tree independent of subsequent fragment mutations.
 - [x] Use materialization for diagnostics, differential tests, public
-      `buildRenders`, and initial threaded rendering.
+      `buildRenders`, and compatibility rendering.
 
 ## NimKit retained render scene
 
@@ -318,38 +320,49 @@ Do not move a `RenderFragments` graph to the renderer thread while the UI scene
 retains handles into it. That would alias mutable fragment objects and node
 storage across threads.
 
-Initial behavior:
+Implemented behavior:
 
 - Direct static rendering reconciles and renders the mutable application-thread
   fragment graph synchronously without materializing `Renders`.
 - Public/diagnostic `buildRenders` retains compatibility by materializing lazily
   and caching the monolithic result until the scene changes.
-- The dedicated renderer continues receiving moved monolithic snapshots and
-  invalidates the submitted root cache.
+- The application scene builds a cumulative update from the last acknowledged
+  scene generation. Every update contains the complete view placement order and
+  node payloads only for contributions changed after that baseline.
+- Updates are move-only and carry copied node sequences plus font/image IDs. They
+  never carry application-thread resource handles or FigDraw fragment handles.
+- The dedicated renderer owns a separate `RenderScene` and moves received node
+  payloads into its own fragment graph before rendering it directly.
+- The bounded two-entry channel coalesces superseded frames. Because the newest
+  update is cumulative from the acknowledged generation, dropping an intermediate
+  update cannot omit one of its fragment replacements.
+- Target, render, scene, and baseline generations are checked before mutating the
+  renderer replica. New scenes, changed layer sets, target replacement, and an
+  explicitly forced recovery are full-update ordering barriers.
+- Render acknowledgement advances the application's cumulative baseline and
+  releases retired fragment resource manifests. Rejection clears that baseline,
+  drops rejected leases, and forces the next update to be full.
+- Atlas recovery uses the transferred live font/image ID set to replay and retain
+  only resources referenced by the accepted scene.
 - No mutable fragment graph crosses the renderer-thread boundary.
 
-This path captures the main CPU benefit while retaining the existing safe thread
-ownership boundary.
-
-A later threaded fragment protocol should make the renderer own a separate graph
-and accept move-only immutable replacement batches stamped with:
+The complete threaded update is stamped with the equivalent of:
 
 ```text
-hostId
 targetGeneration
-scene/tree epoch
-layer epoch
-fragmentId and version
-frame/resource generation
+renderId
+scene identity
+acknowledged base generation
+current scene/resource generation
 ```
 
-- [ ] Bound and coalesce queued replacements by fragment and generation.
-- [ ] Treat clear, layer replacement, target replacement, and full snapshots as
+- [x] Bound and coalesce queued replacements by fragment and generation.
+- [x] Treat clear, layer replacement, target replacement, and full snapshots as
       ordering barriers.
-- [ ] Reject obsolete target, scene, layer, atlas, and fragment generations.
-- [ ] Acknowledge the applied frame/update generation before releasing payloads
+- [x] Reject obsolete target, scene, layer, atlas, and fragment generations.
+- [x] Acknowledge the applied frame/update generation before releasing payloads
       and resources.
-- [ ] Send a full current snapshot after target replacement or when a delta chain
+- [x] Send a full current snapshot after target replacement or when a delta chain
       cannot be applied safely.
 
 ## Tests
@@ -391,9 +404,9 @@ Fig indexes.
 - [x] Structural reconciliation does not redraw unaffected view content.
 - [x] Fragment-backed and monolithic rendering emit equivalent renderer
       operations.
-- [ ] Coalesced thread updates apply the newest valid replacement.
-- [ ] Clear and target-replacement barriers discard stale queued updates.
-- [ ] Resource leases survive until the corresponding renderer acknowledgement.
+- [x] Coalesced thread updates apply the newest valid replacement.
+- [x] Clear and target-replacement barriers discard stale queued updates.
+- [x] Resource leases survive until the corresponding renderer acknowledgement.
 
 ## Performance baseline
 
@@ -444,6 +457,33 @@ dependency pin was advanced:
 NimKit reconciliation should therefore use an isolated move for isolated
 changes and the bulk APIs whenever it already knows a complete sibling order.
 
+`tests/benchmark_markdown_scroll.nim` profiles a more realistic dirty-frame
+workload: the repository's 35,919-byte README in a 760 x 540 `MarkdownView`,
+scrolled bidirectionally over 240 measured frames after 20 warmup frames. It
+measures CPU-side view drawing/reconciliation, bounded-channel handoff,
+renderer-replica application, and acknowledgement; GPU execution is deliberately
+excluded. The renderer stages are serialized in the diagnostic so its CPU total
+is comparable even though production runs them on separate threads.
+
+On the same Apple M3 Pro, the pre-PR monolithic path and completed fragment-native
+path measured:
+
+| Pipeline | wall median | wall p95 | CPU median | CPU p95 | prepare median | transfer median | apply/ack median |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| pre-PR monolithic | 11.439 ms | 12.165 ms | 11.437 ms | 12.144 ms | 11.366 ms | 0.001 ms | 0.001 ms |
+| fragment-native | 15.182 ms | 16.573 ms | 15.181 ms | 16.571 ms | 12.414 ms | 2.245 ms | 0.478 ms |
+
+The median CPU cost is 32.7% higher and p95 is 36.4% higher in this continuously
+dirty scrolling workload. View preparation itself is 9.2% higher; including the
+deep, ARC-isolated transfer clone, total application-thread preparation is 29.0%
+higher.
+Of 1,200 view placements, 714 (59.5%) carried changed contributions; the other
+40.5% reused retained fragments. The result remains in the same order of
+magnitude, and the flat 10,000-view benchmark above confirms linear scaling with
+no population-dependent cliff. The remaining constant-factor cost is primarily
+the independent cross-thread clone of nested text/drawable data plus
+renderer-replica application.
+
 ## Delivery sequence
 
 1. Add failing FigDraw tests for foreign, stale, detached, empty, and raw-mutation
@@ -457,8 +497,8 @@ changes and the bulk APIs whenever it already knows a complete sibling order.
 5. Add per-contribution manifests, live-frame merging, and retirement by frame or
    acknowledgement.
 6. Enable fragment-native rendering for the direct static renderer.
-7. Keep the renderer thread on materialized snapshots until immutable fragment
-   replacement batches and acknowledgements are complete.
+7. Send cumulative move-only fragment updates to a renderer-owned scene and
+   acknowledge applied generations before releasing resources.
 
 ## Deferred work
 

--- a/TODO-fragments.md
+++ b/TODO-fragments.md
@@ -221,19 +221,23 @@ Use a composite entry:
 view slot
 └── stable placement transform fragment
     ├── stable shell fragment      background, shadow, clipping
-    │   ├── replaceable self fragment
-    │   ├── child view slot
-    │   └── child view slot
-    └── escaped fragment           exterior focus ring or chrome
+    │   └── stable content transform fragment
+    │       ├── replaceable self fragment
+    │       ├── child view slot
+    │       └── child view slot
+    └── stable escaped-content transform fragment
+        └── escaped fragment       exterior focus ring or chrome
 
 layer-root transform fragments     popup, focus, tooltip, future overlays
 ```
 
-The placement fragment contains one `nkTransform` node updated through the
-controlled node API. Its fragment ID, shell, self drawing, escaped drawing, and
-child slots remain attached when a view or ancestor moves. The shell remains the
-background and clipping parent. Rebuilding a view's own drawing replaces the self
-fragment without disturbing its child-view slots.
+The placement and content fragments each contain one `nkTransform` node updated
+through the controlled node API. Placement tracks the view frame; clipped and
+escaped content transforms track the negative bounds origin. Their fragment IDs,
+the shell, self drawing, escaped drawing, and child slots remain attached when a
+view or ancestor moves or scrolls. The shell remains the background and clipping
+parent. Rebuilding a view's own drawing replaces the self fragment without
+disturbing its child-view slots.
 
 Preserve these existing semantics:
 
@@ -292,11 +296,12 @@ invalidation raised during layout or drawing must remain pending.
 - [x] Invalidate/reconcile descendants when an ancestor changes an inherited
       render context.
 
-The completed implementation captures drawing in view-local coordinates and keeps
-placement in the stable transform fragment. `DrawContext.visibleRect` records a
-dependency when drawing reads it, so virtualized drawing is recaptured as its clip
-moves while ordinary drawing remains cached. Explicit-layer output is rooted under
-an equivalent absolute placement transform.
+The completed implementation captures drawing in bounds coordinates and keeps
+frame placement and bounds-origin scrolling in stable transform fragments.
+`DrawContext.visibleRect` records a dependency when drawing reads it, so
+virtualized drawing is recaptured as its clip moves while ordinary drawing remains
+cached. Explicit-layer output is rooted under an equivalent absolute content
+transform.
 
 ## Resource manifests
 
@@ -481,24 +486,44 @@ path measured:
 | Pipeline | wall median | wall p95 | CPU median | CPU p95 | prepare median | transfer median | apply/ack median | traversal median |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | pre-PR monolithic | 11.545 ms | 12.308 ms | 11.544 ms | 12.306 ms | 11.023 ms | 0.000 ms | 0.001 ms | 0.455 ms |
-| fragment-native | 1.483 ms | 1.937 ms | 1.483 ms | 1.935 ms | 1.108 ms | 0.344 ms | 0.006 ms | 0.012 ms |
+| fragment-native | 0.047 ms | 0.051 ms | 0.047 ms | 0.050 ms | 0.024 ms | 0.001 ms | 0.002 ms | 0.014 ms |
 
-The retained placement-transform design reduces median CPU cost by 87.2% and
-p95 by 84.3% in this continuously dirty scrolling workload. The Markdown text
-view was captured zero times during the 240 measured frames: scrolling changes
-its ancestor placement, but does not clone or rebuild the document's text nodes.
-Of 1,200 view placements, 476 (39.7%) carried changed contributions for the
-scroll container and its small chrome; all other contributions were reused.
+The retained transform design reduces median CPU cost by 99.6%, about 246x, in
+this continuously dirty scrolling workload. The Markdown text view was captured
+zero times during the 240 measured frames: scrolling changes its ancestor content
+transform, but does not clone or rebuild the document's text nodes. Of 1,200 view
+placements, 238 (19.8%) carried a changed drawing contribution for the moving
+scrollbar; the clip view, document, scroll-view background, and other drawing were
+reused.
+
+The follow-up profile found that the initial 1.483 ms fragment result was not
+fragment traversal overhead. Reading a `ViewRenderEntry` out of a Nim `Table` by
+value deep-copied its cached `RenderList`, including the clean Markdown glyph
+arrays, in capture checks, reconciliation, and update transfer. Reconciliation now
+mutates table entries in place. The same view walk also copied the immutable
+`Appearance` theme snapshot for every view and retained a whole snapshot merely to
+compare generations; the render walk now borrows appearances synchronously and
+caches only `ThemeGeneration`.
+
+A second view-design pass separated bounds-origin movement from self drawing.
+Stable clipped and escaped content transforms now absorb scrolling, and scroll
+invalidation targets the moving scroller rather than the unchanged scroll-view
+background. A focused test verifies that a layout-owned bounds-origin update can
+reach an independent renderer replica with zero view captures, while a descendant
+that reads `DrawContext.visibleRect` is still recaptured.
 
 FigDraw's `renderRoot(RenderFragments)` iterates `levels`, `roots`, and recursive
 `children` cursors directly. Fragment attachment builds its `RenderEntries`
 tracking metadata eagerly, and the child iterator only rebuilds that metadata if
 it is not ready. The renderer does not call `pairs`, clone a `RenderList`, or call
 `materialize`; that separate API remains limited to compatibility and diagnostic
-paths. The benchmark walked 13,200 retained nodes (55 per frame, including five
-placement transforms) in 0.012 ms/frame median. The monolithic comparison walked
-12,000 nodes (50 per frame) in 0.455 ms/frame median, so retained traversal itself
-does not hide a whole-tree construction or introduce a traversal cliff.
+paths. The benchmark walked 15,600 retained nodes (65 per frame, including
+placement and content transforms) in 0.014 ms/frame median. FigDraw's child
+iterator currently copies small `RenderChild` metadata sequences returned by its
+lookup table; the long-running sample identifies that as the main remaining
+traversal micro-cost. It does not copy `Fig` nodes or build a render tree, and at
+0.014 ms here it is not a Merenda-side performance cliff. Avoiding that metadata
+copy is a separate FigDraw optimization.
 
 ## Delivery sequence
 

--- a/TODO-fragments.md
+++ b/TODO-fragments.md
@@ -466,31 +466,39 @@ NimKit reconciliation should therefore use an isolated move for isolated
 changes and the bulk APIs whenever it already knows a complete sibling order.
 
 `tests/benchmark_markdown_scroll.nim` profiles a more realistic dirty-frame
-workload: the repository's 35,919-byte README in a 760 x 540 `MarkdownView`,
+workload: the repository's 36,005-byte README in a 760 x 540 `MarkdownView`,
 scrolled bidirectionally over 240 measured frames after 20 warmup frames. It
 measures CPU-side view drawing/reconciliation, bounded-channel handoff,
-renderer-replica application, and acknowledgement; GPU execution is deliberately
-excluded. The renderer stages are serialized in the diagnostic so its CPU total
-is comparable even though production runs them on separate threads.
+renderer-replica application, acknowledgement, and a direct walk of the
+renderer-facing topology; GPU execution is deliberately excluded. The renderer
+stages are serialized in the diagnostic so its CPU total is comparable even
+though production runs them on separate threads. The table reports the median of
+five complete benchmark runs.
 
 On the same Apple M3 Pro, the pre-PR monolithic path and completed fragment-native
 path measured:
 
-| Pipeline | wall median | wall p95 | CPU median | CPU p95 | prepare median | transfer median | apply/ack median |
-|---|---:|---:|---:|---:|---:|---:|---:|
-| pre-PR monolithic | 11.439 ms | 12.165 ms | 11.437 ms | 12.144 ms | 11.366 ms | 0.001 ms | 0.001 ms |
-| fragment-native | 15.182 ms | 16.573 ms | 15.181 ms | 16.571 ms | 12.414 ms | 2.245 ms | 0.478 ms |
+| Pipeline | wall median | wall p95 | CPU median | CPU p95 | prepare median | transfer median | apply/ack median | traversal median |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| pre-PR monolithic | 11.545 ms | 12.308 ms | 11.544 ms | 12.306 ms | 11.023 ms | 0.000 ms | 0.001 ms | 0.455 ms |
+| fragment-native | 1.483 ms | 1.937 ms | 1.483 ms | 1.935 ms | 1.108 ms | 0.344 ms | 0.006 ms | 0.012 ms |
 
-The median CPU cost is 32.7% higher and p95 is 36.4% higher in this continuously
-dirty scrolling workload. View preparation itself is 9.2% higher; including the
-deep, ARC-isolated transfer clone, total application-thread preparation is 29.0%
-higher.
-Of 1,200 view placements, 714 (59.5%) carried changed contributions; the other
-40.5% reused retained fragments. The result remains in the same order of
-magnitude, and the flat 10,000-view benchmark above confirms linear scaling with
-no population-dependent cliff. The remaining constant-factor cost is primarily
-the independent cross-thread clone of nested text/drawable data plus
-renderer-replica application.
+The retained placement-transform design reduces median CPU cost by 87.2% and
+p95 by 84.3% in this continuously dirty scrolling workload. The Markdown text
+view was captured zero times during the 240 measured frames: scrolling changes
+its ancestor placement, but does not clone or rebuild the document's text nodes.
+Of 1,200 view placements, 476 (39.7%) carried changed contributions for the
+scroll container and its small chrome; all other contributions were reused.
+
+FigDraw's `renderRoot(RenderFragments)` iterates `levels`, `roots`, and recursive
+`children` cursors directly. Fragment attachment builds its `RenderEntries`
+tracking metadata eagerly, and the child iterator only rebuilds that metadata if
+it is not ready. The renderer does not call `pairs`, clone a `RenderList`, or call
+`materialize`; that separate API remains limited to compatibility and diagnostic
+paths. The benchmark walked 13,200 retained nodes (55 per frame, including five
+placement transforms) in 0.012 ms/frame median. The monolithic comparison walked
+12,000 nodes (50 per frame) in 0.455 ms/frame median, so retained traversal itself
+does not hide a whole-tree construction or introduce a traversal cliff.
 
 ## Delivery sequence
 

--- a/src/merenda/nimkit/app/backend.nim
+++ b/src/merenda/nimkit/app/backend.nim
@@ -132,6 +132,7 @@ type
 
   ThreadHostEventKind* = enum
     theRendered
+    theRenderUpdateRejected
     theRenderTargetReleased
 
   ThreadHostEvent* = object
@@ -153,6 +154,16 @@ type
     renders*: Renders
     logicalSize*: Size
     renderId*: uint64
+    targetGeneration*: uint64
+    when not defined(useNativeDynlib):
+      usesFragments*: bool
+      sceneUpdate*: RenderSceneUpdate
+
+  ThreadRenderSnapshotStatus* = enum
+    trssAccepted
+    trssStaleTarget
+    trssStaleRender
+    trssSceneGap
 
   ThreadHostChannels* = object
     events*: ThreadHostEventQueue
@@ -178,6 +189,10 @@ type
   ThreadRenderResourceLease = object
     renderId: uint64
     resources: RenderResourceManifest
+    when not defined(useNativeDynlib):
+      scene: RenderScene
+      sceneIdentity: uint64
+      sceneGeneration: uint64
 
   ThreadHostClient* = ref object
     id*: ThreadHostId
@@ -187,6 +202,10 @@ type
     nextRenderId: uint64
     renderTargetAttached: bool
     renderTargetReleasePending: bool
+    targetGeneration: uint64
+    acknowledgedSceneIdentity: uint64
+    acknowledgedSceneGeneration: uint64
+    forceFullSceneUpdate: bool
     activeResources: RenderResourceManifest
     pendingResources: Deque[ThreadRenderResourceLease]
     rendererWakeups: Chan[bool]
@@ -213,9 +232,15 @@ type
     channels: ThreadHostChannels
     lastRenders: Renders
     lastRenderId: uint64
+    targetGeneration: uint64
     logicalSize: Size
     transparent: bool
     renderCount: Natural
+    when not defined(useNativeDynlib):
+      lastScene: RenderScene
+      lastSceneIdentity: uint64
+      lastSceneGeneration: uint64
+      lastFragmentResources: RenderResourceSnapshot
 
   ThreadRenderer* = ref object
     commands: Chan[ThreadRendererCommand]
@@ -405,6 +430,8 @@ proc newThreadHostClient*(renderer: ThreadRendererClient): ThreadHostClient =
     ),
     rendererWakeups: renderer.wakeups,
     pendingResources: initDeque[ThreadRenderResourceLease](),
+    targetGeneration: 1,
+    forceFullSceneUpdate: true,
   )
   inc renderer.nextHostId
 
@@ -423,12 +450,54 @@ proc submitRenders*(
   )
   host.channels.renders.pushLatest(
     ThreadRenderSnapshot(
-      renders: ensureMove renders, logicalSize: logicalSize, renderId: renderId
+      renders: ensureMove renders,
+      logicalSize: logicalSize,
+      renderId: renderId,
+      targetGeneration: host.targetGeneration,
     )
   )
   host.rendererWakeups.wakeRenderer()
   host.renderRequested = true
   true
+
+when not defined(useNativeDynlib):
+  proc submitRenderScene*(
+      host: ThreadHostClient, scene: RenderScene, logicalSize: Size
+  ): bool {.discardable.} =
+    ## Submits a cumulative, independently owned fragment update.
+    if host.isNil or scene.isNil:
+      return false
+
+    inc host.nextRenderId
+    let
+      renderId = host.nextRenderId
+      sceneIdentity = scene.sceneIdentity()
+      sceneGeneration = scene.frameGeneration()
+    var update = scene.newRenderSceneUpdate(
+      host.acknowledgedSceneIdentity, host.acknowledgedSceneGeneration,
+      host.forceFullSceneUpdate,
+    )
+    host.pendingResources.addLast(
+      ThreadRenderResourceLease(
+        renderId: renderId,
+        resources: scene.renderResources(),
+        scene: scene,
+        sceneIdentity: sceneIdentity,
+        sceneGeneration: sceneGeneration,
+      )
+    )
+    host.channels.renders.pushLatest(
+      ThreadRenderSnapshot(
+        logicalSize: logicalSize,
+        renderId: renderId,
+        targetGeneration: host.targetGeneration,
+        usesFragments: true,
+        sceneUpdate: ensureMove update,
+      )
+    )
+    host.rendererWakeups.wakeRenderer()
+    host.renderRequested = true
+    true
 
 proc acknowledgeRender*(host: ThreadHostClient, renderId: uint64) =
   if host.isNil or renderId == 0:
@@ -437,12 +506,33 @@ proc acknowledgeRender*(host: ThreadHostClient, renderId: uint64) =
       host.pendingResources.peekFirst().renderId <= renderId:
     var lease = host.pendingResources.popFirst()
     host.activeResources = move lease.resources
+    when not defined(useNativeDynlib):
+      if not lease.scene.isNil:
+        lease.scene.acknowledgeRenderGeneration(lease.sceneGeneration)
+        host.acknowledgedSceneIdentity = lease.sceneIdentity
+        host.acknowledgedSceneGeneration = lease.sceneGeneration
+        host.forceFullSceneUpdate = false
+
+proc rejectRenderUpdate*(host: ThreadHostClient, renderId: uint64) =
+  ## Drops rejected leases and forces the next fragment submission to be full.
+  if host.isNil:
+    return
+  while host.pendingResources.len > 0 and
+      host.pendingResources.peekFirst().renderId <= renderId:
+    discard host.pendingResources.popFirst()
+  host.acknowledgedSceneIdentity = 0
+  host.acknowledgedSceneGeneration = 0
+  host.forceFullSceneUpdate = true
+  host.renderRequested = false
 
 proc clearRenderResources*(host: ThreadHostClient) =
   if host.isNil:
     return
   host.activeResources = nil
   host.pendingResources.clear()
+  host.acknowledgedSceneIdentity = 0
+  host.acknowledgedSceneGeneration = 0
+  host.forceFullSceneUpdate = true
 
 proc pollEvent*(host: ThreadHostClient, event: var ThreadHostEvent): bool =
   not host.isNil and host.channels.events.poll(event)
@@ -454,6 +544,21 @@ proc pollLatestRender*(
   while channels.renders.tryRecv(pending):
     snapshot = move pending
     result = true
+
+func status*(
+    snapshot: ThreadRenderSnapshot,
+    targetGeneration, lastRenderId, sceneIdentity, sceneGeneration: uint64,
+): ThreadRenderSnapshotStatus =
+  ## Validates target and scene ordering before a renderer mutates its replica.
+  if snapshot.targetGeneration != targetGeneration:
+    return trssStaleTarget
+  if snapshot.renderId <= lastRenderId:
+    return trssStaleRender
+  when not defined(useNativeDynlib):
+    if snapshot.usesFragments and
+        not snapshot.sceneUpdate.canApply(sceneIdentity, sceneGeneration):
+      return trssSceneGap
+  trssAccepted
 
 type UiScaleOverride* = object
   envName*: string
@@ -1431,6 +1536,7 @@ proc attachThreadRenderer*(
       renderer: move host.xRenderer,
       resources: move host.xResources,
       channels: result.channels,
+      targetGeneration: result.targetGeneration,
       logicalSize: logicalSize,
       transparent: host.xTransparent,
     )
@@ -1446,6 +1552,9 @@ proc detachThreadRenderer*(
     return
   client.renderTargetAttached = false
   client.renderTargetReleasePending = true
+  inc client.targetGeneration
+  if client.targetGeneration == 0:
+    client.targetGeneration = 1
   client.clearRenderResources()
   if not renderer.isNil:
     renderer.sendCommand(
@@ -1798,21 +1907,88 @@ proc acceptPendingRender(state: ThreadRendererHost): bool =
   var snapshot: ThreadRenderSnapshot
   if not state.channels.pollLatestRender(snapshot):
     return
-  state.lastRenders = move snapshot.renders
+  when not defined(useNativeDynlib):
+    let snapshotStatus = snapshot.status(
+      state.targetGeneration, state.lastRenderId, state.lastSceneIdentity,
+      state.lastSceneGeneration,
+    )
+  else:
+    let snapshotStatus =
+      snapshot.status(state.targetGeneration, state.lastRenderId, 0, 0)
+  if snapshotStatus != trssAccepted:
+    state.postEvent(
+      ThreadHostEvent(kind: theRenderUpdateRejected, renderId: snapshot.renderId)
+    )
+    return
+
+  when not defined(useNativeDynlib):
+    if snapshot.usesFragments:
+      var update = move snapshot.sceneUpdate
+      let destination =
+        if update.fullSnapshot():
+          newRenderSceneReplica()
+        else:
+          state.lastScene
+      if destination.isNil:
+        state.postEvent(
+          ThreadHostEvent(kind: theRenderUpdateRejected, renderId: snapshot.renderId)
+        )
+        return
+      try:
+        destination.apply(update)
+      except CatchableError:
+        state.postEvent(
+          ThreadHostEvent(kind: theRenderUpdateRejected, renderId: snapshot.renderId)
+        )
+        return
+      state.lastScene = destination
+      state.lastSceneIdentity = update.sceneIdentity()
+      state.lastSceneGeneration = update.generation()
+      state.lastFragmentResources = update.takeResources()
+      state.lastRenders = nil
+    else:
+      state.lastRenders = move snapshot.renders
+      state.lastScene = nil
+      state.lastSceneIdentity = 0
+      state.lastSceneGeneration = 0
+      state.lastFragmentResources = default(RenderResourceSnapshot)
+  else:
+    state.lastRenders = move snapshot.renders
   state.lastRenderId = snapshot.renderId
   state.logicalSize = snapshot.logicalSize
   true
 
 proc renderLatest(state: ThreadRendererHost) =
-  if state.isNil or state.renderer.isNil or state.lastRenders.isNil:
+  if state.isNil or state.renderer.isNil:
     return
-  state.resources.prepare(state.renderer)
+  when not defined(useNativeDynlib):
+    if state.lastScene.isNil and state.lastRenders.isNil:
+      return
+    if state.lastScene.isNil:
+      state.resources.prepare(state.renderer)
+    else:
+      state.resources.prepare(state.renderer, state.lastFragmentResources)
+  else:
+    if state.lastRenders.isNil:
+      return
+    state.resources.prepare(state.renderer)
   let size = vec2(state.logicalSize.width, state.logicalSize.height)
   state.renderer.beginFrame()
-  if state.transparent:
-    state.renderer.renderFrame(state.lastRenders, size, clearColor = clearColor)
+  when not defined(useNativeDynlib):
+    if not state.lastScene.isNil:
+      if state.transparent:
+        state.lastScene.renderFrame(state.renderer, size, clearFrameColor = clearColor)
+      else:
+        state.lastScene.renderFrame(state.renderer, size)
+    elif state.transparent:
+      state.renderer.renderFrame(state.lastRenders, size, clearColor = clearColor)
+    else:
+      state.renderer.renderFrame(state.lastRenders, size)
   else:
-    state.renderer.renderFrame(state.lastRenders, size)
+    if state.transparent:
+      state.renderer.renderFrame(state.lastRenders, size, clearColor = clearColor)
+    else:
+      state.renderer.renderFrame(state.lastRenders, size)
   state.renderer.endFrame()
   inc state.renderCount
   state.postEvent(

--- a/src/merenda/nimkit/app/backend.nim
+++ b/src/merenda/nimkit/app/backend.nim
@@ -31,6 +31,8 @@ when defined(macosx) and not defined(useNativeDynlib):
 
 import ../drawing/images
 import ../drawing/renderresources
+when not defined(useNativeDynlib):
+  import ../drawing/renderscenes
 import ../foundation/types
 import ../foundation/events
 import ./pasteboards
@@ -1379,6 +1381,22 @@ proc render*(host: HostWindow, renders: var Renders, logicalSize: Size) =
     host.xRenderer.renderFrame(renders, size)
   host.xRenderer.endFrame()
   inc host.xRenderCount
+
+when not defined(useNativeDynlib):
+  proc render*(host: HostWindow, scene: RenderScene, logicalSize: Size) =
+    if not host.isReady or host.xRenderer.isNil or not host.xNativeWindow.opened():
+      return
+    host.xRenderRequested = false
+    host.refreshContentScale()
+    host.xResources.prepare(host.xRenderer, scene.renderResources())
+    let size = vec2(logicalSize.width, logicalSize.height)
+    host.xRenderer.beginFrame()
+    if host.xTransparent:
+      scene.renderFrame(host.xRenderer, size, clearFrameColor = clearColor)
+    else:
+      scene.renderFrame(host.xRenderer, size)
+    host.xRenderer.endFrame()
+    inc host.xRenderCount
 
 proc dedicatedRendererSupported*(): bool =
   when not defined(useNativeDynlib):

--- a/src/merenda/nimkit/app/windows.nim
+++ b/src/merenda/nimkit/app/windows.nim
@@ -2197,20 +2197,19 @@ proc renderNativeWindow*(window: Window) =
       renderScene.acknowledgeRenderGeneration(renderScene.frameGeneration())
       if needsFollowUpRender:
         window.requestNativeDisplayUpdate()
-      return
-  var renders = window.buildRenders()
-  let needsFollowUpRender = window.needsDisplayUpdate()
-  if not window.xThreadHost.isNil:
-    var resources = nimkitRendering.renderResources(window.xContentView)
-    window.xContentView.invalidateRenderCache()
-    discard window.xThreadHost.submitRenders(
-      ensureMove renders, logicalSize, ensureMove resources
-    )
-    window.xHostWindow.renderSubmitted()
+    else:
+      let renderScene = window.buildRenderScene()
+      let needsFollowUpRender = window.needsDisplayUpdate()
+      discard window.xThreadHost.submitRenderScene(renderScene, logicalSize)
+      window.xHostWindow.renderSubmitted()
+      if needsFollowUpRender:
+        window.requestNativeDisplayUpdate()
   else:
+    var renders = window.buildRenders()
+    let needsFollowUpRender = window.needsDisplayUpdate()
     window.xHostWindow.render(renders, logicalSize)
-  if needsFollowUpRender:
-    window.requestNativeDisplayUpdate()
+    if needsFollowUpRender:
+      window.requestNativeDisplayUpdate()
 
 proc contentPoint(window: Window, windowPoint: Point): Point =
   window.xContentView.pointFromWindow(windowPoint)
@@ -2886,6 +2885,9 @@ proc drainThreadHostEvents(window: Window): int =
       window.xThreadHost.acknowledgeRender(event.renderId)
       window.xThreadHost.renderCount = event.renderCount
       window.xThreadHost.renderRequested = false
+    of theRenderUpdateRejected:
+      window.xThreadHost.rejectRenderUpdate(event.renderId)
+      window.requestNativeDisplayUpdate()
     of theRenderTargetReleased:
       window.xThreadHost.clearRenderResources()
       window.xThreadHost.acknowledgeRenderTargetRelease()

--- a/src/merenda/nimkit/app/windows.nim
+++ b/src/merenda/nimkit/app/windows.nim
@@ -2189,6 +2189,10 @@ proc renderNativeWindow*(window: Window) =
 
   window.xHostWindow.refreshContentScale()
   let logicalSize = window.syncNativeGeometry()
+  when not defined(useNativeDynlib):
+    var renderScene: RenderScene
+    if window.xThreadHost.isNil:
+      renderScene = window.buildRenderScene()
   var renders = window.buildRenders()
   let needsFollowUpRender = window.needsDisplayUpdate()
   if not window.xThreadHost.isNil:
@@ -2200,6 +2204,8 @@ proc renderNativeWindow*(window: Window) =
     window.xHostWindow.renderSubmitted()
   else:
     window.xHostWindow.render(renders, logicalSize)
+    when not defined(useNativeDynlib):
+      renderScene.acknowledgeRenderGeneration(renderScene.frameGeneration())
   if needsFollowUpRender:
     window.requestNativeDisplayUpdate()
 

--- a/src/merenda/nimkit/app/windows.nim
+++ b/src/merenda/nimkit/app/windows.nim
@@ -2190,9 +2190,14 @@ proc renderNativeWindow*(window: Window) =
   window.xHostWindow.refreshContentScale()
   let logicalSize = window.syncNativeGeometry()
   when not defined(useNativeDynlib):
-    var renderScene: RenderScene
     if window.xThreadHost.isNil:
-      renderScene = window.buildRenderScene()
+      let renderScene = window.buildRenderScene()
+      let needsFollowUpRender = window.needsDisplayUpdate()
+      window.xHostWindow.render(renderScene, logicalSize)
+      renderScene.acknowledgeRenderGeneration(renderScene.frameGeneration())
+      if needsFollowUpRender:
+        window.requestNativeDisplayUpdate()
+      return
   var renders = window.buildRenders()
   let needsFollowUpRender = window.needsDisplayUpdate()
   if not window.xThreadHost.isNil:
@@ -2204,8 +2209,6 @@ proc renderNativeWindow*(window: Window) =
     window.xHostWindow.renderSubmitted()
   else:
     window.xHostWindow.render(renders, logicalSize)
-    when not defined(useNativeDynlib):
-      renderScene.acknowledgeRenderGeneration(renderScene.frameGeneration())
   if needsFollowUpRender:
     window.requestNativeDisplayUpdate()
 

--- a/src/merenda/nimkit/containers/scrollviews.nim
+++ b/src/merenda/nimkit/containers/scrollviews.nim
@@ -590,7 +590,9 @@ proc reflectScrolledClipView*(scrollView: ScrollView, clipView: ClipView) =
   if clipView.isNil or clipView != scrollView.xClipView:
     return
   scrollView.tile()
-  scrollView.needsDisplay = true
+  for scroller in scrollView.xScroller:
+    if not scroller.isNil and not scroller.isHidden():
+      scroller.needsDisplay = true
 
 proc hasScroller*(scrollView: ScrollView, axis: LayoutAxis): bool =
   scrollView.xHasScroller[axis]

--- a/src/merenda/nimkit/drawing.nim
+++ b/src/merenda/nimkit/drawing.nim
@@ -9,9 +9,12 @@ import ./drawing/chrome
 import ./drawing/chromes/aquachrome
 import ./drawing/chromes/flattransparentchrome
 
-export drawing, rendering, images, svgimages, renderresources
+export drawing, rendering, images, svgimages
+export renderresources except RenderResourceSnapshot, snapshot
 when not defined(useNativeDynlib):
   export renderscenes except
     RenderLayerContribution, RenderViewCacheKey, RenderViewFrame, needsViewCapture,
-    reconcile, renderFrame, renderRoot
+    RenderSceneUpdate, apply, baseGeneration, canApply, capturedViewCount, generation,
+    fullSnapshot, newRenderSceneReplica, newRenderSceneUpdate, reconcile, renderFrame,
+    renderRoot, sceneIdentity, takeResources, viewCount
 export chrome, aquachrome, flattransparentchrome

--- a/src/merenda/nimkit/drawing.nim
+++ b/src/merenda/nimkit/drawing.nim
@@ -13,5 +13,5 @@ export drawing, rendering, images, svgimages, renderresources
 when not defined(useNativeDynlib):
   export renderscenes except
     RenderLayerContribution, RenderViewCacheKey, RenderViewFrame, needsViewCapture,
-    reconcile
+    reconcile, renderFrame, renderRoot
 export chrome, aquachrome, flattransparentchrome

--- a/src/merenda/nimkit/drawing.nim
+++ b/src/merenda/nimkit/drawing.nim
@@ -9,12 +9,14 @@ import ./drawing/chrome
 import ./drawing/chromes/aquachrome
 import ./drawing/chromes/flattransparentchrome
 
-export drawing, rendering, images, svgimages
+export drawing except drawingDependsOnVisibleRect
+export rendering, images, svgimages
 export renderresources except RenderResourceSnapshot, snapshot
 when not defined(useNativeDynlib):
   export renderscenes except
     RenderLayerContribution, RenderViewCacheKey, RenderViewFrame, needsViewCapture,
-    RenderSceneUpdate, apply, baseGeneration, canApply, capturedViewCount, generation,
-    fullSnapshot, newRenderSceneReplica, newRenderSceneUpdate, reconcile, renderFrame,
-    renderRoot, sceneIdentity, takeResources, viewCount
+    needsViewPlacementUpdate, RenderSceneUpdate, apply, baseGeneration, canApply,
+    capturedViewCount, generation, fullSnapshot, newRenderSceneReplica,
+    newRenderSceneUpdate, reconcile, renderFrame, renderRoot, sceneIdentity,
+    takeResources, traversalNodeCount, viewCount
 export chrome, aquachrome, flattransparentchrome

--- a/src/merenda/nimkit/drawing.nim
+++ b/src/merenda/nimkit/drawing.nim
@@ -11,5 +11,7 @@ import ./drawing/chromes/flattransparentchrome
 
 export drawing, rendering, images, svgimages, renderresources
 when not defined(useNativeDynlib):
-  export renderscenes
+  export renderscenes except
+    RenderLayerContribution, RenderViewCacheKey, RenderViewFrame, needsViewCapture,
+    reconcile
 export chrome, aquachrome, flattransparentchrome

--- a/src/merenda/nimkit/drawing/drawing.nim
+++ b/src/merenda/nimkit/drawing/drawing.nim
@@ -88,6 +88,7 @@ type DrawContext* = ref object
   xRenderOrigin: nimkitTypes.Point
   xBounds: nimkitTypes.Rect
   xVisibleRect: nimkitTypes.Rect
+  xUsesVisibleRect: bool
   xAppearance: Appearance
   xResources: RenderResourceManifest
 
@@ -661,6 +662,7 @@ proc beginDraw*(
   context.xRenderOrigin = renderOrigin
   context.xBounds = bounds
   context.xVisibleRect = visibleRect
+  context.xUsesVisibleRect = false
   context.xAppearance = appearance
 
 proc renderList*(context: DrawContext): RenderList =
@@ -703,7 +705,12 @@ proc bounds*(context: DrawContext): nimkitTypes.Rect =
   context.xBounds
 
 proc visibleRect*(context: DrawContext): nimkitTypes.Rect =
+  context.xUsesVisibleRect = true
   context.xVisibleRect
+
+proc drawingDependsOnVisibleRect*(context: DrawContext): bool =
+  ## Reports whether the current drawing read its dynamically clipped bounds.
+  not context.isNil and context.xUsesVisibleRect
 
 proc addFig*(
     context: DrawContext, layer: ZLevel, parent: FigIdx, node: Fig

--- a/src/merenda/nimkit/drawing/rendering.nim
+++ b/src/merenda/nimkit/drawing/rendering.nim
@@ -196,6 +196,21 @@ when not defined(useNativeDynlib):
     for child in source.nodes.childIndex(sourceRoot):
       source.appendSubtree(child, destination, destinationRoot)
 
+  proc placementNode(cacheKey: RenderViewCacheKey, absolute = false): Fig =
+    let origin = if absolute: cacheKey.frame.origin else: cacheKey.placement
+    Fig(
+      kind: nkTransform,
+      screenBox: figdraw.rect(
+        0.0'f32, 0.0'f32, cacheKey.frame.size.width, cacheKey.frame.size.height
+      ),
+      transform: TransformStyle(translation: vec2(origin.x, origin.y)),
+    )
+
+  proc wrapInPlacement(source: RenderList, placement: Fig): RenderList =
+    let root = result.addRoot(placement)
+    for sourceRoot in source.rootIds:
+      source.appendSubtree(sourceRoot, result, root)
+
   proc takeOnlyRootChildren(
       source: var RenderList,
       sourceRoot: FigIdx,
@@ -225,10 +240,12 @@ when not defined(useNativeDynlib):
       appearance: Appearance,
   ): RenderViewFrame =
     let context = initDrawContext()
+    let localFrame =
+      rect(0.0'f32, 0.0'f32, cacheKey.frame.size.width, cacheKey.frame.size.height)
     let rootIdx = context.addRenderRectangle(
       cacheKey.level,
       (-1).FigIdx,
-      cacheKey.frame,
+      localFrame,
       view.viewBackgroundFill(appearance, cacheKey.isRoot),
       shadows = view.shadow,
       clips = view.clipsToBounds,
@@ -236,11 +253,10 @@ when not defined(useNativeDynlib):
 
     if view.usesThemedRootBackground(cacheKey.isRoot):
       context.addRootBackgroundPinstripes(
-        view, cacheKey.level, rootIdx, cacheKey.frame, appearance
+        view, cacheKey.level, rootIdx, localFrame, appearance
       )
 
-    let contentOrigin =
-      cacheKey.frame.origin.addPoints(view.bounds().boundsTranslation())
+    let contentOrigin = view.bounds().boundsTranslation()
     context.beginDraw(
       view, cacheKey.level, rootIdx, (-1).FigIdx, contentOrigin, appearance
     )
@@ -250,8 +266,11 @@ when not defined(useNativeDynlib):
       viewId: viewId,
       parentViewId: parentViewId,
       cacheKey: cacheKey,
+      placementChanged: true,
       captured: true,
+      placement: cacheKey.placementNode(),
       resources: context.resources,
+      usesVisibleRect: context.drawingDependsOnVisibleRect(),
     )
     var ownLayer = move context.renders.layers[cacheKey.level]
     if rootIdx.int == 0 and ownLayer.rootIds == @[rootIdx]:
@@ -267,7 +286,10 @@ when not defined(useNativeDynlib):
           ownLayer.appendSubtree(escapedRoot, result.escapedContents)
     for level, list in context.renders.pairs():
       if level != cacheKey.level and list.nodes.len > 0:
-        result.extraLayers.add RenderLayerContribution(level: level, contents: list)
+        result.extraLayers.add RenderLayerContribution(
+          level: level,
+          contents: list.wrapInPlacement(cacheKey.placementNode(absolute = true)),
+        )
 
   proc collectRenderFrames(
       scene: RenderScene,
@@ -278,6 +300,7 @@ when not defined(useNativeDynlib):
       parentViewId = 0.RenderViewId,
       parentLevel = DefaultDrawLevel,
       parentOrigin = ZeroPoint,
+      parentBoundsOrigin = ZeroPoint,
   ) =
     if view.visibleRect.isEmpty:
       view.finishDisplaySubtree()
@@ -288,21 +311,30 @@ when not defined(useNativeDynlib):
       level = view.trySendLocal(drawLevel()).get(parentLevel)
       viewId = view.renderViewId()
       absoluteFrame = view.renderFrameRect(parentOrigin)
+      viewFrame = view.frame()
       cacheKey = RenderViewCacheKey(
         displayRevision: view.xDisplayRevision,
         appearanceGeneration: uint64(appearance.theme.generation()),
         frame: absoluteFrame,
+        placement: initPoint(
+          viewFrame.origin.x - parentBoundsOrigin.x,
+          viewFrame.origin.y - parentBoundsOrigin.y,
+        ),
         bounds: view.bounds(),
         visibleRect: view.visibleRect(),
         level: level,
         isRoot: parentViewId.uint64 == 0,
       )
 
-    if scene.needsViewCapture(viewId, cacheKey):
+    let capture = scene.needsViewCapture(viewId, cacheKey)
+    if capture:
       frames.add view.captureViewFrame(viewId, parentViewId, cacheKey, appearance)
     else:
       frames.add RenderViewFrame(
-        viewId: viewId, parentViewId: parentViewId, cacheKey: cacheKey
+        viewId: viewId,
+        parentViewId: parentViewId,
+        cacheKey: cacheKey,
+        placementChanged: scene.needsViewPlacementUpdate(viewId, cacheKey),
       )
     revisions.add DisplayRevisionSnapshot(
       view: view, revision: cacheKey.displayRevision
@@ -312,7 +344,14 @@ when not defined(useNativeDynlib):
       absoluteFrame.origin.addPoints(view.bounds().boundsTranslation())
     for child in view.subviews:
       scene.collectRenderFrames(
-        child, appearance, frames, revisions, viewId, level, contentOrigin
+        child,
+        appearance,
+        frames,
+        revisions,
+        viewId,
+        level,
+        contentOrigin,
+        view.bounds().origin,
       )
 
   proc updateRenderScene(root: View, appearance: Appearance): RenderScene =
@@ -356,25 +395,25 @@ proc invalidateRenderCache*(root: View) =
 
 proc buildRenders*(root: View, appearance: Appearance): Renders =
   when not defined(useNativeDynlib):
-    if not root.xCachedRenderScene.isNil:
-      let scene = root.updateRenderScene(appearance)
-      if not root.xHasCachedRenders:
-        root.xCachedRenders = scene.materialize()
-        root.xHasCachedRenders = true
+    let scene = root.updateRenderScene(appearance)
+    if not root.xHasCachedRenders:
+      root.xCachedRenders = scene.materialize()
+      root.xHasCachedRenders = true
+    scene.acknowledgeRenderGeneration(scene.frameGeneration())
+    result = root.xCachedRenders
+  else:
+    discard root.prepareDisplaySubtree()
+    if root.cacheCanReuse(appearance):
       return root.xCachedRenders
 
-  discard root.prepareDisplaySubtree()
-  if root.cacheCanReuse(appearance):
-    return root.xCachedRenders
-
-  let context = initDrawContext()
-  renderViewInto(context, root, appearance)
-  result = context.renders
-  root.xCachedRenders = result
-  root.xCachedRenderResources = context.resources
-  root.xCachedAppearance = appearance
-  root.xHasCachedRenders = true
-  root.finishDisplaySubtree()
+    let context = initDrawContext()
+    renderViewInto(context, root, appearance)
+    result = context.renders
+    root.xCachedRenders = result
+    root.xCachedRenderResources = context.resources
+    root.xCachedAppearance = appearance
+    root.xHasCachedRenders = true
+    root.finishDisplaySubtree()
 
 proc buildRenders*(root: View, theme: Theme): Renders =
   buildRenders(root, initAppearance(theme))

--- a/src/merenda/nimkit/drawing/rendering.nim
+++ b/src/merenda/nimkit/drawing/rendering.nim
@@ -196,6 +196,27 @@ when not defined(useNativeDynlib):
     for child in source.nodes.childIndex(sourceRoot):
       source.appendSubtree(child, destination, destinationRoot)
 
+  proc takeOnlyRootChildren(
+      source: var RenderList,
+      sourceRoot: FigIdx,
+      shell: var Fig,
+      contents: var RenderList,
+  ) =
+    ## Splits the common single-root capture without copying every `Fig`.
+    ## `captureViewFrame` creates the shell first, so its index is zero.
+    shell = source.nodes[sourceRoot.int]
+    shell.parent = (-1).FigIdx
+    shell.childCount = 0
+    contents.nodes = move source.nodes
+    for index in 1 ..< contents.nodes.len:
+      if contents.nodes[index].parent == sourceRoot:
+        contents.nodes[index].parent = (-1).FigIdx
+        contents.rootIds.add (index - 1).FigIdx
+      else:
+        contents.nodes[index].parent = (contents.nodes[index].parent.int - 1).FigIdx
+    contents.nodes.delete(0)
+    source.rootIds.setLen(0)
+
   proc captureViewFrame(
       view: View,
       viewId: RenderViewId,
@@ -232,15 +253,18 @@ when not defined(useNativeDynlib):
       captured: true,
       resources: context.resources,
     )
-    let ownLayer = context.renders.layers[cacheKey.level]
-    result.shell = ownLayer.nodes[rootIdx.int]
-    result.shell.parent = (-1).FigIdx
-    result.shell.childCount = 0
-    for child in ownLayer.nodes.childIndex(rootIdx):
-      ownLayer.appendSubtree(child, result.selfContents)
-    for escapedRoot in ownLayer.rootIds:
-      if escapedRoot != rootIdx:
-        ownLayer.appendSubtree(escapedRoot, result.escapedContents)
+    var ownLayer = move context.renders.layers[cacheKey.level]
+    if rootIdx.int == 0 and ownLayer.rootIds == @[rootIdx]:
+      ownLayer.takeOnlyRootChildren(rootIdx, result.shell, result.selfContents)
+    else:
+      result.shell = ownLayer.nodes[rootIdx.int]
+      result.shell.parent = (-1).FigIdx
+      result.shell.childCount = 0
+      for child in ownLayer.nodes.childIndex(rootIdx):
+        ownLayer.appendSubtree(child, result.selfContents)
+      for escapedRoot in ownLayer.rootIds:
+        if escapedRoot != rootIdx:
+          ownLayer.appendSubtree(escapedRoot, result.escapedContents)
     for level, list in context.renders.pairs():
       if level != cacheKey.level and list.nodes.len > 0:
         result.extraLayers.add RenderLayerContribution(level: level, contents: list)

--- a/src/merenda/nimkit/drawing/rendering.nim
+++ b/src/merenda/nimkit/drawing/rendering.nim
@@ -180,6 +180,14 @@ when not defined(useNativeDynlib):
     view: View
     revision: uint64
 
+  proc renderAppearance(view: View, inherited: ptr Appearance): ptr Appearance =
+    ## Keeps immutable theme snapshots borrowed during a synchronous scene walk.
+    if view.xHasAppearance:
+      return addr view.xAppearance
+    if view.xHasInheritedAppearance and view.superviewBacklink().isNil:
+      return addr view.xInheritedAppearance
+    inherited
+
   proc appendSubtree(
       source: RenderList,
       sourceRoot: FigIdx,
@@ -196,14 +204,23 @@ when not defined(useNativeDynlib):
     for child in source.nodes.childIndex(sourceRoot):
       source.appendSubtree(child, destination, destinationRoot)
 
-  proc placementNode(cacheKey: RenderViewCacheKey, absolute = false): Fig =
-    let origin = if absolute: cacheKey.frame.origin else: cacheKey.placement
+  proc transformNode(origin: Point, size: Size): Fig =
     Fig(
       kind: nkTransform,
-      screenBox: figdraw.rect(
-        0.0'f32, 0.0'f32, cacheKey.frame.size.width, cacheKey.frame.size.height
-      ),
+      screenBox: figdraw.rect(0.0'f32, 0.0'f32, size.width, size.height),
       transform: TransformStyle(translation: vec2(origin.x, origin.y)),
+    )
+
+  proc placementNode(cacheKey: RenderViewCacheKey): Fig =
+    transformNode(cacheKey.placement, cacheKey.frame.size)
+
+  proc contentTransformNode(cacheKey: RenderViewCacheKey): Fig =
+    transformNode(cacheKey.bounds.boundsTranslation(), cacheKey.frame.size)
+
+  proc layerTransformNode(cacheKey: RenderViewCacheKey): Fig =
+    transformNode(
+      cacheKey.frame.origin.addPoints(cacheKey.bounds.boundsTranslation()),
+      cacheKey.frame.size,
     )
 
   proc wrapInPlacement(source: RenderList, placement: Fig): RenderList =
@@ -237,7 +254,7 @@ when not defined(useNativeDynlib):
       viewId: RenderViewId,
       parentViewId: RenderViewId,
       cacheKey: RenderViewCacheKey,
-      appearance: Appearance,
+      appearance: ptr Appearance,
   ): RenderViewFrame =
     let context = initDrawContext()
     let localFrame =
@@ -246,19 +263,18 @@ when not defined(useNativeDynlib):
       cacheKey.level,
       (-1).FigIdx,
       localFrame,
-      view.viewBackgroundFill(appearance, cacheKey.isRoot),
+      view.viewBackgroundFill(appearance[], cacheKey.isRoot),
       shadows = view.shadow,
       clips = view.clipsToBounds,
     )
 
     if view.usesThemedRootBackground(cacheKey.isRoot):
       context.addRootBackgroundPinstripes(
-        view, cacheKey.level, rootIdx, localFrame, appearance
+        view, cacheKey.level, rootIdx, localFrame, appearance[]
       )
 
-    let contentOrigin = view.bounds().boundsTranslation()
     context.beginDraw(
-      view, cacheKey.level, rootIdx, (-1).FigIdx, contentOrigin, appearance
+      view, cacheKey.level, rootIdx, (-1).FigIdx, ZeroPoint, appearance[]
     )
     discard view.sendLocalIfHandled(draw(), context)
 
@@ -269,6 +285,8 @@ when not defined(useNativeDynlib):
       placementChanged: true,
       captured: true,
       placement: cacheKey.placementNode(),
+      contentTransform: cacheKey.contentTransformNode(),
+      escapedTransform: cacheKey.contentTransformNode(),
       resources: context.resources,
       usesVisibleRect: context.drawingDependsOnVisibleRect(),
     )
@@ -287,39 +305,38 @@ when not defined(useNativeDynlib):
     for level, list in context.renders.pairs():
       if level != cacheKey.level and list.nodes.len > 0:
         result.extraLayers.add RenderLayerContribution(
-          level: level,
-          contents: list.wrapInPlacement(cacheKey.placementNode(absolute = true)),
+          level: level, contents: list.wrapInPlacement(cacheKey.layerTransformNode())
         )
 
   proc collectRenderFrames(
       scene: RenderScene,
       view: View,
-      inheritedAppearance: Appearance,
+      inheritedAppearance: ptr Appearance,
       frames: var seq[RenderViewFrame],
       revisions: var seq[DisplayRevisionSnapshot],
       parentViewId = 0.RenderViewId,
       parentLevel = DefaultDrawLevel,
       parentOrigin = ZeroPoint,
-      parentBoundsOrigin = ZeroPoint,
   ) =
     if view.visibleRect.isEmpty:
       view.finishDisplaySubtree()
       return
 
     let
-      appearance = view.resolvedAppearance(inheritedAppearance)
+      appearance = view.renderAppearance(inheritedAppearance)
       level = view.trySendLocal(drawLevel()).get(parentLevel)
       viewId = view.renderViewId()
       absoluteFrame = view.renderFrameRect(parentOrigin)
       viewFrame = view.frame()
       cacheKey = RenderViewCacheKey(
         displayRevision: view.xDisplayRevision,
-        appearanceGeneration: uint64(appearance.theme.generation()),
+        appearanceGeneration: uint64(appearance[].theme.generation()),
         frame: absoluteFrame,
-        placement: initPoint(
-          viewFrame.origin.x - parentBoundsOrigin.x,
-          viewFrame.origin.y - parentBoundsOrigin.y,
-        ),
+        placement:
+          if parentViewId.uint64 == 0 or level != parentLevel:
+            absoluteFrame.origin
+          else:
+            viewFrame.origin,
         bounds: view.bounds(),
         visibleRect: view.visibleRect(),
         level: level,
@@ -344,21 +361,14 @@ when not defined(useNativeDynlib):
       absoluteFrame.origin.addPoints(view.bounds().boundsTranslation())
     for child in view.subviews:
       scene.collectRenderFrames(
-        child,
-        appearance,
-        frames,
-        revisions,
-        viewId,
-        level,
-        contentOrigin,
-        view.bounds().origin,
+        child, appearance, frames, revisions, viewId, level, contentOrigin
       )
 
   proc updateRenderScene(root: View, appearance: Appearance): RenderScene =
     root.layoutSubtreeIfNeeded()
     if not root.xCachedRenderScene.isNil and
         root.xCachedRenderScene.frameGeneration() > 0 and not root.xNeedsDisplay and
-        root.xCachedAppearance.sameAppearanceGeneration(appearance):
+        root.xCachedAppearanceGeneration == appearance.theme.generation():
       return root.xCachedRenderScene
     if root.xCachedRenderScene.isNil:
       root.xCachedRenderScene = newRenderScene()
@@ -366,7 +376,9 @@ when not defined(useNativeDynlib):
     var
       frames: seq[RenderViewFrame]
       revisions: seq[DisplayRevisionSnapshot]
-    root.xCachedRenderScene.collectRenderFrames(root, appearance, frames, revisions)
+    root.xCachedRenderScene.collectRenderFrames(
+      root, unsafeAddr appearance, frames, revisions
+    )
     let changed = root.xCachedRenderScene.reconcile(frames, DefaultDrawLevel)
     for snapshot in revisions:
       snapshot.view.acknowledgeDisplayRevision(snapshot.revision)
@@ -376,13 +388,13 @@ when not defined(useNativeDynlib):
       root.xCachedRenders = nil
       root.xHasCachedRenders = false
     root.xCachedRenderResources = root.xCachedRenderScene.renderResources()
-    root.xCachedAppearance = appearance
+    root.xCachedAppearanceGeneration = appearance.theme.generation()
     root.xCachedRenderScene
 
 proc cacheCanReuse(root: View, appearance: Appearance): bool =
   result =
     root.xHasCachedRenders and not root.needsDisplayInSubtree() and
-    root.xCachedAppearance.sameAppearanceGeneration(appearance)
+    root.xCachedAppearanceGeneration == appearance.theme.generation()
 
 proc invalidateRenderCache*(root: View) =
   if root.isNil:
@@ -411,7 +423,7 @@ proc buildRenders*(root: View, appearance: Appearance): Renders =
     result = context.renders
     root.xCachedRenders = result
     root.xCachedRenderResources = context.resources
-    root.xCachedAppearance = appearance
+    root.xCachedAppearanceGeneration = appearance.theme.generation()
     root.xHasCachedRenders = true
     root.finishDisplaySubtree()
 

--- a/src/merenda/nimkit/drawing/rendering.nim
+++ b/src/merenda/nimkit/drawing/rendering.nim
@@ -293,8 +293,8 @@ when not defined(useNativeDynlib):
 
   proc updateRenderScene(root: View, appearance: Appearance): RenderScene =
     root.layoutSubtreeIfNeeded()
-    if not root.xCachedRenderScene.isNil and root.xHasCachedRenders and
-        not root.xNeedsDisplay and
+    if not root.xCachedRenderScene.isNil and
+        root.xCachedRenderScene.frameGeneration() > 0 and not root.xNeedsDisplay and
         root.xCachedAppearance.sameAppearanceGeneration(appearance):
       return root.xCachedRenderScene
     if root.xCachedRenderScene.isNil:
@@ -309,11 +309,11 @@ when not defined(useNativeDynlib):
       snapshot.view.acknowledgeDisplayRevision(snapshot.revision)
     root.refreshDisplayStateSubtree()
 
-    if changed or not root.xHasCachedRenders:
-      root.xCachedRenders = root.xCachedRenderScene.materialize()
+    if changed:
+      root.xCachedRenders = nil
+      root.xHasCachedRenders = false
     root.xCachedRenderResources = root.xCachedRenderScene.renderResources()
     root.xCachedAppearance = appearance
-    root.xHasCachedRenders = true
     root.xCachedRenderScene
 
 proc cacheCanReuse(root: View, appearance: Appearance): bool =
@@ -333,7 +333,10 @@ proc invalidateRenderCache*(root: View) =
 proc buildRenders*(root: View, appearance: Appearance): Renders =
   when not defined(useNativeDynlib):
     if not root.xCachedRenderScene.isNil:
-      discard root.updateRenderScene(appearance)
+      let scene = root.updateRenderScene(appearance)
+      if not root.xHasCachedRenders:
+        root.xCachedRenders = scene.materialize()
+        root.xHasCachedRenders = true
       return root.xCachedRenders
 
   discard root.prepareDisplaySubtree()

--- a/src/merenda/nimkit/drawing/rendering.nim
+++ b/src/merenda/nimkit/drawing/rendering.nim
@@ -1,5 +1,4 @@
 import std/options
-import std/tables
 
 when defined(useNativeDynlib):
   import figdraw/dynlib
@@ -20,11 +19,6 @@ type RenderPlacement = object
   rootRect: types.Rect
   contentOrigin: types.Point
   contentParent: FigIdx
-
-when defined(useNativeDynlib):
-  type SeenRenderViews = object
-else:
-  type SeenRenderViews = seq[RenderViewId]
 
 proc addPoints(a, b: types.Point): types.Point =
   initPoint(a.x + b.x, a.y + b.y)
@@ -136,13 +130,9 @@ proc renderViewInto(
     parent = (-1).FigIdx,
     parentLevel = DefaultDrawLevel,
     parentOrigin = ZeroPoint,
-    seenViews: var SeenRenderViews,
 ) =
   if view.visibleRect.isEmpty:
     return
-
-  when not defined(useNativeDynlib):
-    seenViews.add view.renderViewId()
 
   let
     appearance = view.resolvedAppearance(inheritedAppearance)
@@ -182,12 +172,149 @@ proc renderViewInto(
   for child in view.subviews:
     renderViewInto(
       context, child, appearance, placement.contentParent, level,
-      placement.contentOrigin, seenViews,
+      placement.contentOrigin,
     )
 
-proc emptyRenders(): Renders =
-  result = Renders(layers: initOrderedTable[ZLevel, RenderList]())
-  result.layers[DefaultDrawLevel] = RenderList()
+when not defined(useNativeDynlib):
+  type DisplayRevisionSnapshot = object
+    view: View
+    revision: uint64
+
+  proc appendSubtree(
+      source: RenderList,
+      sourceRoot: FigIdx,
+      destination: var RenderList,
+      parent = (-1).FigIdx,
+  ) =
+    var node = source.nodes[sourceRoot.int]
+    node.childCount = 0
+    let destinationRoot =
+      if parent.int < 0:
+        destination.addRoot(node)
+      else:
+        destination.addChild(parent, node)
+    for child in source.nodes.childIndex(sourceRoot):
+      source.appendSubtree(child, destination, destinationRoot)
+
+  proc captureViewFrame(
+      view: View,
+      viewId: RenderViewId,
+      parentViewId: RenderViewId,
+      cacheKey: RenderViewCacheKey,
+      appearance: Appearance,
+  ): RenderViewFrame =
+    let context = initDrawContext()
+    let rootIdx = context.addRenderRectangle(
+      cacheKey.level,
+      (-1).FigIdx,
+      cacheKey.frame,
+      view.viewBackgroundFill(appearance, cacheKey.isRoot),
+      shadows = view.shadow,
+      clips = view.clipsToBounds,
+    )
+
+    if view.usesThemedRootBackground(cacheKey.isRoot):
+      context.addRootBackgroundPinstripes(
+        view, cacheKey.level, rootIdx, cacheKey.frame, appearance
+      )
+
+    let contentOrigin =
+      cacheKey.frame.origin.addPoints(view.bounds().boundsTranslation())
+    context.beginDraw(
+      view, cacheKey.level, rootIdx, (-1).FigIdx, contentOrigin, appearance
+    )
+    discard view.sendLocalIfHandled(draw(), context)
+
+    result = RenderViewFrame(
+      viewId: viewId,
+      parentViewId: parentViewId,
+      cacheKey: cacheKey,
+      captured: true,
+      resources: context.resources,
+    )
+    let ownLayer = context.renders.layers[cacheKey.level]
+    result.shell = ownLayer.nodes[rootIdx.int]
+    result.shell.parent = (-1).FigIdx
+    result.shell.childCount = 0
+    for child in ownLayer.nodes.childIndex(rootIdx):
+      ownLayer.appendSubtree(child, result.selfContents)
+    for escapedRoot in ownLayer.rootIds:
+      if escapedRoot != rootIdx:
+        ownLayer.appendSubtree(escapedRoot, result.escapedContents)
+    for level, list in context.renders.pairs():
+      if level != cacheKey.level and list.nodes.len > 0:
+        result.extraLayers.add RenderLayerContribution(level: level, contents: list)
+
+  proc collectRenderFrames(
+      scene: RenderScene,
+      view: View,
+      inheritedAppearance: Appearance,
+      frames: var seq[RenderViewFrame],
+      revisions: var seq[DisplayRevisionSnapshot],
+      parentViewId = 0.RenderViewId,
+      parentLevel = DefaultDrawLevel,
+      parentOrigin = ZeroPoint,
+  ) =
+    if view.visibleRect.isEmpty:
+      view.finishDisplaySubtree()
+      return
+
+    let
+      appearance = view.resolvedAppearance(inheritedAppearance)
+      level = view.trySendLocal(drawLevel()).get(parentLevel)
+      viewId = view.renderViewId()
+      absoluteFrame = view.renderFrameRect(parentOrigin)
+      cacheKey = RenderViewCacheKey(
+        displayRevision: view.xDisplayRevision,
+        appearanceGeneration: uint64(appearance.theme.generation()),
+        frame: absoluteFrame,
+        bounds: view.bounds(),
+        visibleRect: view.visibleRect(),
+        level: level,
+        isRoot: parentViewId.uint64 == 0,
+      )
+
+    if scene.needsViewCapture(viewId, cacheKey):
+      frames.add view.captureViewFrame(viewId, parentViewId, cacheKey, appearance)
+    else:
+      frames.add RenderViewFrame(
+        viewId: viewId, parentViewId: parentViewId, cacheKey: cacheKey
+      )
+    revisions.add DisplayRevisionSnapshot(
+      view: view, revision: cacheKey.displayRevision
+    )
+
+    let contentOrigin =
+      absoluteFrame.origin.addPoints(view.bounds().boundsTranslation())
+    for child in view.subviews:
+      scene.collectRenderFrames(
+        child, appearance, frames, revisions, viewId, level, contentOrigin
+      )
+
+  proc updateRenderScene(root: View, appearance: Appearance): RenderScene =
+    root.layoutSubtreeIfNeeded()
+    if not root.xCachedRenderScene.isNil and root.xHasCachedRenders and
+        not root.xNeedsDisplay and
+        root.xCachedAppearance.sameAppearanceGeneration(appearance):
+      return root.xCachedRenderScene
+    if root.xCachedRenderScene.isNil:
+      root.xCachedRenderScene = newRenderScene()
+
+    var
+      frames: seq[RenderViewFrame]
+      revisions: seq[DisplayRevisionSnapshot]
+    root.xCachedRenderScene.collectRenderFrames(root, appearance, frames, revisions)
+    let changed = root.xCachedRenderScene.reconcile(frames, DefaultDrawLevel)
+    for snapshot in revisions:
+      snapshot.view.acknowledgeDisplayRevision(snapshot.revision)
+    root.refreshDisplayStateSubtree()
+
+    if changed or not root.xHasCachedRenders:
+      root.xCachedRenders = root.xCachedRenderScene.materialize()
+    root.xCachedRenderResources = root.xCachedRenderScene.renderResources()
+    root.xCachedAppearance = appearance
+    root.xHasCachedRenders = true
+    root.xCachedRenderScene
 
 proc cacheCanReuse(root: View, appearance: Appearance): bool =
   result =
@@ -204,17 +331,18 @@ proc invalidateRenderCache*(root: View) =
   root.xHasCachedRenders = false
 
 proc buildRenders*(root: View, appearance: Appearance): Renders =
+  when not defined(useNativeDynlib):
+    if not root.xCachedRenderScene.isNil:
+      discard root.updateRenderScene(appearance)
+      return root.xCachedRenders
+
   discard root.prepareDisplaySubtree()
   if root.cacheCanReuse(appearance):
     return root.xCachedRenders
 
   let context = initDrawContext()
-  var seenViews: SeenRenderViews
-  renderViewInto(context, root, appearance, seenViews = seenViews)
+  renderViewInto(context, root, appearance)
   result = context.renders
-  when not defined(useNativeDynlib):
-    if not root.xCachedRenderScene.isNil:
-      root.xCachedRenderScene.replaceContents(result, context.resources, seenViews)
   root.xCachedRenders = result
   root.xCachedRenderResources = context.resources
   root.xCachedAppearance = appearance
@@ -228,23 +356,10 @@ proc buildRenders*(root: View): Renders =
   buildRenders(root, root.effectiveAppearance())
 
 when not defined(useNativeDynlib):
-  proc collectRenderedViewIds(view: View, ids: var seq[RenderViewId]) =
-    if view.visibleRect.isEmpty:
-      return
-    ids.add view.renderViewId()
-    for child in view.subviews:
-      child.collectRenderedViewIds(ids)
-
   proc buildRenderScene*(root: View, appearance: Appearance): RenderScene =
-    discard root.buildRenders(appearance)
-    if root.xCachedRenderScene.isNil:
-      var seenViews: seq[RenderViewId]
-      root.collectRenderedViewIds(seenViews)
-      root.xCachedRenderScene = newRenderScene()
-      root.xCachedRenderScene.replaceContents(
-        root.xCachedRenders, root.xCachedRenderResources, seenViews
-      )
-    root.xCachedRenderScene
+    ## Builds or incrementally updates `root`'s scene-local per-view render cache.
+    ## Clean view contributions retain their fragments and do not invoke `draw`.
+    root.updateRenderScene(appearance)
 
   proc buildRenderScene*(root: View, theme: Theme): RenderScene =
     root.buildRenderScene(initAppearance(theme))

--- a/src/merenda/nimkit/drawing/renderresources.nim
+++ b/src/merenda/nimkit/drawing/renderresources.nim
@@ -1,4 +1,4 @@
-import std/tables
+import std/[sets, tables]
 
 when defined(useNativeDynlib):
   {.error: "FigDraw managed resources require the static FigDraw build".}
@@ -23,6 +23,16 @@ type
     ## Fonts and images referenced by one live render contribution or scene.
     fonts: Table[FontId, FontRef]
     images: Table[ImageId, RenderImageResource]
+
+  RenderResourceSnapshot* = object
+    ## Thread-transferable identities for one live render resource working set.
+    ##
+    ## Managed `FontRef`, `ImageRef`, and `ImageResource` handles remain on the
+    ## application thread. FigDraw's retained image replay supplies pixels to
+    ## the renderer thread, while this snapshot limits replay to live IDs.
+    present: bool
+    fonts: HashSet[FontId]
+    images: HashSet[ImageId]
 
   RenderResourceMetrics* = object
     replayCount*: uint64
@@ -93,11 +103,29 @@ proc mergeRenderResources*(
   for manifest in manifests:
     result.addResources(manifest)
 
+proc snapshot*(manifest: RenderResourceManifest): RenderResourceSnapshot =
+  ## Copies only thread-safe resource identities, never managed resource handles.
+  if manifest.isNil:
+    return
+  result.present = true
+  result.fonts = initHashSet[FontId]()
+  result.images = initHashSet[ImageId]()
+  for id in manifest.fonts.keys:
+    result.fonts.incl id
+  for id in manifest.images.keys:
+    result.images.incl id
+
 proc fontCount*(manifest: RenderResourceManifest): Natural =
   if manifest.isNil: 0 else: manifest.fonts.len.Natural
 
 proc imageCount*(manifest: RenderResourceManifest): Natural =
   if manifest.isNil: 0 else: manifest.images.len.Natural
+
+proc fontCount*(snapshot: RenderResourceSnapshot): Natural =
+  snapshot.fonts.len.Natural
+
+proc imageCount*(snapshot: RenderResourceSnapshot): Natural =
+  snapshot.images.len.Natural
 
 proc containsFont*(manifest: RenderResourceManifest, id: FontId): bool =
   ## Reports whether `manifest` retains `id` for rendering.
@@ -106,6 +134,18 @@ proc containsFont*(manifest: RenderResourceManifest, id: FontId): bool =
 proc containsImage*(manifest: RenderResourceManifest, id: ImageId): bool =
   ## Reports whether `manifest` retains `id` and its recovery source.
   not manifest.isNil and id in manifest.images
+
+proc containsFont*(snapshot: RenderResourceSnapshot, id: FontId): bool =
+  snapshot.present and id in snapshot.fonts
+
+proc containsImage*(snapshot: RenderResourceSnapshot, id: ImageId): bool =
+  snapshot.present and id in snapshot.images
+
+proc hasResourceFilter(resources: RenderResourceManifest): bool =
+  not resources.isNil
+
+proc hasResourceFilter(resources: RenderResourceSnapshot): bool =
+  resources.present
 
 proc newRenderResourceManager*(
     pressureThreshold = ImageAtlasPressureThreshold,
@@ -121,9 +161,9 @@ proc metrics*(manager: RenderResourceManager): RenderResourceMetrics =
     result = manager.metricsValue
 
 proc removeResourcesOutsideManifest[BackendState](
-    renderer: FigRenderer[BackendState], resources: RenderResourceManifest
+    renderer: FigRenderer[BackendState], resources: auto
 ) =
-  if resources.isNil:
+  if not resources.hasResourceFilter():
     return
 
   var removed: seq[Hash]
@@ -150,10 +190,15 @@ proc restoreManifestImages[BackendState](
     let pixels = resource.source.pixels()
     discard renderer.ensureImage(id, pixels)
 
+proc restoreManifestImages[BackendState](
+    renderer: FigRenderer[BackendState], resources: RenderResourceSnapshot
+) =
+  ## Image pixels are replayed by FigDraw's cross-thread retained-image store.
+  discard renderer
+  discard resources
+
 proc replayWorkingSet[BackendState](
-    manager: RenderResourceManager,
-    renderer: FigRenderer[BackendState],
-    resources: RenderResourceManifest,
+    manager: RenderResourceManager, renderer: FigRenderer[BackendState], resources: auto
 ) =
   var attempts = 0
   while attempts < 8:
@@ -169,16 +214,11 @@ proc replayWorkingSet[BackendState](
     inc manager.metricsValue.generationRecoveryCount
     inc attempts
 
-proc prepare*[BackendState](
+proc prepareWithResources[BackendState, Resources](
     manager: RenderResourceManager,
     renderer: FigRenderer[BackendState],
-    resources: RenderResourceManifest = nil,
+    resources: Resources,
 ) =
-  ## Applies pending resource messages and repairs atlas loss or pressure.
-  ##
-  ## When `resources` is present, recovery restores only that live manifest.
-  ## Passing `nil` retains the global replay behavior used by transferred
-  ## monolithic snapshots on the dedicated renderer.
   if manager.isNil or renderer.isNil:
     return
 
@@ -241,6 +281,26 @@ proc prepare*[BackendState](
   manager.metricsValue.atlasGeneration = usage.generation
   manager.metricsValue.atlasRebuildCount = usage.rebuildCount
   manager.atlasGeneration = usage.generation
+
+proc prepare*[BackendState](
+    manager: RenderResourceManager,
+    renderer: FigRenderer[BackendState],
+    resources: RenderResourceManifest = nil,
+) =
+  ## Applies pending resource messages and repairs atlas loss or pressure.
+  ##
+  ## When `resources` is present, recovery restores only that live manifest.
+  ## Passing `nil` retains the global replay behavior used by compatibility
+  ## monolithic snapshots.
+  manager.prepareWithResources(renderer, resources)
+
+proc prepare*[BackendState](
+    manager: RenderResourceManager,
+    renderer: FigRenderer[BackendState],
+    resources: RenderResourceSnapshot,
+) =
+  ## Repairs renderer-thread atlas state using only the transferred live IDs.
+  manager.prepareWithResources(renderer, resources)
 
 proc clear*(manager: RenderResourceManager) =
   if not manager.isNil:

--- a/src/merenda/nimkit/drawing/renderresources.nim
+++ b/src/merenda/nimkit/drawing/renderresources.nim
@@ -14,9 +14,15 @@ const
   ImageAtlasShrinkWorkingSetDivisor* = 4
 
 type
+  RenderImageResource = object
+    ## Retains both renderer ownership and the pixels needed after atlas loss.
+    source: ImageResource
+    owned: ImageRef
+
   RenderResourceManifest* = ref object
+    ## Fonts and images referenced by one live render contribution or scene.
     fonts: Table[FontId, FontRef]
-    images: Table[ImageId, ImageRef]
+    images: Table[ImageId, RenderImageResource]
 
   RenderResourceMetrics* = object
     replayCount*: uint64
@@ -36,11 +42,13 @@ type
     pressureCooldown: int
     initialAtlasSize: int
     atlasHighWaterUsedArea: int
+    atlasGeneration: uint64
     metricsValue: RenderResourceMetrics
 
 proc initRenderResourceManifest*(): RenderResourceManifest =
   RenderResourceManifest(
-    fonts: initTable[FontId, FontRef](), images: initTable[ImageId, ImageRef]()
+    fonts: initTable[FontId, FontRef](),
+    images: initTable[ImageId, RenderImageResource](),
   )
 
 proc ensureManifest(manifest: var RenderResourceManifest) =
@@ -64,7 +72,7 @@ proc addImage*(manifest: var RenderResourceManifest, image: ImageResource) =
     return
   manifest.ensureManifest()
   let owned = image.renderingRef()
-  manifest.images[owned.id] = owned
+  manifest.images[owned.id] = RenderImageResource(source: image, owned: owned)
 
 proc addResources*(
     manifest: var RenderResourceManifest, resources: RenderResourceManifest
@@ -91,6 +99,14 @@ proc fontCount*(manifest: RenderResourceManifest): Natural =
 proc imageCount*(manifest: RenderResourceManifest): Natural =
   if manifest.isNil: 0 else: manifest.images.len.Natural
 
+proc containsFont*(manifest: RenderResourceManifest, id: FontId): bool =
+  ## Reports whether `manifest` retains `id` for rendering.
+  not manifest.isNil and id in manifest.fonts
+
+proc containsImage*(manifest: RenderResourceManifest, id: ImageId): bool =
+  ## Reports whether `manifest` retains `id` and its recovery source.
+  not manifest.isNil and id in manifest.images
+
 proc newRenderResourceManager*(
     pressureThreshold = ImageAtlasPressureThreshold,
     pressureCooldownFrames = ImageAtlasPressureCooldownFrames,
@@ -104,14 +120,49 @@ proc metrics*(manager: RenderResourceManager): RenderResourceMetrics =
   if not manager.isNil:
     result = manager.metricsValue
 
+proc removeResourcesOutsideManifest[BackendState](
+    renderer: FigRenderer[BackendState], resources: RenderResourceManifest
+) =
+  if resources.isNil:
+    return
+
+  var removed: seq[Hash]
+  for key, metadata in renderer.ctx.atlasEntryMetaPtr().pairs:
+    let retained =
+      case metadata.kind
+      of aekImage:
+        resources.containsImage(metadata.imageId)
+      of aekGlyph:
+        resources.containsFont(metadata.fontId)
+      of aekGenerated:
+        ImageId(key) in resources.images
+    if not retained:
+      removed.add key
+  for key in removed:
+    renderer.ctx.removeAtlasEntry(key)
+
+proc restoreManifestImages[BackendState](
+    renderer: FigRenderer[BackendState], resources: RenderResourceManifest
+) =
+  if resources.isNil:
+    return
+  for id, resource in resources.images:
+    let pixels = resource.source.pixels()
+    discard renderer.ensureImage(id, pixels)
+
 proc replayWorkingSet[BackendState](
-    manager: RenderResourceManager, renderer: FigRenderer[BackendState]
+    manager: RenderResourceManager,
+    renderer: FigRenderer[BackendState],
+    resources: RenderResourceManifest,
 ) =
   var attempts = 0
   while attempts < 8:
     let generation = renderer.atlasGeneration()
-    renderer.ctx.imageMessages = newImageMessageSubscription()
+    renderer.ctx.ensureImageMessageSubscription()
+    replayImageMessages(renderer.ctx.imageMessages)
     renderer.processImageMessages()
+    renderer.removeResourcesOutsideManifest(resources)
+    renderer.restoreManifestImages(resources)
     inc manager.metricsValue.replayCount
     if renderer.atlasGeneration() == generation:
       break
@@ -119,19 +170,29 @@ proc replayWorkingSet[BackendState](
     inc attempts
 
 proc prepare*[BackendState](
-    manager: RenderResourceManager, renderer: FigRenderer[BackendState]
+    manager: RenderResourceManager,
+    renderer: FigRenderer[BackendState],
+    resources: RenderResourceManifest = nil,
 ) =
+  ## Applies pending resource messages and repairs atlas loss or pressure.
+  ##
+  ## When `resources` is present, recovery restores only that live manifest.
+  ## Passing `nil` retains the global replay behavior used by transferred
+  ## monolithic snapshots on the dedicated renderer.
   if manager.isNil or renderer.isNil:
     return
 
   if manager.initialAtlasSize <= 0:
     manager.initialAtlasSize = renderer.atlasUsage().atlasSize
 
-  let generationBefore = renderer.atlasGeneration()
+  let
+    generationBefore = renderer.atlasGeneration()
+    generationChanged =
+      manager.atlasGeneration != 0 and manager.atlasGeneration != generationBefore
   renderer.processImageMessages()
-  if renderer.atlasGeneration() != generationBefore:
+  if generationChanged or renderer.atlasGeneration() != generationBefore:
     inc manager.metricsValue.generationRecoveryCount
-    manager.replayWorkingSet(renderer)
+    manager.replayWorkingSet(renderer, resources)
 
   var usage = renderer.atlasUsage()
   manager.atlasHighWaterUsedArea = max(manager.atlasHighWaterUsedArea, usage.usedArea)
@@ -148,7 +209,7 @@ proc prepare*[BackendState](
   if shouldShrink:
     let previousAtlasSize = usage.atlasSize
     renderer.rebuildImageAtlas(manager.initialAtlasSize)
-    manager.replayWorkingSet(renderer)
+    manager.replayWorkingSet(renderer, resources)
     usage = renderer.atlasUsage()
     if usage.atlasSize < previousAtlasSize:
       inc manager.metricsValue.atlasShrinkRebuildCount
@@ -170,7 +231,7 @@ proc prepare*[BackendState](
       renderer.rebuildImageAtlas(minimumSize)
       inc manager.metricsValue.pressureRebuildCount
       manager.pressureCooldown = manager.pressureCooldownFrames.int
-      manager.replayWorkingSet(renderer)
+      manager.replayWorkingSet(renderer, resources)
       usage = renderer.atlasUsage()
       manager.atlasHighWaterUsedArea =
         max(manager.atlasHighWaterUsedArea, usage.usedArea)
@@ -179,7 +240,9 @@ proc prepare*[BackendState](
   manager.metricsValue.atlasPackedRatio = usage.packedRatio()
   manager.metricsValue.atlasGeneration = usage.generation
   manager.metricsValue.atlasRebuildCount = usage.rebuildCount
+  manager.atlasGeneration = usage.generation
 
 proc clear*(manager: RenderResourceManager) =
   if not manager.isNil:
+    manager.atlasGeneration = 0
     manager.metricsValue = default(RenderResourceMetrics)

--- a/src/merenda/nimkit/drawing/renderscenes.nim
+++ b/src/merenda/nimkit/drawing/renderscenes.nim
@@ -1,15 +1,67 @@
+## Retained, per-view render scenes built on FigDraw fragment attachments.
+##
+## Each visible view owns a stable shell fragment, a replaceable self-drawing
+## fragment, an escaped-sibling fragment, and zero or more extra-layer root
+## fragments. Child view shells attach beneath their parent's shell, so replacing
+## one view's self drawing cannot detach descendant or sibling identities.
+
 import std/[hashes, tables]
 
 import figdraw
 
 import ./renderresources
+import ../foundation/types
 
 type
   RenderViewId* = distinct uint64
     ## Stable application-thread identity for a NimKit view.
 
+  RenderViewCacheKey* = object
+    ## Inputs that can change one view's captured drawing without changing its ID.
+    displayRevision*: uint64
+    appearanceGeneration*: uint64
+    frame*: Rect
+    bounds*: Rect
+    visibleRect*: Rect
+    level*: ZLevel
+    isRoot*: bool
+
+  RenderLayerContribution* = object
+    ## Root drawing emitted explicitly onto a layer by one view.
+    level*: ZLevel
+    contents*: RenderList
+
+  RenderViewFrame* = object
+    ## One visible view's placement and optional freshly captured contribution.
+    viewId*: RenderViewId
+    parentViewId*: RenderViewId
+    cacheKey*: RenderViewCacheKey
+    captured*: bool
+    shell*: Fig
+    selfContents*: RenderList
+    escapedContents*: RenderList
+    extraLayers*: seq[RenderLayerContribution]
+    resources*: RenderResourceManifest
+
+  ViewPlacement = object
+    viewId: RenderViewId
+    parentViewId: RenderViewId
+    level: ZLevel
+
   ViewRenderEntry = object
-    lastSeenGeneration: uint64
+    cacheKey: RenderViewCacheKey
+    shell: Fig
+    selfContents: RenderList
+    escapedContents: RenderList
+    extraLayers: seq[RenderLayerContribution]
+    resources: RenderResourceManifest
+    shellHandle: RenderFragmentHandle
+    shellCursor: RenderCursor
+    selfHandle: RenderFragmentHandle
+    escapedHandle: RenderFragmentHandle
+    extraHandles: Table[ZLevel, RenderFragmentHandle]
+    externalParent: RenderViewId
+    captureGeneration: uint64
 
   RetiredRenderResources = object
     releaseGeneration: uint64
@@ -21,7 +73,9 @@ type
     rootLevels: seq[ZLevel]
     rootFragments: seq[RenderFragmentHandle]
     viewEntries: Table[RenderViewId, ViewRenderEntry]
+    placements: seq[ViewPlacement]
     generation: uint64
+    perViewMode: bool
     liveResources: RenderResourceManifest
     retiredResources: seq[RetiredRenderResources]
 
@@ -53,6 +107,9 @@ proc copyRenderList(list: RenderList): RenderList =
   for root in list.rootIds:
     result.rootIds.add root
 
+proc shellRenderList(node: Fig): RenderList =
+  discard result.addRoot(node)
+
 proc buildFragmentTree(
     renders: Renders
 ): tuple[tree: RenderFragments, levels: seq[ZLevel], roots: seq[RenderFragmentHandle]] =
@@ -71,8 +128,9 @@ proc replaceContents*(
     seenViews: openArray[RenderViewId],
 ) =
   ## Installs a validated monolithic build as a fragment snapshot.
-  ## This first implementation uses one persistent root fragment per layer;
-  ## later reconciliation will subdivide those roots into per-view entries.
+  ##
+  ## This compatibility path deliberately discards per-view cache entries. The
+  ## next incremental reconciliation will capture scene-local contributions.
   if scene.isNil:
     raise newException(ValueError, "cannot update a nil render scene")
 
@@ -84,18 +142,19 @@ proc replaceContents*(
   for id in seenViews:
     if id.uint64 == 0:
       raise newException(ValueError, "render scene received an invalid view identity")
-    nextEntries[id] = ViewRenderEntry(lastSeenGeneration: nextGeneration)
+    nextEntries[id] = ViewRenderEntry()
 
   if not scene.liveResources.isNil and scene.liveResources != resources:
     scene.retiredResources.add RetiredRenderResources(
       releaseGeneration: nextGeneration, manifest: scene.liveResources
     )
 
-  if scene.rootLevels == built.levels and scene.rootFragments.len == built.roots.len:
+  if not scene.perViewMode and scene.rootLevels == built.levels and
+      scene.rootFragments.len == built.roots.len:
     var nextRoots = newSeqOfCap[RenderFragmentHandle](scene.rootFragments.len)
-    for idx, level in built.levels:
+    for index, level in built.levels:
       nextRoots.add scene.tree.replaceFragment(
-        scene.rootFragments[idx], renders.layers[level].copyRenderList()
+        scene.rootFragments[index], renders.layers[level].copyRenderList()
       )
     scene.rootFragments = move nextRoots
   else:
@@ -103,8 +162,330 @@ proc replaceContents*(
     scene.rootLevels = built.levels
     scene.rootFragments = built.roots
   scene.viewEntries = move nextEntries
+  scene.placements.setLen(0)
   scene.generation = nextGeneration
+  scene.perViewMode = false
   scene.liveResources = resources
+
+proc needsViewCapture*(
+    scene: RenderScene, viewId: RenderViewId, cacheKey: RenderViewCacheKey
+): bool =
+  ## Reports whether this scene lacks a current contribution for `viewId`.
+  if scene.isNil or not scene.perViewMode or viewId notin scene.viewEntries:
+    return true
+  scene.viewEntries[viewId].cacheKey != cacheKey
+
+proc externalParent(
+    frame: RenderViewFrame, levels: Table[RenderViewId, ZLevel]
+): RenderViewId =
+  if frame.parentViewId.uint64 == 0 or levels[frame.parentViewId] != frame.cacheKey.level:
+    return 0.RenderViewId
+  frame.parentViewId
+
+proc validateFrames(frames: openArray[RenderViewFrame]) =
+  var levels = initTable[RenderViewId, ZLevel]()
+  for frame in frames:
+    if frame.viewId.uint64 == 0:
+      raise newException(ValueError, "render frame received an invalid view identity")
+    if frame.viewId in levels:
+      raise newException(ValueError, "render frame contains a duplicate view identity")
+    if frame.parentViewId.uint64 != 0 and frame.parentViewId notin levels:
+      raise newException(ValueError, "render frame parent must precede its child")
+    levels[frame.viewId] = frame.cacheKey.level
+
+proc nextPlacements(frames: openArray[RenderViewFrame]): seq[ViewPlacement] =
+  result = newSeqOfCap[ViewPlacement](frames.len)
+  for frame in frames:
+    result.add ViewPlacement(
+      viewId: frame.viewId,
+      parentViewId: frame.parentViewId,
+      level: frame.cacheKey.level,
+    )
+
+proc containsLevel(levels: openArray[ZLevel], level: ZLevel): bool =
+  for candidate in levels:
+    if candidate == level:
+      return true
+
+proc sameLayerShape(
+    cached: openArray[RenderLayerContribution],
+    captured: openArray[RenderLayerContribution],
+): bool =
+  if cached.len != captured.len:
+    return false
+  for index, layer in cached:
+    if layer.level != captured[index].level:
+      return false
+  true
+
+proc desiredLevels(
+    scene: RenderScene, frames: openArray[RenderViewFrame], baseLevel: ZLevel
+): seq[ZLevel] =
+  result.add baseLevel
+  for frame in frames:
+    if not result.containsLevel(frame.cacheKey.level):
+      result.add frame.cacheKey.level
+    for extra in scene.viewEntries[frame.viewId].extraLayers:
+      if not result.containsLevel(extra.level):
+        result.add extra.level
+
+proc attachRoot(
+    scene: RenderScene, level: ZLevel, contents: RenderList
+): RenderFragmentHandle =
+  scene.tree.attachRootFragment(level, 0, contents.copyRenderList())
+
+proc attachChild(
+    scene: RenderScene, parent: RenderCursor, contents: RenderList
+): RenderFragmentHandle =
+  scene.tree.attachChildFragment(parent, 0, contents.copyRenderList())
+
+proc attachViewEntry(
+    scene: RenderScene, entry: var ViewRenderEntry, parent: RenderViewId
+) =
+  let shellList = entry.shell.shellRenderList()
+  if parent.uint64 == 0:
+    entry.shellHandle = scene.attachRoot(entry.cacheKey.level, shellList)
+  else:
+    entry.shellHandle =
+      scene.attachChild(scene.viewEntries[parent].shellCursor, shellList)
+
+  let roots = scene.tree.fragmentRoots(entry.shellHandle)
+  if roots.len != 1:
+    raise
+      newException(ValueError, "a view shell fragment must contain exactly one root")
+  entry.shellCursor = roots[0]
+  entry.selfHandle = scene.attachChild(entry.shellCursor, entry.selfContents)
+
+  if parent.uint64 == 0:
+    entry.escapedHandle = scene.attachRoot(entry.cacheKey.level, entry.escapedContents)
+  else:
+    entry.escapedHandle =
+      scene.attachChild(scene.viewEntries[parent].shellCursor, entry.escapedContents)
+
+  entry.extraHandles = initTable[ZLevel, RenderFragmentHandle]()
+  for extra in entry.extraLayers:
+    entry.extraHandles[extra.level] = scene.attachRoot(extra.level, extra.contents)
+  entry.externalParent = parent
+
+proc detachEntry(scene: RenderScene, entry: ViewRenderEntry) =
+  for _, handle in entry.extraHandles:
+    if scene.tree.isValid(handle):
+      scene.tree.removeFragment(handle)
+  if scene.tree.isValid(entry.escapedHandle):
+    scene.tree.removeFragment(entry.escapedHandle)
+  if scene.tree.isValid(entry.shellHandle):
+    scene.tree.removeFragment(entry.shellHandle)
+
+proc rebuildTree(
+    scene: RenderScene, frames: openArray[RenderViewFrame], levels: seq[ZLevel]
+) =
+  scene.tree = newRenderFragments()
+  scene.rootLevels = levels
+  scene.rootFragments.setLen(0)
+
+  var viewLevels = initTable[RenderViewId, ZLevel]()
+  for frame in frames:
+    viewLevels[frame.viewId] = frame.cacheKey.level
+  for frame in frames:
+    var entry = scene.viewEntries[frame.viewId]
+    scene.attachViewEntry(entry, frame.externalParent(viewLevels))
+    scene.viewEntries[frame.viewId] = entry
+
+proc updateCapturedEntry(scene: RenderScene, entry: var ViewRenderEntry) =
+  scene.tree.updateNode(entry.shellCursor, entry.shell)
+  entry.selfHandle =
+    scene.tree.replaceFragment(entry.selfHandle, entry.selfContents.copyRenderList())
+  entry.escapedHandle = scene.tree.replaceFragment(
+    entry.escapedHandle, entry.escapedContents.copyRenderList()
+  )
+
+  var retained = initTable[ZLevel, bool]()
+  for extra in entry.extraLayers:
+    retained[extra.level] = true
+    if extra.level in entry.extraHandles:
+      entry.extraHandles[extra.level] = scene.tree.replaceFragment(
+        entry.extraHandles[extra.level], extra.contents.copyRenderList()
+      )
+    else:
+      entry.extraHandles[extra.level] = scene.attachRoot(extra.level, extra.contents)
+
+  var removed: seq[ZLevel]
+  for level in entry.extraHandles.keys:
+    if level notin retained:
+      removed.add level
+  for level in removed:
+    let handle = entry.extraHandles[level]
+    if scene.tree.isValid(handle):
+      scene.tree.removeFragment(handle)
+    entry.extraHandles.del(level)
+
+proc moveViewEntry(
+    scene: RenderScene, entry: var ViewRenderEntry, parent: RenderViewId
+) =
+  if entry.externalParent == parent:
+    return
+  if parent.uint64 == 0:
+    entry.shellHandle =
+      scene.tree.moveFragmentToRoot(entry.shellHandle, entry.cacheKey.level, 0)
+    entry.escapedHandle =
+      scene.tree.moveFragmentToRoot(entry.escapedHandle, entry.cacheKey.level, 0)
+  else:
+    let parentCursor = scene.viewEntries[parent].shellCursor
+    entry.shellHandle = scene.tree.moveFragment(entry.shellHandle, parentCursor, 0)
+    entry.escapedHandle = scene.tree.moveFragment(entry.escapedHandle, parentCursor, 0)
+  entry.externalParent = parent
+
+proc reconcileOrders(
+    scene: RenderScene, frames: openArray[RenderViewFrame], levels: openArray[ZLevel]
+) =
+  var
+    viewLevels = initTable[RenderViewId, ZLevel]()
+    childOrders = initTable[RenderViewId, seq[RenderFragmentHandle]]()
+    rootOrders = initTable[ZLevel, seq[RenderFragmentHandle]]()
+
+  for level in levels:
+    rootOrders[level] = @[]
+  for frame in frames:
+    viewLevels[frame.viewId] = frame.cacheKey.level
+    childOrders[frame.viewId] = @[scene.viewEntries[frame.viewId].selfHandle]
+
+  for frame in frames:
+    let
+      entry = scene.viewEntries[frame.viewId]
+      parent = frame.externalParent(viewLevels)
+    if parent.uint64 == 0:
+      rootOrders[frame.cacheKey.level].add entry.shellHandle
+      rootOrders[frame.cacheKey.level].add entry.escapedHandle
+    else:
+      childOrders[parent].add entry.shellHandle
+      childOrders[parent].add entry.escapedHandle
+    for extra in entry.extraLayers:
+      rootOrders[extra.level].add entry.extraHandles[extra.level]
+
+  for frame in frames:
+    let entry = scene.viewEntries[frame.viewId]
+    scene.tree.reorderChildFragments(entry.shellCursor, childOrders[frame.viewId])
+  scene.rootFragments.setLen(0)
+  for level in levels:
+    scene.tree.reorderRootFragments(level, rootOrders[level])
+    scene.rootFragments.add rootOrders[level]
+
+proc mergeEntryResources(
+    scene: RenderScene, frames: openArray[RenderViewFrame]
+): RenderResourceManifest =
+  result = initRenderResourceManifest()
+  for frame in frames:
+    result.addResources(scene.viewEntries[frame.viewId].resources)
+
+proc reconcile*(
+    scene: RenderScene, frames: openArray[RenderViewFrame], baseLevel: ZLevel
+): bool {.discardable.} =
+  ## Reconciles one frame while retaining clean per-view drawing fragments.
+  ##
+  ## `frames` must be in depth-first view order, with parents before children.
+  ## A captured entry atomically updates its shell, self, escaped, and extra-layer
+  ## outputs. Clean entries only participate in placement and ordering.
+  if scene.isNil:
+    raise newException(ValueError, "cannot update a nil render scene")
+  frames.validateFrames()
+
+  let placements = frames.nextPlacements()
+  var
+    topologyChanged = not scene.perViewMode or placements != scene.placements
+    changed = topologyChanged
+    levelChanged = false
+    seen = initTable[RenderViewId, bool]()
+
+  for frame in frames:
+    seen[frame.viewId] = true
+    let existed = frame.viewId in scene.viewEntries and scene.perViewMode
+    if not existed and not frame.captured:
+      raise newException(ValueError, "a new render view must include a capture")
+    if not existed:
+      topologyChanged = true
+    if existed and scene.viewEntries[frame.viewId].cacheKey.level != frame.cacheKey.level:
+      levelChanged = true
+
+    var entry =
+      if existed:
+        scene.viewEntries[frame.viewId]
+      else:
+        ViewRenderEntry(extraHandles: initTable[ZLevel, RenderFragmentHandle]())
+    if frame.captured:
+      if existed and not entry.extraLayers.sameLayerShape(frame.extraLayers):
+        topologyChanged = true
+      entry.cacheKey = frame.cacheKey
+      entry.shell = frame.shell
+      entry.selfContents = frame.selfContents.copyRenderList()
+      entry.escapedContents = frame.escapedContents.copyRenderList()
+      entry.extraLayers = frame.extraLayers
+      entry.resources = frame.resources
+      entry.captureGeneration.advance()
+      changed = true
+    elif entry.cacheKey != frame.cacheKey:
+      raise newException(ValueError, "a changed render view must include a capture")
+    if frame.captured:
+      scene.viewEntries[frame.viewId] = entry
+
+  var removed: seq[RenderViewId]
+  for viewId in scene.viewEntries.keys:
+    if viewId notin seen:
+      removed.add viewId
+  if removed.len > 0:
+    changed = true
+    topologyChanged = true
+
+  let levels = scene.desiredLevels(frames, baseLevel)
+  let rebuild = not scene.perViewMode or levelChanged or levels != scene.rootLevels
+  if not changed and not rebuild:
+    return false
+
+  var nextGeneration = scene.generation
+  nextGeneration.advance()
+
+  if rebuild:
+    for viewId in removed:
+      scene.viewEntries.del(viewId)
+    scene.rebuildTree(frames, levels)
+  else:
+    var viewLevels = initTable[RenderViewId, ZLevel]()
+    for frame in frames:
+      viewLevels[frame.viewId] = frame.cacheKey.level
+
+    if topologyChanged:
+      for frame in frames:
+        var entry = scene.viewEntries[frame.viewId]
+        if not scene.tree.isValid(entry.shellHandle):
+          scene.attachViewEntry(entry, frame.externalParent(viewLevels))
+        else:
+          scene.moveViewEntry(entry, frame.externalParent(viewLevels))
+          if frame.captured:
+            scene.updateCapturedEntry(entry)
+        scene.viewEntries[frame.viewId] = entry
+    else:
+      for frame in frames:
+        if frame.captured:
+          var entry = scene.viewEntries[frame.viewId]
+          scene.updateCapturedEntry(entry)
+          scene.viewEntries[frame.viewId] = entry
+
+    for viewId in removed:
+      scene.detachEntry(scene.viewEntries[viewId])
+      scene.viewEntries.del(viewId)
+
+  if rebuild or topologyChanged:
+    scene.reconcileOrders(frames, levels)
+  let resources = scene.mergeEntryResources(frames)
+  if not scene.liveResources.isNil:
+    scene.retiredResources.add RetiredRenderResources(
+      releaseGeneration: nextGeneration, manifest: scene.liveResources
+    )
+  scene.liveResources = resources
+  scene.placements = placements
+  scene.rootLevels = levels
+  scene.generation = nextGeneration
+  scene.perViewMode = true
+  true
 
 proc materialize*(scene: RenderScene): Renders =
   ## Returns an independent monolithic snapshot for diagnostics and transfer.
@@ -123,6 +504,20 @@ proc rootFragmentIds*(scene: RenderScene): seq[uint64] =
   result = newSeqOfCap[uint64](scene.rootFragments.len)
   for handle in scene.rootFragments:
     result.add handle.fragmentId()
+
+proc viewCaptureGeneration*(scene: RenderScene, id: RenderViewId): uint64 =
+  ## Returns how many contributions this scene has captured for one view identity.
+  if not scene.isNil and id in scene.viewEntries:
+    result = scene.viewEntries[id].captureGeneration
+
+proc viewFragmentIds*(scene: RenderScene, id: RenderViewId): seq[uint64] =
+  ## Returns the stable shell, self, and escaped fragment IDs for diagnostics.
+  if scene.isNil or id notin scene.viewEntries:
+    return
+  let entry = scene.viewEntries[id]
+  for handle in [entry.shellHandle, entry.selfHandle, entry.escapedHandle]:
+    if scene.tree.isValid(handle):
+      result.add handle.fragmentId()
 
 proc viewEntryCount*(scene: RenderScene): Natural =
   if not scene.isNil:

--- a/src/merenda/nimkit/drawing/renderscenes.nim
+++ b/src/merenda/nimkit/drawing/renderscenes.nim
@@ -1,14 +1,15 @@
 ## Retained, per-view render scenes built on FigDraw fragment attachments.
 ##
-## Each visible view owns a one-node placement transform fragment. That transform
-## owns a stable background/clip shell, a replaceable self-drawing fragment,
-## escaped drawing outside the clip, and child placement fragments::
+## Each visible view owns stable placement and content transform fragments. They
+## keep frame and bounds-origin movement separate from replaceable drawing::
 ##
 ##   placement transform
 ##   +-- background/clip shell
-##   |   +-- self drawing
-##   |   +-- child placement transform
-##   +-- escaped drawing
+##   |   +-- clipped content transform
+##   |       +-- self drawing
+##   |       +-- child placement transform
+##   +-- escaped content transform
+##       +-- escaped drawing
 ##
 ## Scrolling or moving an ancestor updates only placement transform nodes. It does
 ## not rebuild a descendant's drawing unless that drawing read
@@ -52,6 +53,8 @@ type
     captured*: bool
     placement*: Fig
     shell*: Fig
+    contentTransform*: Fig
+    escapedTransform*: Fig
     selfContents*: RenderList
     escapedContents*: RenderList
     extraLayers*: seq[RenderLayerContribution]
@@ -67,6 +70,8 @@ type
     cacheKey: RenderViewCacheKey
     placement: Fig
     shell: Fig
+    contentTransform: Fig
+    escapedTransform: Fig
     selfContents: RenderList
     escapedContents: RenderList
     extraLayers: seq[RenderLayerContribution]
@@ -76,6 +81,10 @@ type
     placementCursor: RenderCursor
     shellHandle: RenderFragmentHandle
     shellCursor: RenderCursor
+    contentHandle: RenderFragmentHandle
+    contentCursor: RenderCursor
+    escapedTransformHandle: RenderFragmentHandle
+    escapedTransformCursor: RenderCursor
     selfHandle: RenderFragmentHandle
     escapedHandle: RenderFragmentHandle
     extraHandles: Table[ZLevel, RenderFragmentHandle]
@@ -274,12 +283,13 @@ proc needsViewCapture*(
   ## Reports whether this scene lacks a current contribution for `viewId`.
   if scene.isNil or not scene.perViewMode or viewId notin scene.viewEntries:
     return true
-  let entry = scene.viewEntries[viewId]
-  let cached = entry.cacheKey
+  let entry = addr scene.viewEntries[viewId]
+  let cached = entry[].cacheKey
   cached.displayRevision != cacheKey.displayRevision or
     cached.appearanceGeneration != cacheKey.appearanceGeneration or
-    cached.frame.size != cacheKey.frame.size or cached.bounds != cacheKey.bounds or
-    (entry.usesVisibleRect and cached.visibleRect != cacheKey.visibleRect) or
+    cached.frame.size != cacheKey.frame.size or
+    cached.bounds.size != cacheKey.bounds.size or
+    (entry[].usesVisibleRect and cached.visibleRect != cacheKey.visibleRect) or
     cached.level != cacheKey.level or cached.isRoot != cacheKey.isRoot
 
 proc needsViewPlacementUpdate*(
@@ -367,7 +377,7 @@ proc attachViewEntry(
     entry.placementHandle = scene.attachRoot(entry.cacheKey.level, placementList)
   else:
     entry.placementHandle =
-      scene.attachChild(scene.viewEntries[parent].shellCursor, placementList)
+      scene.attachChild(scene.viewEntries[parent].contentCursor, placementList)
 
   let roots = scene.tree.fragmentRoots(entry.placementHandle)
   if roots.len != 1:
@@ -383,8 +393,27 @@ proc attachViewEntry(
     raise
       newException(ValueError, "a view shell fragment must contain exactly one root")
   entry.shellCursor = shellRoots[0]
-  entry.selfHandle = scene.attachChild(entry.shellCursor, entry.selfContents)
-  entry.escapedHandle = scene.attachChild(entry.placementCursor, entry.escapedContents)
+
+  var contentList = entry.contentTransform.nodeRenderList()
+  entry.contentHandle = scene.attachChild(entry.shellCursor, contentList)
+  let contentRoots = scene.tree.fragmentRoots(entry.contentHandle)
+  if contentRoots.len != 1:
+    raise
+      newException(ValueError, "a view content fragment must contain exactly one root")
+  entry.contentCursor = contentRoots[0]
+  entry.selfHandle = scene.attachChild(entry.contentCursor, entry.selfContents)
+
+  var escapedTransformList = entry.escapedTransform.nodeRenderList()
+  entry.escapedTransformHandle =
+    scene.attachChild(entry.placementCursor, escapedTransformList)
+  let escapedTransformRoots = scene.tree.fragmentRoots(entry.escapedTransformHandle)
+  if escapedTransformRoots.len != 1:
+    raise newException(
+      ValueError, "an escaped content fragment must contain exactly one root"
+    )
+  entry.escapedTransformCursor = escapedTransformRoots[0]
+  entry.escapedHandle =
+    scene.attachChild(entry.escapedTransformCursor, entry.escapedContents)
 
   entry.extraHandles = initTable[ZLevel, RenderFragmentHandle]()
   for extra in entry.extraLayers.mitems:
@@ -409,14 +438,18 @@ proc rebuildTree(
   for frame in frames:
     viewLevels[frame.viewId] = frame.cacheKey.level
   for frame in frames:
-    var entry = scene.viewEntries[frame.viewId]
-    scene.attachViewEntry(entry, frame.externalParent(viewLevels))
-    scene.viewEntries[frame.viewId] = entry
+    let entry = addr scene.viewEntries[frame.viewId]
+    scene.attachViewEntry(entry[], frame.externalParent(viewLevels))
 
 proc refreshPlacementNodes(entry: var ViewRenderEntry, cacheKey: RenderViewCacheKey) =
   entry.cacheKey = cacheKey
   entry.placement.transform.translation =
     vec2(cacheKey.placement.x, cacheKey.placement.y)
+  let contentTranslation = cacheKey.bounds.origin
+  entry.contentTransform.transform.translation =
+    vec2(-contentTranslation.x, -contentTranslation.y)
+  entry.escapedTransform.transform.translation =
+    entry.contentTransform.transform.translation
   for extra in entry.extraLayers.mitems:
     if extra.contents.rootIds.len != 1:
       raise newException(ValueError, "an extra-layer placement must have one root")
@@ -424,11 +457,15 @@ proc refreshPlacementNodes(entry: var ViewRenderEntry, cacheKey: RenderViewCache
     if extra.contents.nodes[root.int].kind != nkTransform:
       raise
         newException(ValueError, "an extra-layer placement root must be a transform")
-    extra.contents.nodes[root.int].transform.translation =
-      vec2(cacheKey.frame.origin.x, cacheKey.frame.origin.y)
+    extra.contents.nodes[root.int].transform.translation = vec2(
+      cacheKey.frame.origin.x - cacheKey.bounds.origin.x,
+      cacheKey.frame.origin.y - cacheKey.bounds.origin.y,
+    )
 
 proc updatePlacementEntry(scene: RenderScene, entry: var ViewRenderEntry) =
   scene.tree.updateNode(entry.placementCursor, entry.placement)
+  scene.tree.updateNode(entry.contentCursor, entry.contentTransform)
+  scene.tree.updateNode(entry.escapedTransformCursor, entry.escapedTransform)
   for extra in entry.extraLayers:
     let roots = scene.tree.fragmentRoots(entry.extraHandles[extra.level])
     if roots.len != 1:
@@ -438,6 +475,8 @@ proc updatePlacementEntry(scene: RenderScene, entry: var ViewRenderEntry) =
 proc updateCapturedEntry(scene: RenderScene, entry: var ViewRenderEntry) =
   scene.tree.updateNode(entry.placementCursor, entry.placement)
   scene.tree.updateNode(entry.shellCursor, entry.shell)
+  scene.tree.updateNode(entry.contentCursor, entry.contentTransform)
+  scene.tree.updateNode(entry.escapedTransformCursor, entry.escapedTransform)
   if scene.replicaMode:
     entry.selfHandle =
       scene.tree.replaceFragment(entry.selfHandle, move entry.selfContents)
@@ -484,7 +523,7 @@ proc moveViewEntry(
     entry.placementHandle =
       scene.tree.moveFragmentToRoot(entry.placementHandle, entry.cacheKey.level, 0)
   else:
-    let parentCursor = scene.viewEntries[parent].shellCursor
+    let parentCursor = scene.viewEntries[parent].contentCursor
     entry.placementHandle =
       scene.tree.moveFragment(entry.placementHandle, parentCursor, 0)
   entry.externalParent = parent
@@ -505,21 +544,25 @@ proc reconcileOrders(
 
   for frame in frames:
     let
-      entry = scene.viewEntries[frame.viewId]
+      entry = addr scene.viewEntries[frame.viewId]
       parent = frame.externalParent(viewLevels)
     if parent.uint64 == 0:
-      rootOrders[frame.cacheKey.level].add entry.placementHandle
+      rootOrders[frame.cacheKey.level].add entry[].placementHandle
     else:
-      childOrders[parent].add entry.placementHandle
-    for extra in entry.extraLayers:
-      rootOrders[extra.level].add entry.extraHandles[extra.level]
+      childOrders[parent].add entry[].placementHandle
+    for extra in entry[].extraLayers:
+      rootOrders[extra.level].add entry[].extraHandles[extra.level]
 
   for frame in frames:
-    let entry = scene.viewEntries[frame.viewId]
+    let entry = addr scene.viewEntries[frame.viewId]
     scene.tree.reorderChildFragments(
-      entry.placementCursor, [entry.shellHandle, entry.escapedHandle]
+      entry[].placementCursor, [entry[].shellHandle, entry[].escapedTransformHandle]
     )
-    scene.tree.reorderChildFragments(entry.shellCursor, childOrders[frame.viewId])
+    scene.tree.reorderChildFragments(entry[].shellCursor, [entry[].contentHandle])
+    scene.tree.reorderChildFragments(entry[].contentCursor, childOrders[frame.viewId])
+    scene.tree.reorderChildFragments(
+      entry[].escapedTransformCursor, [entry[].escapedHandle]
+    )
   scene.rootFragments.setLen(0)
   for level in levels:
     scene.tree.reorderRootFragments(level, rootOrders[level])
@@ -566,34 +609,33 @@ proc reconcile*(
     if existed and scene.viewEntries[frame.viewId].cacheKey.level != frame.cacheKey.level:
       levelChanged = true
 
-    var entry =
-      if existed:
-        scene.viewEntries[frame.viewId]
-      else:
+    if not existed:
+      scene.viewEntries[frame.viewId] =
         ViewRenderEntry(extraHandles: initTable[ZLevel, RenderFragmentHandle]())
+    let entry = addr scene.viewEntries[frame.viewId]
     if frame.captured:
-      if existed and not entry.extraLayers.sameLayerShape(frame.extraLayers):
+      if existed and not entry[].extraLayers.sameLayerShape(frame.extraLayers):
         topologyChanged = true
-      entry.cacheKey = frame.cacheKey
-      entry.placement = move frame.placement
-      entry.shell = move frame.shell
-      entry.selfContents = move frame.selfContents
-      entry.escapedContents = move frame.escapedContents
-      entry.extraLayers = move frame.extraLayers
-      entry.resources = move frame.resources
-      entry.usesVisibleRect = frame.usesVisibleRect
-      entry.captureGeneration.advance()
+      entry[].cacheKey = frame.cacheKey
+      entry[].placement = move frame.placement
+      entry[].shell = move frame.shell
+      entry[].contentTransform = move frame.contentTransform
+      entry[].escapedTransform = move frame.escapedTransform
+      entry[].selfContents = move frame.selfContents
+      entry[].escapedContents = move frame.escapedContents
+      entry[].extraLayers = move frame.extraLayers
+      entry[].resources = move frame.resources
+      entry[].usesVisibleRect = frame.usesVisibleRect
+      entry[].captureGeneration.advance()
       capturedViews.add frame.viewId
       changedViews.add frame.viewId
       changed = true
     elif frame.placementChanged:
-      entry.refreshPlacementNodes(frame.cacheKey)
+      entry[].refreshPlacementNodes(frame.cacheKey)
       changedViews.add frame.viewId
       changed = true
-    elif entry.cacheKey != frame.cacheKey:
+    elif entry[].cacheKey != frame.cacheKey:
       raise newException(ValueError, "a changed render view must include an update")
-    if frame.captured or frame.placementChanged:
-      scene.viewEntries[frame.viewId] = entry
 
   var removed: seq[RenderViewId]
   for viewId in scene.viewEntries.keys:
@@ -623,32 +665,26 @@ proc reconcile*(
       scene.viewEntries.del(viewId)
     scene.rebuildTree(frames, levels)
   else:
-    var viewLevels = initTable[RenderViewId, ZLevel]()
-    for frame in frames:
-      viewLevels[frame.viewId] = frame.cacheKey.level
-
     if topologyChanged:
+      var viewLevels = initTable[RenderViewId, ZLevel]()
       for frame in frames:
-        var entry = scene.viewEntries[frame.viewId]
-        if not scene.tree.isValid(entry.placementHandle):
-          scene.attachViewEntry(entry, frame.externalParent(viewLevels))
+        viewLevels[frame.viewId] = frame.cacheKey.level
+      for frame in frames:
+        let entry = addr scene.viewEntries[frame.viewId]
+        if not scene.tree.isValid(entry[].placementHandle):
+          scene.attachViewEntry(entry[], frame.externalParent(viewLevels))
         else:
-          scene.moveViewEntry(entry, frame.externalParent(viewLevels))
+          scene.moveViewEntry(entry[], frame.externalParent(viewLevels))
           if frame.captured:
-            scene.updateCapturedEntry(entry)
+            scene.updateCapturedEntry(entry[])
           elif frame.placementChanged:
-            scene.updatePlacementEntry(entry)
-        scene.viewEntries[frame.viewId] = entry
+            scene.updatePlacementEntry(entry[])
     else:
       for frame in frames:
         if frame.captured:
-          var entry = scene.viewEntries[frame.viewId]
-          scene.updateCapturedEntry(entry)
-          scene.viewEntries[frame.viewId] = entry
+          scene.updateCapturedEntry(scene.viewEntries[frame.viewId])
         elif frame.placementChanged:
-          var entry = scene.viewEntries[frame.viewId]
-          scene.updatePlacementEntry(entry)
-          scene.viewEntries[frame.viewId] = entry
+          scene.updatePlacementEntry(scene.viewEntries[frame.viewId])
 
     for viewId in removed:
       scene.detachEntry(scene.viewEntries[viewId])
@@ -694,6 +730,8 @@ proc transferFrame(
   if captured:
     result.placement = entry.placement.isolateFig()
     result.shell = entry.shell.isolateFig()
+    result.contentTransform = entry.contentTransform.isolateFig()
+    result.escapedTransform = entry.escapedTransform.isolateFig()
     result.selfContents = entry.selfContents.isolateRenderList()
     result.escapedContents = entry.escapedContents.isolateRenderList()
     result.extraLayers = entry.extraLayers.copyLayerContributions()
@@ -726,11 +764,11 @@ proc newRenderSceneUpdate*(
   result.baseLevel = scene.baseLevel
   result.frames = newSeqOfCap[RenderViewFrame](scene.placements.len)
   for placement in scene.placements:
-    let entry = scene.viewEntries[placement.viewId]
-    result.frames.add entry.transferFrame(
+    let entry = addr scene.viewEntries[placement.viewId]
+    result.frames.add entry[].transferFrame(
       placement,
-      full or entry.changeGeneration > acknowledgedGeneration,
-      full or entry.captureChangeGeneration > acknowledgedGeneration,
+      full or entry[].changeGeneration > acknowledgedGeneration,
+      full or entry[].captureChangeGeneration > acknowledgedGeneration,
     )
   result.resources = scene.liveResources.snapshot()
 
@@ -850,12 +888,17 @@ proc viewCaptureGeneration*(scene: RenderScene, id: RenderViewId): uint64 =
     result = scene.viewEntries[id].captureGeneration
 
 proc viewFragmentIds*(scene: RenderScene, id: RenderViewId): seq[uint64] =
-  ## Returns stable placement, shell, self, and escaped IDs for diagnostics.
+  ## Returns stable placement, shell, content, self, and escaped IDs for diagnostics.
   if scene.isNil or id notin scene.viewEntries:
     return
-  let entry = scene.viewEntries[id]
+  let entry = addr scene.viewEntries[id]
   for handle in [
-    entry.placementHandle, entry.shellHandle, entry.selfHandle, entry.escapedHandle
+    entry[].placementHandle,
+    entry[].shellHandle,
+    entry[].contentHandle,
+    entry[].selfHandle,
+    entry[].escapedTransformHandle,
+    entry[].escapedHandle,
   ]:
     if scene.tree.isValid(handle):
       result.add handle.fragmentId()

--- a/src/merenda/nimkit/drawing/renderscenes.nim
+++ b/src/merenda/nimkit/drawing/renderscenes.nim
@@ -493,6 +493,26 @@ proc materialize*(scene: RenderScene): Renders =
     raise newException(ValueError, "cannot materialize a nil render scene")
   scene.tree.materialize()
 
+proc renderRoot*(scene: RenderScene, context: BackendContext) =
+  ## Sends the retained fragment graph directly through FigDraw's renderer traversal.
+  if scene.isNil:
+    raise newException(ValueError, "cannot render a nil render scene")
+  context.renderRoot(scene.tree)
+
+proc renderFrame*[BackendState](
+    scene: RenderScene,
+    renderer: FigRenderer[BackendState],
+    frameSize: Vec2,
+    clearMain = true,
+    clearFrameColor = color(1.0, 1.0, 1.0, 1.0),
+) =
+  ## Renders the retained fragment graph without creating a monolithic snapshot.
+  if scene.isNil:
+    raise newException(ValueError, "cannot render a nil render scene")
+  renderer.renderFrame(
+    scene.tree, frameSize, clearMain = clearMain, clearColor = clearFrameColor
+  )
+
 proc frameGeneration*(scene: RenderScene): uint64 =
   if not scene.isNil:
     result = scene.generation

--- a/src/merenda/nimkit/drawing/renderscenes.nim
+++ b/src/merenda/nimkit/drawing/renderscenes.nim
@@ -62,6 +62,7 @@ type
     extraHandles: Table[ZLevel, RenderFragmentHandle]
     externalParent: RenderViewId
     captureGeneration: uint64
+    changeGeneration: uint64
 
   RetiredRenderResources = object
     releaseGeneration: uint64
@@ -78,8 +79,31 @@ type
     perViewMode: bool
     liveResources: RenderResourceManifest
     retiredResources: seq[RetiredRenderResources]
+    identity: uint64
+    baseLevel: ZLevel
+    replicaMode: bool
+    fullTransferGeneration: uint64
 
-var renderViewIdCounter: uint64
+  RenderSceneUpdate* = object
+    ## Move-only cumulative update for a renderer-owned scene replica.
+    ##
+    ## Every update contains the complete current placement order, but only
+    ## contributions changed after `baseGeneration` carry node payloads. A full
+    ## update carries every payload and acts as an ordering barrier.
+    sceneIdentity: uint64
+    baseGeneration: uint64
+    generation: uint64
+    full: bool
+    baseLevel: ZLevel
+    frames: seq[RenderViewFrame]
+    resources: RenderResourceSnapshot
+
+var
+  renderViewIdCounter: uint64
+  renderSceneIdCounter: uint64
+
+proc `=copy`*(destination: var RenderSceneUpdate, source: RenderSceneUpdate) {.error.}
+proc `=dup`*(source: RenderSceneUpdate): RenderSceneUpdate {.error.}
 
 func `==`*(a, b: RenderViewId): bool {.borrow.}
 func hash*(id: RenderViewId): Hash {.borrow.}
@@ -94,10 +118,24 @@ proc nextRenderViewId*(): RenderViewId =
   renderViewIdCounter.advance()
   renderViewIdCounter.RenderViewId
 
-proc newRenderScene*(): RenderScene =
+proc nextRenderSceneId(): uint64 =
+  renderSceneIdCounter.advance()
+  renderSceneIdCounter
+
+proc initRenderScene(identity: uint64): RenderScene =
   RenderScene(
-    tree: newRenderFragments(), viewEntries: initTable[RenderViewId, ViewRenderEntry]()
+    tree: newRenderFragments(),
+    viewEntries: initTable[RenderViewId, ViewRenderEntry](),
+    identity: identity,
   )
+
+proc newRenderScene*(): RenderScene =
+  initRenderScene(nextRenderSceneId())
+
+proc newRenderSceneReplica*(): RenderScene =
+  ## Creates renderer-owned storage whose application identity comes from updates.
+  result = initRenderScene(0)
+  result.replicaMode = true
 
 proc copyRenderList(list: RenderList): RenderList =
   result.nodes = newSeqOfCap[Fig](list.nodes.len)
@@ -106,6 +144,48 @@ proc copyRenderList(list: RenderList): RenderList =
   result.rootIds = newSeqOfCap[FigIdx](list.rootIds.len)
   for root in list.rootIds:
     result.rootIds.add root
+
+proc isolateSequence[T](values: openArray[T]): seq[T] =
+  result = newSeqOfCap[T](values.len)
+  for value in values:
+    result.add value
+
+proc isolateGlyphArrangement(layout: GlyphArrangement): GlyphArrangement =
+  result = layout
+  result.lines = layout.lines.isolateSequence()
+  result.spans = layout.spans.isolateSequence()
+  result.fonts = layout.fonts.isolateSequence()
+  result.spanColors = layout.spanColors.isolateSequence()
+  result.sourceRunes = layout.sourceRunes.isolateSequence()
+  result.arrangedGlyphs = layout.arrangedGlyphs.isolateSequence()
+  result.runes = layout.runes.isolateSequence()
+  result.positions = layout.positions.isolateSequence()
+  result.selectionRects = layout.selectionRects.isolateSequence()
+
+proc isolateDrawableOp(operation: DrawableOp): DrawableOp =
+  result = operation
+  if operation.kind == dkBezier:
+    result.controls = operation.controls.isolateSequence()
+
+proc isolateFig(node: Fig): Fig =
+  result = node
+  case node.kind
+  of nkText:
+    result.textLayout = node.textLayout.isolateGlyphArrangement()
+  of nkDrawable:
+    result.drawOps = newSeqOfCap[DrawableOp](node.drawOps.len)
+    for operation in node.drawOps:
+      result.drawOps.add operation.isolateDrawableOp()
+  else:
+    discard
+
+proc isolateRenderList(list: RenderList): RenderList =
+  ## Clones nested glyph/drawable sequences as well as the outer node storage.
+  ## Renderer updates must not share ARC-managed payloads with the UI scene.
+  result.nodes = newSeqOfCap[Fig](list.nodes.len)
+  for node in list.nodes:
+    result.nodes.add node.isolateFig()
+  result.rootIds = list.rootIds.isolateSequence()
 
 proc shellRenderList(node: Fig): RenderList =
   discard result.addRoot(node)
@@ -230,19 +310,25 @@ proc desiredLevels(
         result.add extra.level
 
 proc attachRoot(
-    scene: RenderScene, level: ZLevel, contents: RenderList
+    scene: RenderScene, level: ZLevel, contents: var RenderList
 ): RenderFragmentHandle =
-  scene.tree.attachRootFragment(level, 0, contents.copyRenderList())
+  if scene.replicaMode:
+    scene.tree.attachRootFragment(level, 0, move contents)
+  else:
+    scene.tree.attachRootFragment(level, 0, contents.copyRenderList())
 
 proc attachChild(
-    scene: RenderScene, parent: RenderCursor, contents: RenderList
+    scene: RenderScene, parent: RenderCursor, contents: var RenderList
 ): RenderFragmentHandle =
-  scene.tree.attachChildFragment(parent, 0, contents.copyRenderList())
+  if scene.replicaMode:
+    scene.tree.attachChildFragment(parent, 0, move contents)
+  else:
+    scene.tree.attachChildFragment(parent, 0, contents.copyRenderList())
 
 proc attachViewEntry(
     scene: RenderScene, entry: var ViewRenderEntry, parent: RenderViewId
 ) =
-  let shellList = entry.shell.shellRenderList()
+  var shellList = entry.shell.shellRenderList()
   if parent.uint64 == 0:
     entry.shellHandle = scene.attachRoot(entry.cacheKey.level, shellList)
   else:
@@ -263,7 +349,7 @@ proc attachViewEntry(
       scene.attachChild(scene.viewEntries[parent].shellCursor, entry.escapedContents)
 
   entry.extraHandles = initTable[ZLevel, RenderFragmentHandle]()
-  for extra in entry.extraLayers:
+  for extra in entry.extraLayers.mitems:
     entry.extraHandles[extra.level] = scene.attachRoot(extra.level, extra.contents)
   entry.externalParent = parent
 
@@ -293,19 +379,30 @@ proc rebuildTree(
 
 proc updateCapturedEntry(scene: RenderScene, entry: var ViewRenderEntry) =
   scene.tree.updateNode(entry.shellCursor, entry.shell)
-  entry.selfHandle =
-    scene.tree.replaceFragment(entry.selfHandle, entry.selfContents.copyRenderList())
-  entry.escapedHandle = scene.tree.replaceFragment(
-    entry.escapedHandle, entry.escapedContents.copyRenderList()
-  )
+  if scene.replicaMode:
+    entry.selfHandle =
+      scene.tree.replaceFragment(entry.selfHandle, move entry.selfContents)
+    entry.escapedHandle =
+      scene.tree.replaceFragment(entry.escapedHandle, move entry.escapedContents)
+  else:
+    entry.selfHandle =
+      scene.tree.replaceFragment(entry.selfHandle, entry.selfContents.copyRenderList())
+    entry.escapedHandle = scene.tree.replaceFragment(
+      entry.escapedHandle, entry.escapedContents.copyRenderList()
+    )
 
   var retained = initTable[ZLevel, bool]()
-  for extra in entry.extraLayers:
+  for extra in entry.extraLayers.mitems:
     retained[extra.level] = true
     if extra.level in entry.extraHandles:
-      entry.extraHandles[extra.level] = scene.tree.replaceFragment(
-        entry.extraHandles[extra.level], extra.contents.copyRenderList()
-      )
+      if scene.replicaMode:
+        entry.extraHandles[extra.level] = scene.tree.replaceFragment(
+          entry.extraHandles[extra.level], move extra.contents
+        )
+      else:
+        entry.extraHandles[extra.level] = scene.tree.replaceFragment(
+          entry.extraHandles[extra.level], extra.contents.copyRenderList()
+        )
     else:
       entry.extraHandles[extra.level] = scene.attachRoot(extra.level, extra.contents)
 
@@ -378,7 +475,7 @@ proc mergeEntryResources(
     result.addResources(scene.viewEntries[frame.viewId].resources)
 
 proc reconcile*(
-    scene: RenderScene, frames: openArray[RenderViewFrame], baseLevel: ZLevel
+    scene: RenderScene, frames: var seq[RenderViewFrame], baseLevel: ZLevel
 ): bool {.discardable.} =
   ## Reconciles one frame while retaining clean per-view drawing fragments.
   ##
@@ -395,8 +492,9 @@ proc reconcile*(
     changed = topologyChanged
     levelChanged = false
     seen = initTable[RenderViewId, bool]()
+    changedViews: seq[RenderViewId]
 
-  for frame in frames:
+  for frame in frames.mitems:
     seen[frame.viewId] = true
     let existed = frame.viewId in scene.viewEntries and scene.perViewMode
     if not existed and not frame.captured:
@@ -415,12 +513,13 @@ proc reconcile*(
       if existed and not entry.extraLayers.sameLayerShape(frame.extraLayers):
         topologyChanged = true
       entry.cacheKey = frame.cacheKey
-      entry.shell = frame.shell
-      entry.selfContents = frame.selfContents.copyRenderList()
-      entry.escapedContents = frame.escapedContents.copyRenderList()
-      entry.extraLayers = frame.extraLayers
-      entry.resources = frame.resources
+      entry.shell = move frame.shell
+      entry.selfContents = move frame.selfContents
+      entry.escapedContents = move frame.escapedContents
+      entry.extraLayers = move frame.extraLayers
+      entry.resources = move frame.resources
       entry.captureGeneration.advance()
+      changedViews.add frame.viewId
       changed = true
     elif entry.cacheKey != frame.cacheKey:
       raise newException(ValueError, "a changed render view must include a capture")
@@ -442,6 +541,11 @@ proc reconcile*(
 
   var nextGeneration = scene.generation
   nextGeneration.advance()
+
+  for viewId in changedViews:
+    scene.viewEntries[viewId].changeGeneration = nextGeneration
+  if rebuild:
+    scene.fullTransferGeneration = nextGeneration
 
   if rebuild:
     for viewId in removed:
@@ -483,9 +587,126 @@ proc reconcile*(
   scene.liveResources = resources
   scene.placements = placements
   scene.rootLevels = levels
+  scene.baseLevel = baseLevel
   scene.generation = nextGeneration
   scene.perViewMode = true
   true
+
+proc copyLayerContributions(
+    layers: openArray[RenderLayerContribution]
+): seq[RenderLayerContribution] =
+  result = newSeqOfCap[RenderLayerContribution](layers.len)
+  for layer in layers:
+    result.add RenderLayerContribution(
+      level: layer.level, contents: layer.contents.isolateRenderList()
+    )
+
+proc transferFrame(
+    entry: ViewRenderEntry, placement: ViewPlacement, captured: bool
+): RenderViewFrame =
+  result = RenderViewFrame(
+    viewId: placement.viewId,
+    parentViewId: placement.parentViewId,
+    cacheKey: entry.cacheKey,
+    captured: captured,
+  )
+  if captured:
+    result.shell = entry.shell.isolateFig()
+    result.selfContents = entry.selfContents.isolateRenderList()
+    result.escapedContents = entry.escapedContents.isolateRenderList()
+    result.extraLayers = entry.extraLayers.copyLayerContributions()
+
+proc newRenderSceneUpdate*(
+    scene: RenderScene,
+    acknowledgedSceneIdentity: uint64,
+    acknowledgedGeneration: uint64,
+    forceFull = false,
+): RenderSceneUpdate =
+  ## Builds a self-contained cumulative update from an acknowledged baseline.
+  ##
+  ## The update owns independent node sequences. It can therefore be moved to a
+  ## renderer thread without sharing the mutable application scene or its
+  ## FigDraw fragment handles.
+  if scene.isNil:
+    raise newException(ValueError, "cannot transfer a nil render scene")
+  if not scene.perViewMode:
+    raise newException(ValueError, "only reconciled per-view scenes can be transferred")
+
+  let full =
+    forceFull or acknowledgedSceneIdentity != scene.identity or
+    acknowledgedGeneration == 0 or acknowledgedGeneration > scene.generation or
+    scene.fullTransferGeneration > acknowledgedGeneration
+  result.sceneIdentity = scene.identity
+  result.baseGeneration = if full: 0 else: acknowledgedGeneration
+  result.generation = scene.generation
+  result.full = full
+  result.baseLevel = scene.baseLevel
+  result.frames = newSeqOfCap[RenderViewFrame](scene.placements.len)
+  for placement in scene.placements:
+    let entry = scene.viewEntries[placement.viewId]
+    result.frames.add entry.transferFrame(
+      placement, full or entry.changeGeneration > acknowledgedGeneration
+    )
+  result.resources = scene.liveResources.snapshot()
+
+func sceneIdentity*(scene: RenderScene): uint64 =
+  if scene.isNil: 0 else: scene.identity
+
+func sceneIdentity*(update: RenderSceneUpdate): uint64 =
+  update.sceneIdentity
+
+func baseGeneration*(update: RenderSceneUpdate): uint64 =
+  update.baseGeneration
+
+func generation*(update: RenderSceneUpdate): uint64 =
+  update.generation
+
+func fullSnapshot*(update: RenderSceneUpdate): bool =
+  update.full
+
+func capturedViewCount*(update: RenderSceneUpdate): Natural =
+  for frame in update.frames:
+    if frame.captured:
+      inc result
+
+func viewCount*(update: RenderSceneUpdate): Natural =
+  update.frames.len.Natural
+
+func canApply*(
+    update: RenderSceneUpdate, currentSceneIdentity, currentGeneration: uint64
+): bool =
+  ## Checks ordering without consulting renderer-local fragment generations.
+  ##
+  ## Cumulative updates can apply to a renderer newer than their baseline, but
+  ## never to an older one. Full updates establish a new ordering epoch.
+  if update.sceneIdentity == 0 or update.generation == 0:
+    return false
+  if update.full:
+    return
+      update.sceneIdentity != currentSceneIdentity or
+      update.generation >= currentGeneration
+  update.sceneIdentity == currentSceneIdentity and
+    update.baseGeneration <= currentGeneration and update.generation >= currentGeneration
+
+proc apply*(scene: RenderScene, update: var RenderSceneUpdate) =
+  ## Applies an accepted update to renderer-owned scene storage.
+  if scene.isNil:
+    raise newException(ValueError, "cannot update a nil renderer scene")
+  if not update.canApply(scene.identity, scene.generation):
+    raise
+      newException(ValueError, "render-scene update is stale or has a generation gap")
+  if update.full:
+    for frame in update.frames:
+      if not frame.captured:
+        raise
+          newException(ValueError, "a full render-scene update must capture every view")
+  discard scene.reconcile(update.frames, update.baseLevel)
+  scene.identity = update.sceneIdentity
+  scene.generation = update.generation
+
+proc takeResources*(update: var RenderSceneUpdate): RenderResourceSnapshot =
+  ## Moves the update's thread-safe live-resource identities to its receiver.
+  result = move update.resources
 
 proc materialize*(scene: RenderScene): Renders =
   ## Returns an independent monolithic snapshot for diagnostics and transfer.

--- a/src/merenda/nimkit/drawing/renderscenes.nim
+++ b/src/merenda/nimkit/drawing/renderscenes.nim
@@ -1,9 +1,20 @@
 ## Retained, per-view render scenes built on FigDraw fragment attachments.
 ##
-## Each visible view owns a stable shell fragment, a replaceable self-drawing
-## fragment, an escaped-sibling fragment, and zero or more extra-layer root
-## fragments. Child view shells attach beneath their parent's shell, so replacing
-## one view's self drawing cannot detach descendant or sibling identities.
+## Each visible view owns a one-node placement transform fragment. That transform
+## owns a stable background/clip shell, a replaceable self-drawing fragment,
+## escaped drawing outside the clip, and child placement fragments::
+##
+##   placement transform
+##   +-- background/clip shell
+##   |   +-- self drawing
+##   |   +-- child placement transform
+##   +-- escaped drawing
+##
+## Scrolling or moving an ancestor updates only placement transform nodes. It does
+## not rebuild a descendant's drawing unless that drawing read
+## `DrawContext.visibleRect`; that dependency is recorded during capture. Explicit
+## layers use equivalent layer-root transforms. Stable fragment IDs and nested
+## attachments therefore survive placement-only updates.
 
 import std/[hashes, tables]
 
@@ -17,10 +28,11 @@ type
     ## Stable application-thread identity for a NimKit view.
 
   RenderViewCacheKey* = object
-    ## Inputs that can change one view's captured drawing without changing its ID.
+    ## Drawing and placement inputs for one stable view identity.
     displayRevision*: uint64
     appearanceGeneration*: uint64
     frame*: Rect
+    placement*: Point
     bounds*: Rect
     visibleRect*: Rect
     level*: ZLevel
@@ -32,16 +44,19 @@ type
     contents*: RenderList
 
   RenderViewFrame* = object
-    ## One visible view's placement and optional freshly captured contribution.
+    ## One visible view's changed placement and optional drawing contribution.
     viewId*: RenderViewId
     parentViewId*: RenderViewId
     cacheKey*: RenderViewCacheKey
+    placementChanged*: bool
     captured*: bool
+    placement*: Fig
     shell*: Fig
     selfContents*: RenderList
     escapedContents*: RenderList
     extraLayers*: seq[RenderLayerContribution]
     resources*: RenderResourceManifest
+    usesVisibleRect*: bool
 
   ViewPlacement = object
     viewId: RenderViewId
@@ -50,11 +65,15 @@ type
 
   ViewRenderEntry = object
     cacheKey: RenderViewCacheKey
+    placement: Fig
     shell: Fig
     selfContents: RenderList
     escapedContents: RenderList
     extraLayers: seq[RenderLayerContribution]
     resources: RenderResourceManifest
+    usesVisibleRect: bool
+    placementHandle: RenderFragmentHandle
+    placementCursor: RenderCursor
     shellHandle: RenderFragmentHandle
     shellCursor: RenderCursor
     selfHandle: RenderFragmentHandle
@@ -63,6 +82,7 @@ type
     externalParent: RenderViewId
     captureGeneration: uint64
     changeGeneration: uint64
+    captureChangeGeneration: uint64
 
   RetiredRenderResources = object
     releaseGeneration: uint64
@@ -88,8 +108,9 @@ type
     ## Move-only cumulative update for a renderer-owned scene replica.
     ##
     ## Every update contains the complete current placement order, but only
-    ## contributions changed after `baseGeneration` carry node payloads. A full
-    ## update carries every payload and acts as an ordering barrier.
+    ## contributions changed after `baseGeneration` carry drawing payloads.
+    ## Placement-only changes carry cache keys and update retained transform nodes.
+    ## A full update carries every payload and acts as an ordering barrier.
     sceneIdentity: uint64
     baseGeneration: uint64
     generation: uint64
@@ -187,7 +208,7 @@ proc isolateRenderList(list: RenderList): RenderList =
     result.nodes.add node.isolateFig()
   result.rootIds = list.rootIds.isolateSequence()
 
-proc shellRenderList(node: Fig): RenderList =
+proc nodeRenderList(node: Fig): RenderList =
   discard result.addRoot(node)
 
 proc buildFragmentTree(
@@ -253,7 +274,20 @@ proc needsViewCapture*(
   ## Reports whether this scene lacks a current contribution for `viewId`.
   if scene.isNil or not scene.perViewMode or viewId notin scene.viewEntries:
     return true
-  scene.viewEntries[viewId].cacheKey != cacheKey
+  let entry = scene.viewEntries[viewId]
+  let cached = entry.cacheKey
+  cached.displayRevision != cacheKey.displayRevision or
+    cached.appearanceGeneration != cacheKey.appearanceGeneration or
+    cached.frame.size != cacheKey.frame.size or cached.bounds != cacheKey.bounds or
+    (entry.usesVisibleRect and cached.visibleRect != cacheKey.visibleRect) or
+    cached.level != cacheKey.level or cached.isRoot != cacheKey.isRoot
+
+proc needsViewPlacementUpdate*(
+    scene: RenderScene, viewId: RenderViewId, cacheKey: RenderViewCacheKey
+): bool =
+  ## Reports whether the view's retained transform placement changed.
+  scene.isNil or not scene.perViewMode or viewId notin scene.viewEntries or
+    scene.viewEntries[viewId].cacheKey != cacheKey
 
 proc externalParent(
     frame: RenderViewFrame, levels: Table[RenderViewId, ZLevel]
@@ -328,25 +362,29 @@ proc attachChild(
 proc attachViewEntry(
     scene: RenderScene, entry: var ViewRenderEntry, parent: RenderViewId
 ) =
-  var shellList = entry.shell.shellRenderList()
+  var placementList = entry.placement.nodeRenderList()
   if parent.uint64 == 0:
-    entry.shellHandle = scene.attachRoot(entry.cacheKey.level, shellList)
+    entry.placementHandle = scene.attachRoot(entry.cacheKey.level, placementList)
   else:
-    entry.shellHandle =
-      scene.attachChild(scene.viewEntries[parent].shellCursor, shellList)
+    entry.placementHandle =
+      scene.attachChild(scene.viewEntries[parent].shellCursor, placementList)
 
-  let roots = scene.tree.fragmentRoots(entry.shellHandle)
+  let roots = scene.tree.fragmentRoots(entry.placementHandle)
   if roots.len != 1:
+    raise newException(
+      ValueError, "a view placement fragment must contain exactly one root"
+    )
+  entry.placementCursor = roots[0]
+
+  var shellList = entry.shell.nodeRenderList()
+  entry.shellHandle = scene.attachChild(entry.placementCursor, shellList)
+  let shellRoots = scene.tree.fragmentRoots(entry.shellHandle)
+  if shellRoots.len != 1:
     raise
       newException(ValueError, "a view shell fragment must contain exactly one root")
-  entry.shellCursor = roots[0]
+  entry.shellCursor = shellRoots[0]
   entry.selfHandle = scene.attachChild(entry.shellCursor, entry.selfContents)
-
-  if parent.uint64 == 0:
-    entry.escapedHandle = scene.attachRoot(entry.cacheKey.level, entry.escapedContents)
-  else:
-    entry.escapedHandle =
-      scene.attachChild(scene.viewEntries[parent].shellCursor, entry.escapedContents)
+  entry.escapedHandle = scene.attachChild(entry.placementCursor, entry.escapedContents)
 
   entry.extraHandles = initTable[ZLevel, RenderFragmentHandle]()
   for extra in entry.extraLayers.mitems:
@@ -357,10 +395,8 @@ proc detachEntry(scene: RenderScene, entry: ViewRenderEntry) =
   for _, handle in entry.extraHandles:
     if scene.tree.isValid(handle):
       scene.tree.removeFragment(handle)
-  if scene.tree.isValid(entry.escapedHandle):
-    scene.tree.removeFragment(entry.escapedHandle)
-  if scene.tree.isValid(entry.shellHandle):
-    scene.tree.removeFragment(entry.shellHandle)
+  if scene.tree.isValid(entry.placementHandle):
+    scene.tree.removeFragment(entry.placementHandle)
 
 proc rebuildTree(
     scene: RenderScene, frames: openArray[RenderViewFrame], levels: seq[ZLevel]
@@ -377,7 +413,30 @@ proc rebuildTree(
     scene.attachViewEntry(entry, frame.externalParent(viewLevels))
     scene.viewEntries[frame.viewId] = entry
 
+proc refreshPlacementNodes(entry: var ViewRenderEntry, cacheKey: RenderViewCacheKey) =
+  entry.cacheKey = cacheKey
+  entry.placement.transform.translation =
+    vec2(cacheKey.placement.x, cacheKey.placement.y)
+  for extra in entry.extraLayers.mitems:
+    if extra.contents.rootIds.len != 1:
+      raise newException(ValueError, "an extra-layer placement must have one root")
+    let root = extra.contents.rootIds[0]
+    if extra.contents.nodes[root.int].kind != nkTransform:
+      raise
+        newException(ValueError, "an extra-layer placement root must be a transform")
+    extra.contents.nodes[root.int].transform.translation =
+      vec2(cacheKey.frame.origin.x, cacheKey.frame.origin.y)
+
+proc updatePlacementEntry(scene: RenderScene, entry: var ViewRenderEntry) =
+  scene.tree.updateNode(entry.placementCursor, entry.placement)
+  for extra in entry.extraLayers:
+    let roots = scene.tree.fragmentRoots(entry.extraHandles[extra.level])
+    if roots.len != 1:
+      raise newException(ValueError, "an extra-layer fragment must have one root")
+    scene.tree.updateNode(roots[0], extra.contents.nodes[extra.contents.rootIds[0].int])
+
 proc updateCapturedEntry(scene: RenderScene, entry: var ViewRenderEntry) =
+  scene.tree.updateNode(entry.placementCursor, entry.placement)
   scene.tree.updateNode(entry.shellCursor, entry.shell)
   if scene.replicaMode:
     entry.selfHandle =
@@ -422,14 +481,12 @@ proc moveViewEntry(
   if entry.externalParent == parent:
     return
   if parent.uint64 == 0:
-    entry.shellHandle =
-      scene.tree.moveFragmentToRoot(entry.shellHandle, entry.cacheKey.level, 0)
-    entry.escapedHandle =
-      scene.tree.moveFragmentToRoot(entry.escapedHandle, entry.cacheKey.level, 0)
+    entry.placementHandle =
+      scene.tree.moveFragmentToRoot(entry.placementHandle, entry.cacheKey.level, 0)
   else:
     let parentCursor = scene.viewEntries[parent].shellCursor
-    entry.shellHandle = scene.tree.moveFragment(entry.shellHandle, parentCursor, 0)
-    entry.escapedHandle = scene.tree.moveFragment(entry.escapedHandle, parentCursor, 0)
+    entry.placementHandle =
+      scene.tree.moveFragment(entry.placementHandle, parentCursor, 0)
   entry.externalParent = parent
 
 proc reconcileOrders(
@@ -451,16 +508,17 @@ proc reconcileOrders(
       entry = scene.viewEntries[frame.viewId]
       parent = frame.externalParent(viewLevels)
     if parent.uint64 == 0:
-      rootOrders[frame.cacheKey.level].add entry.shellHandle
-      rootOrders[frame.cacheKey.level].add entry.escapedHandle
+      rootOrders[frame.cacheKey.level].add entry.placementHandle
     else:
-      childOrders[parent].add entry.shellHandle
-      childOrders[parent].add entry.escapedHandle
+      childOrders[parent].add entry.placementHandle
     for extra in entry.extraLayers:
       rootOrders[extra.level].add entry.extraHandles[extra.level]
 
   for frame in frames:
     let entry = scene.viewEntries[frame.viewId]
+    scene.tree.reorderChildFragments(
+      entry.placementCursor, [entry.shellHandle, entry.escapedHandle]
+    )
     scene.tree.reorderChildFragments(entry.shellCursor, childOrders[frame.viewId])
   scene.rootFragments.setLen(0)
   for level in levels:
@@ -480,8 +538,9 @@ proc reconcile*(
   ## Reconciles one frame while retaining clean per-view drawing fragments.
   ##
   ## `frames` must be in depth-first view order, with parents before children.
-  ## A captured entry atomically updates its shell, self, escaped, and extra-layer
-  ## outputs. Clean entries only participate in placement and ordering.
+  ## A captured entry atomically updates its placement, shell, self, escaped, and
+  ## extra-layer outputs. Placement-only entries update retained transforms. Clean
+  ## entries only participate in ordering.
   if scene.isNil:
     raise newException(ValueError, "cannot update a nil render scene")
   frames.validateFrames()
@@ -493,12 +552,15 @@ proc reconcile*(
     levelChanged = false
     seen = initTable[RenderViewId, bool]()
     changedViews: seq[RenderViewId]
+    capturedViews: seq[RenderViewId]
 
   for frame in frames.mitems:
     seen[frame.viewId] = true
     let existed = frame.viewId in scene.viewEntries and scene.perViewMode
     if not existed and not frame.captured:
       raise newException(ValueError, "a new render view must include a capture")
+    if frame.captured and not frame.placementChanged:
+      raise newException(ValueError, "a captured render view must include placement")
     if not existed:
       topologyChanged = true
     if existed and scene.viewEntries[frame.viewId].cacheKey.level != frame.cacheKey.level:
@@ -513,17 +575,24 @@ proc reconcile*(
       if existed and not entry.extraLayers.sameLayerShape(frame.extraLayers):
         topologyChanged = true
       entry.cacheKey = frame.cacheKey
+      entry.placement = move frame.placement
       entry.shell = move frame.shell
       entry.selfContents = move frame.selfContents
       entry.escapedContents = move frame.escapedContents
       entry.extraLayers = move frame.extraLayers
       entry.resources = move frame.resources
+      entry.usesVisibleRect = frame.usesVisibleRect
       entry.captureGeneration.advance()
+      capturedViews.add frame.viewId
+      changedViews.add frame.viewId
+      changed = true
+    elif frame.placementChanged:
+      entry.refreshPlacementNodes(frame.cacheKey)
       changedViews.add frame.viewId
       changed = true
     elif entry.cacheKey != frame.cacheKey:
-      raise newException(ValueError, "a changed render view must include a capture")
-    if frame.captured:
+      raise newException(ValueError, "a changed render view must include an update")
+    if frame.captured or frame.placementChanged:
       scene.viewEntries[frame.viewId] = entry
 
   var removed: seq[RenderViewId]
@@ -544,6 +613,8 @@ proc reconcile*(
 
   for viewId in changedViews:
     scene.viewEntries[viewId].changeGeneration = nextGeneration
+  for viewId in capturedViews:
+    scene.viewEntries[viewId].captureChangeGeneration = nextGeneration
   if rebuild:
     scene.fullTransferGeneration = nextGeneration
 
@@ -559,18 +630,24 @@ proc reconcile*(
     if topologyChanged:
       for frame in frames:
         var entry = scene.viewEntries[frame.viewId]
-        if not scene.tree.isValid(entry.shellHandle):
+        if not scene.tree.isValid(entry.placementHandle):
           scene.attachViewEntry(entry, frame.externalParent(viewLevels))
         else:
           scene.moveViewEntry(entry, frame.externalParent(viewLevels))
           if frame.captured:
             scene.updateCapturedEntry(entry)
+          elif frame.placementChanged:
+            scene.updatePlacementEntry(entry)
         scene.viewEntries[frame.viewId] = entry
     else:
       for frame in frames:
         if frame.captured:
           var entry = scene.viewEntries[frame.viewId]
           scene.updateCapturedEntry(entry)
+          scene.viewEntries[frame.viewId] = entry
+        elif frame.placementChanged:
+          var entry = scene.viewEntries[frame.viewId]
+          scene.updatePlacementEntry(entry)
           scene.viewEntries[frame.viewId] = entry
 
     for viewId in removed:
@@ -602,19 +679,25 @@ proc copyLayerContributions(
     )
 
 proc transferFrame(
-    entry: ViewRenderEntry, placement: ViewPlacement, captured: bool
+    entry: ViewRenderEntry,
+    placement: ViewPlacement,
+    placementChanged: bool,
+    captured: bool,
 ): RenderViewFrame =
   result = RenderViewFrame(
     viewId: placement.viewId,
     parentViewId: placement.parentViewId,
     cacheKey: entry.cacheKey,
+    placementChanged: placementChanged,
     captured: captured,
   )
   if captured:
+    result.placement = entry.placement.isolateFig()
     result.shell = entry.shell.isolateFig()
     result.selfContents = entry.selfContents.isolateRenderList()
     result.escapedContents = entry.escapedContents.isolateRenderList()
     result.extraLayers = entry.extraLayers.copyLayerContributions()
+    result.usesVisibleRect = entry.usesVisibleRect
 
 proc newRenderSceneUpdate*(
     scene: RenderScene,
@@ -645,7 +728,9 @@ proc newRenderSceneUpdate*(
   for placement in scene.placements:
     let entry = scene.viewEntries[placement.viewId]
     result.frames.add entry.transferFrame(
-      placement, full or entry.changeGeneration > acknowledgedGeneration
+      placement,
+      full or entry.changeGeneration > acknowledgedGeneration,
+      full or entry.captureChangeGeneration > acknowledgedGeneration,
     )
   result.resources = scene.liveResources.snapshot()
 
@@ -720,6 +805,19 @@ proc renderRoot*(scene: RenderScene, context: BackendContext) =
     raise newException(ValueError, "cannot render a nil render scene")
   context.renderRoot(scene.tree)
 
+proc countTraversalNodes(tree: RenderFragments, cursor: RenderCursor): Natural =
+  result = 1
+  for child in tree.children(cursor):
+    result += tree.countTraversalNodes(child)
+
+proc traversalNodeCount*(scene: RenderScene): Natural =
+  ## Traverses retained fragment edges without materializing a render tree.
+  if scene.isNil:
+    return
+  for level in scene.tree.levels():
+    for root in scene.tree.roots(level):
+      result += scene.tree.countTraversalNodes(root)
+
 proc renderFrame*[BackendState](
     scene: RenderScene,
     renderer: FigRenderer[BackendState],
@@ -752,11 +850,13 @@ proc viewCaptureGeneration*(scene: RenderScene, id: RenderViewId): uint64 =
     result = scene.viewEntries[id].captureGeneration
 
 proc viewFragmentIds*(scene: RenderScene, id: RenderViewId): seq[uint64] =
-  ## Returns the stable shell, self, and escaped fragment IDs for diagnostics.
+  ## Returns stable placement, shell, self, and escaped IDs for diagnostics.
   if scene.isNil or id notin scene.viewEntries:
     return
   let entry = scene.viewEntries[id]
-  for handle in [entry.shellHandle, entry.selfHandle, entry.escapedHandle]:
+  for handle in [
+    entry.placementHandle, entry.shellHandle, entry.selfHandle, entry.escapedHandle
+  ]:
     if scene.tree.isValid(handle):
       result.add handle.fragmentId()
 

--- a/src/merenda/nimkit/view/viewbase.nim
+++ b/src/merenda/nimkit/view/viewbase.nim
@@ -158,6 +158,8 @@ type
     xBounds*: Rect
     xFlipped*: bool
     xNeedsDisplay*: bool
+    xNeedsLocalDisplay*: bool
+    xDisplayRevision*: uint64
     xInvalidRects*: seq[Rect]
     xBackgroundColor*: Color
     xUsesThemedRootBackground*: bool
@@ -230,6 +232,22 @@ proc windowBacklink*(view: View): Responder {.inline.} =
 
 var activeLayoutTransaction* {.threadvar.}: ptr LayoutTransactionState
 var layoutGenerationCounter {.threadvar.}: Natural
+
+proc markLocalNeedsDisplay*(view: View, wholeView = true, propagateAncestors = false) =
+  if view.isNil:
+    return
+  inc view.xDisplayRevision
+  if view.xDisplayRevision == 0:
+    view.xDisplayRevision = 1
+  view.xNeedsDisplay = true
+  view.xNeedsLocalDisplay = true
+  if wholeView:
+    view.xInvalidRects.setLen(0)
+  if propagateAncestors:
+    var ancestor = view.superviewBacklink()
+    while not ancestor.isNil:
+      ancestor.xNeedsDisplay = true
+      ancestor = ancestor.superviewBacklink()
 
 proc nextLayoutGeneration*(): Natural =
   inc layoutGenerationCounter

--- a/src/merenda/nimkit/view/viewbase.nim
+++ b/src/merenda/nimkit/view/viewbase.nim
@@ -219,7 +219,7 @@ type
       xCachedRenderScene*: RenderScene
     xCachedRenders*: Renders
     xCachedRenderResources*: RenderResourceManifest
-    xCachedAppearance*: Appearance
+    xCachedAppearanceGeneration*: ThemeGeneration
     xHasCachedRenders*: bool
 
 proc superviewBacklink*(view: View): View {.inline.} =
@@ -244,6 +244,19 @@ proc markLocalNeedsDisplay*(view: View, wholeView = true, propagateAncestors = f
   if wholeView:
     view.xInvalidRects.setLen(0)
   if propagateAncestors:
+    var ancestor = view.superviewBacklink()
+    while not ancestor.isNil:
+      ancestor.xNeedsDisplay = true
+      ancestor = ancestor.superviewBacklink()
+
+proc markRenderStructureChanged*(view: View) =
+  ## Schedules retained-transform reconciliation without dirtying view drawing.
+  if view.isNil:
+    return
+  when defined(useNativeDynlib):
+    view.markLocalNeedsDisplay(propagateAncestors = true)
+  else:
+    view.xNeedsDisplay = true
     var ancestor = view.superviewBacklink()
     while not ancestor.isNil:
       ancestor.xNeedsDisplay = true

--- a/src/merenda/nimkit/view/viewgeometry.nim
+++ b/src/merenda/nimkit/view/viewgeometry.nim
@@ -277,8 +277,7 @@ proc applyLayoutFrame*(view: View, frame: Rect, origin = lfoContainer) =
   view.xFrame = frame
   view.xBounds = rect(view.xBounds.origin, frame.size)
   view.xNeedsLayout = true
-  view.xNeedsDisplay = true
-  view.xInvalidRects.setLen(0)
+  view.markLocalNeedsDisplay(propagateAncestors = true)
   case origin
   of lfoAuthored:
     view.invalidateLayoutItemGeometry(lirFrame)

--- a/src/merenda/nimkit/view/viewprotos.nim
+++ b/src/merenda/nimkit/view/viewprotos.nim
@@ -9,6 +9,8 @@ import ./viewgeometry
 import ./viewbase
 import sigils/core
 
+proc propagateNeedsDisplayInRect(view: View, rect: Rect)
+
 protocol ViewProtocol {.setterStyle: nim.} from View:
   property tag -> int
   property identifier -> string
@@ -78,30 +80,29 @@ protocol ViewProtocol {.setterStyle: nim.} from View:
   method `needsDisplay=`(self: View, value: bool) =
     if not value:
       self.xNeedsDisplay = false
+      self.xNeedsLocalDisplay = false
       self.xInvalidRects.setLen(0)
       return
 
-    self.xNeedsDisplay = true
-    self.xInvalidRects.setLen(0)
+    self.markLocalNeedsDisplay()
     let parent = self.superviewBacklink()
     if not parent.isNil:
-      parent.setNeedsDisplayInRect(self.rectToView(self.bounds, parent))
+      parent.propagateNeedsDisplayInRect(self.rectToView(self.bounds, parent))
 
   method setNeedsDisplayInRect*(self: View, rect: Rect) =
     let clipped = rect.intersection(self.visibleRect())
     if clipped.isEmpty:
       return
-
-    if not self.xNeedsDisplay:
-      self.xNeedsDisplay = true
+    let wasDirty = self.xNeedsDisplay
+    self.markLocalNeedsDisplay(wholeView = false)
+    if not wasDirty:
       self.xInvalidRects = @[clipped]
     elif self.xInvalidRects.len > 0:
       self.xInvalidRects[0] = self.xInvalidRects[0].union(clipped)
       self.xInvalidRects.setLen(1)
-
     let parent = self.superviewBacklink()
     if not parent.isNil:
-      parent.setNeedsDisplayInRect(self.rectToView(clipped, parent))
+      parent.propagateNeedsDisplayInRect(self.rectToView(clipped, parent))
 
   method invalidRect*(self: View): Rect =
     if not self.xNeedsDisplay:
@@ -334,7 +335,7 @@ protocol ViewProtocol {.setterStyle: nim.} from View:
       parent.xSubviews.delete(idx)
       emit self.layoutInputChanged(lirSuperview)
       emit parent.layoutInputChanged(lirHierarchy)
-      parent.setNeedsDisplayInRect(self.rectToView(self.bounds, parent))
+      parent.propagateNeedsDisplayInRect(self.rectToView(self.bounds, parent))
     self.xSuperview[] = nil
     self.resetAutoresizingState()
     self.clearNextResponder()
@@ -369,7 +370,7 @@ protocol ViewProtocol {.setterStyle: nim.} from View:
       child.propagateDidMoveToWindow()
     emit child.layoutInputChanged(lirSuperview)
     emit self.layoutInputChanged(lirHierarchy)
-    self.setNeedsDisplayInRect(child.rectToView(child.bounds, self))
+    self.propagateNeedsDisplayInRect(child.rectToView(child.bounds, self))
 
   method pointInside*(self: View, point: Point): bool =
     self.xBounds.contains(point)
@@ -401,6 +402,22 @@ protocol ViewProtocol {.setterStyle: nim.} from View:
         return bestHit
 
     if inside: self else: nil
+
+proc propagateNeedsDisplayInRect(view: View, rect: Rect) =
+  let clipped = rect.intersection(view.visibleRect())
+  if clipped.isEmpty:
+    return
+
+  if not view.xNeedsDisplay:
+    view.xNeedsDisplay = true
+    view.xInvalidRects = @[clipped]
+  elif view.xInvalidRects.len > 0:
+    view.xInvalidRects[0] = view.xInvalidRects[0].union(clipped)
+    view.xInvalidRects.setLen(1)
+
+  let parent = view.superviewBacklink()
+  if not parent.isNil:
+    parent.propagateNeedsDisplayInRect(view.rectToView(clipped, parent))
 
 protocol ViewLifecycleProtocol:
   proc viewWillMoveToSuperview*(view: View, superview: View) {.signal.}
@@ -436,15 +453,14 @@ proc setHiddenFromLayout*(view: View, hidden: bool) =
     return
   let parent = view.superviewBacklink()
   if not parent.isNil:
-    parent.setNeedsDisplayInRect(view.rectToView(view.bounds(), parent))
+    parent.propagateNeedsDisplayInRect(view.rectToView(view.bounds(), parent))
   if hidden:
     view.xWidgetStates.incl ssHidden
   else:
     view.xWidgetStates.excl ssHidden
-  view.xNeedsDisplay = true
-  view.xInvalidRects.setLen(0)
+  view.needsDisplay = true
   if not hidden and not parent.isNil:
-    parent.setNeedsDisplayInRect(view.rectToView(view.bounds(), parent))
+    parent.propagateNeedsDisplayInRect(view.rectToView(view.bounds(), parent))
 
 proc setBoundsOriginFromLayout*(view: View, origin: Point) =
   ## Apply a container-owned content offset without invalidating constraints.
@@ -556,7 +572,7 @@ proc attachSubviewAt(view, child: View, index: Natural) =
     child.propagateDidMoveToWindow()
   emit child.layoutInputChanged(lirSuperview)
   emit view.layoutInputChanged(lirHierarchy)
-  view.setNeedsDisplayInRect(child.rectToView(child.bounds, view))
+  view.propagateNeedsDisplayInRect(child.rectToView(child.bounds, view))
 
 proc insertSubview*(view, child: View, index: Natural) =
   if view.isNil:

--- a/src/merenda/nimkit/view/viewprotos.nim
+++ b/src/merenda/nimkit/view/viewprotos.nim
@@ -463,11 +463,11 @@ proc setHiddenFromLayout*(view: View, hidden: bool) =
     parent.propagateNeedsDisplayInRect(view.rectToView(view.bounds(), parent))
 
 proc setBoundsOriginFromLayout*(view: View, origin: Point) =
-  ## Apply a container-owned content offset without invalidating constraints.
+  ## Apply a container-owned content offset without invalidating drawing.
   if view.isNil or view.xBounds.origin == origin:
     return
   view.xBounds.origin = origin
-  view.needsDisplay = true
+  view.markRenderStructureChanged()
 
 proc viewCanBecomeKeyView*(view: View): bool =
   view.acceptsFirstResponder() and not view.isHiddenOrHasHiddenAncestor()

--- a/src/merenda/nimkit/view/views.nim
+++ b/src/merenda/nimkit/view/views.nim
@@ -18,7 +18,7 @@ export responders
 export viewbase except
   AutoresizingState, LayoutInputKind, LayoutTerm, LayoutEquation, LayoutInput,
   LayoutInputCache, LayoutTransactionState, activeLayoutTransaction,
-  nextLayoutGeneration, noteLayoutInvalidation
+  markLocalNeedsDisplay, nextLayoutGeneration, noteLayoutInvalidation
 export viewconstraints except generatedLayoutInputs, applyConstraintsForSubtree
 export viewgeometry except
   resetAutoresizingState, refreshAutoresizingReference,
@@ -360,6 +360,25 @@ proc finishDisplaySubtree*(view: View) =
   for child in view.xSubviews:
     child.finishDisplaySubtree()
 
+proc acknowledgeDisplayRevision*(view: View, revision: uint64) =
+  ## Marks one captured local drawing revision complete without losing a newer one.
+  if view.isNil or view.xDisplayRevision != revision:
+    return
+  view.xNeedsLocalDisplay = false
+
+proc refreshDisplayStateSubtree*(view: View): bool {.discardable.} =
+  ## Rebuilds aggregate descendant-dirty state after revision acknowledgement.
+  if view.isNil:
+    return
+  var hasDirtyDescendant = false
+  for child in view.xSubviews:
+    if child.refreshDisplayStateSubtree():
+      hasDirtyDescendant = true
+  view.xNeedsDisplay = view.xNeedsLocalDisplay or hasDirtyDescendant
+  if not view.xNeedsDisplay:
+    view.xInvalidRects.setLen(0)
+  view.xNeedsDisplay
+
 proc moveToWindowOwner*(view: View, window: Responder) =
   if view.windowBacklink() == window:
     return
@@ -391,6 +410,8 @@ proc initViewFields*(view: View, frame: Rect = AutoRect) =
   view.xFlipped = true
   view.xAlphaValue = 1.0'f32
   view.xNeedsDisplay = true
+  view.xNeedsLocalDisplay = true
+  view.xDisplayRevision = 1
   view.xNeedsLayout = true
   view.xAutoresizingMaskConstraints = not frame.hasAutoMetric
   view.xHuggingPriority[laHorizontal] = LayoutPriorityLow

--- a/tests/benchmark_markdown_scroll.nim
+++ b/tests/benchmark_markdown_scroll.nim
@@ -8,7 +8,7 @@
 ##
 ## This diagnostic excludes GPU execution. It measures scroll invalidation, view
 ## rendering/reconciliation, bounded-channel transfer, renderer-side scene
-## application, and acknowledgement.
+## application, direct fragment-edge traversal, and acknowledgement.
 
 import std/[algorithm, monotimes, os, strformat, times]
 
@@ -43,6 +43,16 @@ proc scrollPosition(frame: int, maximum: float32): float32 =
   else:
     maximum * (1.0'f32 - fraction)
 
+proc countTraversalNodes(renders: Renders, cursor: RenderCursor): Natural =
+  result = 1
+  for child in renders.children(cursor):
+    result += renders.countTraversalNodes(child)
+
+proc traversalNodeCount(renders: Renders): Natural =
+  for level, _ in renders.pairs():
+    for root in renders.roots(level):
+      result += renders.countTraversalNodes(root)
+
 let
   source = readFile(RepositoryReadme)
   viewer = newMarkdownView(
@@ -64,11 +74,15 @@ doAssert maximumY > 0.0'f32, "README should exceed the Markdown viewport"
 var
   checksum: uint64
   capturedViews: uint64
+  traversedNodes: uint64
   prepareMilliseconds: seq[float]
   transferMilliseconds: seq[float]
   applyMilliseconds: seq[float]
+  traversalMilliseconds: seq[float]
 when defined(fragmentNativeProfile):
   var replica = retainedScenes.newRenderSceneReplica()
+  let retainedScene = viewer.buildRenderScene()
+  var documentCaptureBaseline: uint64
 
 proc renderScrollFrame(frame: int) =
   scrollView.contentOffset = initPoint(0.0, scrollPosition(frame, maximumY))
@@ -96,12 +110,22 @@ proc renderScrollFrame(frame: int) =
     applyMilliseconds.add(
       (getMonoTime() - applyStarted).inNanoseconds.float / 1_000_000.0
     )
+    let traversalStarted = getMonoTime()
+    traversedNodes += retainedScenes.traversalNodeCount(replica).uint64
+    traversalMilliseconds.add(
+      (getMonoTime() - traversalStarted).inNanoseconds.float / 1_000_000.0
+    )
   else:
     var renders = viewer.buildRenders()
     prepareMilliseconds.add(
       (getMonoTime() - prepareStarted).inNanoseconds.float / 1_000_000.0
     )
     checksum += renders.len(DefaultDrawLevel).uint64
+    let traversalStarted = getMonoTime()
+    traversedNodes += renders.traversalNodeCount().uint64
+    traversalMilliseconds.add(
+      (getMonoTime() - traversalStarted).inNanoseconds.float / 1_000_000.0
+    )
     let transferStarted = getMonoTime()
     doAssert host.submitRenders(ensureMove renders, logicalSize)
     var snapshot: nimkitBackend.ThreadRenderSnapshot
@@ -118,11 +142,16 @@ proc renderScrollFrame(frame: int) =
 
 for frame in 0 ..< WarmupFrames:
   renderScrollFrame(frame)
+when defined(fragmentNativeProfile):
+  documentCaptureBaseline =
+    retainedScene.viewCaptureGeneration(viewer.textView().renderViewId())
 checksum = 0
 capturedViews = 0
+traversedNodes = 0
 prepareMilliseconds.setLen(0)
 transferMilliseconds.setLen(0)
 applyMilliseconds.setLen(0)
+traversalMilliseconds.setLen(0)
 
 var
   wallMilliseconds = newSeqOfCap[float](ProfileFrames)
@@ -151,8 +180,15 @@ echo &"CPU:  median {cpuMilliseconds.percentile(0.50):.3f} ms/frame, " &
   &"p95 {cpuMilliseconds.percentile(0.95):.3f} ms/frame"
 echo &"stages (median wall): prepare {prepareMilliseconds.percentile(0.50):.3f} ms, " &
   &"transfer {transferMilliseconds.percentile(0.50):.3f} ms, " &
-  &"apply/ack {applyMilliseconds.percentile(0.50):.3f} ms"
+  &"apply/ack {applyMilliseconds.percentile(0.50):.3f} ms, " &
+  &"traversal {traversalMilliseconds.percentile(0.50):.3f} ms"
+echo &"traversed nodes: {traversedNodes}"
 when defined(fragmentNativeProfile):
   echo &"captured view contributions: {capturedViews}"
+  echo &"document contribution captures: " &
+    $(
+      retainedScene.viewCaptureGeneration(viewer.textView().renderViewId()) -
+      documentCaptureBaseline
+    )
 echo &"total: {totalWall:.3f} s wall, {totalCpu:.3f} s CPU, " &
   &"CPU/wall {totalCpu / max(totalWall, 0.000_001) * 100.0:.1f}%"

--- a/tests/benchmark_markdown_scroll.nim
+++ b/tests/benchmark_markdown_scroll.nim
@@ -22,8 +22,8 @@ when defined(fragmentNativeProfile):
 const
   RepositoryRoot = currentSourcePath().parentDir.parentDir
   RepositoryReadme = RepositoryRoot / "README.md"
-  WarmupFrames = 20
-  ProfileFrames = 240
+  WarmupFrames {.intdefine.} = 20
+  ProfileFrames {.intdefine.} = 240
 
 proc unavailableMarkdownImage(url: string): ImageResource =
   discard url

--- a/tests/benchmark_markdown_scroll.nim
+++ b/tests/benchmark_markdown_scroll.nim
@@ -1,0 +1,158 @@
+## Profiles CPU-side README scrolling through the dedicated-renderer handoff.
+##
+## Run the base revision without a define, and the fragment-native revision with:
+##
+##   atlas-run tests tests/benchmark_markdown_scroll.nim -- -d:release
+##   atlas-run tests tests/benchmark_markdown_scroll.nim -- \
+##     -d:release -d:fragmentNativeProfile
+##
+## This diagnostic excludes GPU execution. It measures scroll invalidation, view
+## rendering/reconciliation, bounded-channel transfer, renderer-side scene
+## application, and acknowledgement.
+
+import std/[algorithm, monotimes, os, strformat, times]
+
+import figdraw
+
+import merenda/nimkit
+import merenda/nimkit/app/backend as nimkitBackend
+when defined(fragmentNativeProfile):
+  import merenda/nimkit/drawing/renderscenes as retainedScenes
+
+const
+  RepositoryRoot = currentSourcePath().parentDir.parentDir
+  RepositoryReadme = RepositoryRoot / "README.md"
+  WarmupFrames = 20
+  ProfileFrames = 240
+
+proc unavailableMarkdownImage(url: string): ImageResource =
+  discard url
+
+proc percentile(samples: seq[float], fraction: float): float =
+  var ordered = samples
+  ordered.sort()
+  ordered[min((ordered.len.float * fraction).int, ordered.high)]
+
+proc scrollPosition(frame: int, maximum: float32): float32 =
+  let
+    cycleLength = ProfileFrames div 2
+    position = frame mod cycleLength
+    fraction = position.float32 / max(cycleLength - 1, 1).float32
+  if (frame div cycleLength) mod 2 == 0:
+    maximum * fraction
+  else:
+    maximum * (1.0'f32 - fraction)
+
+let
+  source = readFile(RepositoryReadme)
+  viewer = newMarkdownView(
+    source, frame = rect(0, 0, 760, 540), imageLoader = unavailableMarkdownImage
+  )
+doAssert viewer.waitForMarkdownParsing(), "README parsing should complete"
+discard viewer.buildRenders()
+doAssert viewer.waitForMarkdownLayout(), "README layout should complete"
+discard viewer.buildRenders()
+
+let
+  scrollView = viewer.scrollView()
+  maximumY = scrollView.maximumContentOffset().y
+  logicalSize = initSize(760.0, 540.0)
+  runtime = nimkitBackend.newThreadRenderer()
+  host = nimkitBackend.newThreadHostClient(runtime.client)
+doAssert maximumY > 0.0'f32, "README should exceed the Markdown viewport"
+
+var
+  checksum: uint64
+  capturedViews: uint64
+  prepareMilliseconds: seq[float]
+  transferMilliseconds: seq[float]
+  applyMilliseconds: seq[float]
+when defined(fragmentNativeProfile):
+  var replica = retainedScenes.newRenderSceneReplica()
+
+proc renderScrollFrame(frame: int) =
+  scrollView.contentOffset = initPoint(0.0, scrollPosition(frame, maximumY))
+  let prepareStarted = getMonoTime()
+  when defined(fragmentNativeProfile):
+    let scene = viewer.buildRenderScene()
+    prepareMilliseconds.add(
+      (getMonoTime() - prepareStarted).inNanoseconds.float / 1_000_000.0
+    )
+    let transferStarted = getMonoTime()
+    doAssert host.submitRenderScene(scene, logicalSize)
+    var snapshot: nimkitBackend.ThreadRenderSnapshot
+    doAssert host.channels.pollLatestRender(snapshot)
+    transferMilliseconds.add(
+      (getMonoTime() - transferStarted).inNanoseconds.float / 1_000_000.0
+    )
+    let applyStarted = getMonoTime()
+    var update = move snapshot.sceneUpdate
+    if retainedScenes.fullSnapshot(update):
+      replica = retainedScenes.newRenderSceneReplica()
+    retainedScenes.apply(replica, update)
+    checksum += retainedScenes.viewCount(update).uint64
+    capturedViews += retainedScenes.capturedViewCount(update).uint64
+    host.acknowledgeRender(snapshot.renderId)
+    applyMilliseconds.add(
+      (getMonoTime() - applyStarted).inNanoseconds.float / 1_000_000.0
+    )
+  else:
+    var renders = viewer.buildRenders()
+    prepareMilliseconds.add(
+      (getMonoTime() - prepareStarted).inNanoseconds.float / 1_000_000.0
+    )
+    checksum += renders.len(DefaultDrawLevel).uint64
+    let transferStarted = getMonoTime()
+    doAssert host.submitRenders(ensureMove renders, logicalSize)
+    var snapshot: nimkitBackend.ThreadRenderSnapshot
+    doAssert host.channels.pollLatestRender(snapshot)
+    transferMilliseconds.add(
+      (getMonoTime() - transferStarted).inNanoseconds.float / 1_000_000.0
+    )
+    let applyStarted = getMonoTime()
+    viewer.invalidateRenderCache()
+    host.acknowledgeRender(snapshot.renderId)
+    applyMilliseconds.add(
+      (getMonoTime() - applyStarted).inNanoseconds.float / 1_000_000.0
+    )
+
+for frame in 0 ..< WarmupFrames:
+  renderScrollFrame(frame)
+checksum = 0
+capturedViews = 0
+prepareMilliseconds.setLen(0)
+transferMilliseconds.setLen(0)
+applyMilliseconds.setLen(0)
+
+var
+  wallMilliseconds = newSeqOfCap[float](ProfileFrames)
+  cpuMilliseconds = newSeqOfCap[float](ProfileFrames)
+let
+  totalWallStarted = getMonoTime()
+  totalCpuStarted = cpuTime()
+for frame in 0 ..< ProfileFrames:
+  let
+    wallStarted = getMonoTime()
+    cpuStarted = cpuTime()
+  renderScrollFrame(frame + WarmupFrames)
+  cpuMilliseconds.add((cpuTime() - cpuStarted) * 1_000.0)
+  wallMilliseconds.add((getMonoTime() - wallStarted).inNanoseconds.float / 1_000_000.0)
+let
+  totalCpu = cpuTime() - totalCpuStarted
+  totalWall = (getMonoTime() - totalWallStarted).inNanoseconds.float / 1_000_000_000.0
+  mode = when defined(fragmentNativeProfile): "fragment-native" else: "monolithic"
+
+echo "README Markdown scroll profile (", mode, ")"
+echo &"document: {source.len} bytes, maximum scroll: {maximumY:.1f} px"
+echo &"frames: {ProfileFrames}, checksum: {checksum}"
+echo &"wall: median {wallMilliseconds.percentile(0.50):.3f} ms/frame, " &
+  &"p95 {wallMilliseconds.percentile(0.95):.3f} ms/frame"
+echo &"CPU:  median {cpuMilliseconds.percentile(0.50):.3f} ms/frame, " &
+  &"p95 {cpuMilliseconds.percentile(0.95):.3f} ms/frame"
+echo &"stages (median wall): prepare {prepareMilliseconds.percentile(0.50):.3f} ms, " &
+  &"transfer {transferMilliseconds.percentile(0.50):.3f} ms, " &
+  &"apply/ack {applyMilliseconds.percentile(0.50):.3f} ms"
+when defined(fragmentNativeProfile):
+  echo &"captured view contributions: {capturedViews}"
+echo &"total: {totalWall:.3f} s wall, {totalCpu:.3f} s CPU, " &
+  &"CPU/wall {totalCpu / max(totalWall, 0.000_001) * 100.0:.1f}%"

--- a/tests/nimkit/images.nim
+++ b/tests/nimkit/images.nim
@@ -335,3 +335,33 @@ suite "nimkit image resources":
       check retainedImage.imageId().Hash in recovery.context.entries
       check releasedImage.imageId().Hash notin recovery.context.entries
       check manager.metrics.atlasShrinkRebuildCount == 1
+
+    test "atlas recovery restores only the current live manifest":
+      clearImageCache()
+      let
+        retainedImage = newImageResource(testImage(3, 2))
+        unrelatedImage = newImageResource(testImage(4, 3))
+        manager = newRenderResourceManager()
+        recovery = newRecoveryRenderer()
+      recovery.context.resetOnSecondUpload = false
+      recovery.context.packedArea = 0
+      var
+        liveManifest = initRenderResourceManifest()
+        unrelatedManifest = initRenderResourceManifest()
+      liveManifest.addImage(retainedImage)
+      unrelatedManifest.addImage(unrelatedImage)
+
+      manager.prepare(recovery.renderer)
+      check retainedImage.imageId().Hash in recovery.context.entries
+      check unrelatedImage.imageId().Hash in recovery.context.entries
+
+      recovery.renderer.rebuildImageAtlas()
+      manager.prepare(recovery.renderer, liveManifest)
+      check retainedImage.imageId().Hash in recovery.context.entries
+      check unrelatedImage.imageId().Hash notin recovery.context.entries
+      check manager.metrics.generationRecoveryCount >= 1
+
+      clearImageCache()
+      manager.prepare(recovery.renderer, liveManifest)
+      check retainedImage.imageId().Hash in recovery.context.entries
+      check unrelatedImage.imageId().Hash notin recovery.context.entries

--- a/tests/nimkit/images.nim
+++ b/tests/nimkit/images.nim
@@ -365,3 +365,29 @@ suite "nimkit image resources":
       manager.prepare(recovery.renderer, liveManifest)
       check retainedImage.imageId().Hash in recovery.context.entries
       check unrelatedImage.imageId().Hash notin recovery.context.entries
+
+    test "renderer-thread atlas recovery filters by transferred resource IDs":
+      clearImageCache()
+      let
+        retainedImage = newImageResource(testImage(3, 2))
+        unrelatedImage = newImageResource(testImage(4, 3))
+        manager = newRenderResourceManager()
+        recovery = newRecoveryRenderer()
+      recovery.context.resetOnSecondUpload = false
+      recovery.context.packedArea = 0
+      var
+        liveManifest = initRenderResourceManifest()
+        unrelatedManifest = initRenderResourceManifest()
+      liveManifest.addImage(retainedImage)
+      unrelatedManifest.addImage(unrelatedImage)
+      let liveSnapshot = liveManifest.snapshot()
+
+      manager.prepare(recovery.renderer)
+      check retainedImage.imageId().Hash in recovery.context.entries
+      check unrelatedImage.imageId().Hash in recovery.context.entries
+
+      recovery.renderer.rebuildImageAtlas()
+      manager.prepare(recovery.renderer, liveSnapshot)
+      check retainedImage.imageId().Hash in recovery.context.entries
+      check unrelatedImage.imageId().Hash notin recovery.context.entries
+      check manager.metrics.generationRecoveryCount >= 1

--- a/tests/nimkit/markdownviews.nim
+++ b/tests/nimkit/markdownviews.nim
@@ -12,6 +12,7 @@ const
   RepositoryRoot = currentSourcePath().parentDir.parentDir.parentDir
   RepositoryReadme = RepositoryRoot / "README.md"
   TestImagePath = RepositoryRoot / "data" / "img1.png"
+  ReadmeLayoutTimeoutMilliseconds = 15_000
 
 proc runeIndexOf(text, needle: string): int =
   let
@@ -974,7 +975,7 @@ Press <kbd>Enter</kbd>.
     let
       singleElapsed = getMonoTime() - singleStarted
       singleSettleStarted = getMonoTime()
-    require first.waitForMarkdownLayout()
+    require first.waitForMarkdownLayout(ReadmeLayoutTimeoutMilliseconds)
     discard buildRenders(first)
     let
       singleSettleElapsed = getMonoTime() - singleSettleStarted
@@ -993,8 +994,8 @@ Press <kbd>Enter</kbd>.
     let
       pairElapsed = getMonoTime() - pairStarted
       pairSettleStarted = getMonoTime()
-    require first.waitForMarkdownLayout()
-    require second.waitForMarkdownLayout()
+    require first.waitForMarkdownLayout(ReadmeLayoutTimeoutMilliseconds)
+    require second.waitForMarkdownLayout(ReadmeLayoutTimeoutMilliseconds)
     discard buildRenders(first)
     discard buildRenders(second)
     let pairSettleElapsed = getMonoTime() - pairSettleStarted

--- a/tests/nimkit/renderfragments.nim
+++ b/tests/nimkit/renderfragments.nim
@@ -502,16 +502,17 @@ suite "NimKit render fragments":
     var initial = retainedScenes.newRenderSceneUpdate(scene, 0, 0)
     retainedScenes.apply(replica, initial)
 
-    viewport.bounds = rect(0, 24, 100, 80)
+    viewport.setBoundsOriginFromLayout(initPoint(0, 24))
     discard root.buildRenderScene()
     var update =
       retainedScenes.newRenderSceneUpdate(scene, sceneIdentity, initialGeneration)
 
-    check viewport.drawCount == 2
+    check viewport.drawCount == 1
     check document.drawCount == 1
+    check scene.viewCaptureGeneration(viewport.renderViewId()) == 1
     check scene.viewCaptureGeneration(document.renderViewId()) == 1
     check scene.viewFragmentIds(document.renderViewId()) == documentFragments
-    check retainedScenes.capturedViewCount(update) == 1
+    check retainedScenes.capturedViewCount(update) == 0
     retainedScenes.apply(replica, update)
     check replica.materialize().canonicalNodes() == scene.materialize().canonicalNodes()
 
@@ -525,9 +526,10 @@ suite "NimKit render fragments":
     root.addSubview(viewport)
     let scene = root.buildRenderScene()
 
-    viewport.bounds = rect(0, 24, 100, 80)
+    viewport.setBoundsOriginFromLayout(initPoint(0, 24))
     discard root.buildRenderScene()
 
+    check viewport.drawCount == 1
     check document.drawCount == 2
     check scene.viewCaptureGeneration(document.renderViewId()) == 2
 

--- a/tests/nimkit/renderfragments.nim
+++ b/tests/nimkit/renderfragments.nim
@@ -12,6 +12,7 @@ type
   CountedSceneView = ref object of View
     drawCount: int
     drawColor: Color
+    drawLevelValue: ZLevel
     invalidatesDuringDraw: bool
 
   MultiOutputSceneView = ref object of View
@@ -51,6 +52,9 @@ protocol ScenePopupDrawing of ViewDrawingProtocol:
     context.addRectangle(rect(1, 1, 8, 6), color(0.2, 0.5, 0.9))
 
 protocol CountedSceneDrawing of ViewDrawingProtocol:
+  method drawLevel(view: CountedSceneView): ZLevel =
+    view.drawLevelValue
+
   method draw(view: CountedSceneView, context: DrawContext) =
     inc view.drawCount
     context.addRectangle(rect(1, 2, 9, 7), view.drawColor)
@@ -265,6 +269,80 @@ proc testImage(width, height: int): Image =
   result.fill(rgba(64, 128, 192, 255))
 
 suite "NimKit render fragments":
+  test "cumulative scene updates apply after coalescing and reject stale baselines":
+    let
+      root = newView(frame = rect(0, 0, 180, 120))
+      first = newCountedSceneView(rect(5, 6, 50, 30), color(0.2, 0.3, 0.4))
+      second = newCountedSceneView(rect(62, 6, 50, 30), color(0.5, 0.6, 0.7))
+    root.addSubview(first)
+    root.addSubview(second)
+
+    let scene = root.buildRenderScene()
+    let
+      sceneIdentity = retainedScenes.sceneIdentity(scene)
+      acknowledgedGeneration = scene.frameGeneration()
+      replica = retainedScenes.newRenderSceneReplica()
+    var full = retainedScenes.newRenderSceneUpdate(scene, 0, 0)
+    check retainedScenes.fullSnapshot(full)
+    check retainedScenes.baseGeneration(full) == 0
+    check retainedScenes.capturedViewCount(full) == 3
+    check retainedScenes.canApply(full, 0, 0)
+    retainedScenes.apply(replica, full)
+    check replica.materialize().canonicalNodes() == scene.materialize().canonicalNodes()
+
+    first.drawColor = color(0.8, 0.1, 0.2)
+    first.needsDisplay = true
+    discard root.buildRenderScene()
+    let skippedGeneration = scene.frameGeneration()
+
+    second.drawColor = color(0.1, 0.8, 0.3)
+    second.needsDisplay = true
+    discard root.buildRenderScene()
+    let latestGeneration = scene.frameGeneration()
+    var cumulative =
+      retainedScenes.newRenderSceneUpdate(scene, sceneIdentity, acknowledgedGeneration)
+
+    check not retainedScenes.fullSnapshot(cumulative)
+    check retainedScenes.baseGeneration(cumulative) == acknowledgedGeneration
+    check retainedScenes.generation(cumulative) == latestGeneration
+    check skippedGeneration > acknowledgedGeneration
+    check latestGeneration > skippedGeneration
+    check retainedScenes.capturedViewCount(cumulative) == 2
+    check retainedScenes.canApply(cumulative, sceneIdentity, acknowledgedGeneration)
+    retainedScenes.apply(replica, cumulative)
+    check replica.frameGeneration() == latestGeneration
+    check replica.materialize().canonicalNodes() == scene.materialize().canonicalNodes()
+    check not retainedScenes.canApply(full, sceneIdentity, latestGeneration)
+    expect ValueError:
+      retainedScenes.apply(replica, full)
+
+    let replacement = newView(frame = rect(0, 0, 180, 120)).buildRenderScene()
+    var barrier =
+      retainedScenes.newRenderSceneUpdate(replacement, sceneIdentity, latestGeneration)
+    check retainedScenes.fullSnapshot(barrier)
+    check retainedScenes.canApply(barrier, sceneIdentity, latestGeneration)
+
+  test "layer changes force a full renderer-scene ordering barrier":
+    let
+      root = newView(frame = rect(0, 0, 180, 120))
+      child = newCountedSceneView(rect(5, 6, 50, 30), color(0.2, 0.3, 0.4))
+    root.addSubview(child)
+
+    let scene = root.buildRenderScene()
+    let
+      sceneIdentity = retainedScenes.sceneIdentity(scene)
+      acknowledgedGeneration = scene.frameGeneration()
+
+    child.drawLevelValue = PopupDrawLevel
+    child.needsDisplay = true
+    discard root.buildRenderScene()
+    var barrier =
+      retainedScenes.newRenderSceneUpdate(scene, sceneIdentity, acknowledgedGeneration)
+
+    check retainedScenes.fullSnapshot(barrier)
+    check retainedScenes.baseGeneration(barrier) == 0
+    check retainedScenes.capturedViewCount(barrier) == 2
+
   test "scene materializes monolithic order and sweeps removed views":
     let
       root = newView(frame = rect(0, 0, 160, 120))

--- a/tests/nimkit/renderfragments.nim
+++ b/tests/nimkit/renderfragments.nim
@@ -8,6 +8,15 @@ import merenda/nimkit
 type
   SceneDrawView = ref object of View
   ScenePopupView = ref object of View
+  CountedSceneView = ref object of View
+    drawCount: int
+    drawColor: Color
+    invalidatesDuringDraw: bool
+
+  MultiOutputSceneView = ref object of View
+    escapedRootCount: int
+    drawsPopup: bool
+    drawsTooltip: bool
 
   CanonicalRenderNode = object
     level: ZLevel
@@ -28,6 +37,39 @@ protocol ScenePopupDrawing of ViewDrawingProtocol:
   method draw(view: ScenePopupView, context: DrawContext) =
     context.addRectangle(rect(1, 1, 8, 6), color(0.2, 0.5, 0.9))
 
+protocol CountedSceneDrawing of ViewDrawingProtocol:
+  method draw(view: CountedSceneView, context: DrawContext) =
+    inc view.drawCount
+    context.addRectangle(rect(1, 2, 9, 7), view.drawColor)
+    if view.invalidatesDuringDraw:
+      view.invalidatesDuringDraw = false
+      view.needsDisplay = true
+
+protocol MultiOutputSceneDrawing of ViewDrawingProtocol:
+  method draw(view: MultiOutputSceneView, context: DrawContext) =
+    context.addRectangle(rect(1, 1, 10, 8), color(0.3, 0.4, 0.5))
+    for index in 0 ..< view.escapedRootCount:
+      discard context.addRenderRectangle(
+        context.renderLayer,
+        context.renderViewParent,
+        context.renderRectFor(rect(index.float32, 12, 4, 3)),
+        color(0.8, 0.2, 0.1),
+      )
+    if view.drawsTooltip:
+      discard context.addRenderRectangle(
+        TooltipDrawLevel,
+        (-1).FigIdx,
+        context.renderRectFor(rect(2, 18, 15, 5)),
+        color(0.2, 0.7, 0.3),
+      )
+    if view.drawsPopup:
+      discard context.addRenderRectangle(
+        PopupDrawLevel,
+        (-1).FigIdx,
+        context.renderRectFor(rect(3, 24, 18, 7)),
+        color(0.2, 0.3, 0.8),
+      )
+
 proc newSceneDrawView(frame: Rect): SceneDrawView =
   result = SceneDrawView()
   result.initViewFields(frame)
@@ -37,6 +79,16 @@ proc newScenePopupView(frame: Rect): ScenePopupView =
   result = ScenePopupView()
   result.initViewFields(frame)
   discard result.withProtocol(ScenePopupDrawing)
+
+proc newCountedSceneView(frame: Rect, drawColor: Color): CountedSceneView =
+  result = CountedSceneView(drawColor: drawColor)
+  result.initViewFields(frame)
+  discard result.withProtocol(CountedSceneDrawing)
+
+proc newMultiOutputSceneView(frame: Rect): MultiOutputSceneView =
+  result = MultiOutputSceneView()
+  result.initViewFields(frame)
+  discard result.withProtocol(MultiOutputSceneDrawing)
 
 proc renderLevels(renders: Renders): seq[ZLevel] =
   for level, _ in renders.pairs():
@@ -86,7 +138,7 @@ suite "NimKit render fragments":
       firstFragmentIds = scene.rootFragmentIds()
       materialized = scene.materialize()
 
-    check sceneDrawCount == 1
+    check sceneDrawCount == 2
     check materialized.renderLevels() == monolithic.renderLevels()
     check materialized.canonicalNodes() == monolithic.canonicalNodes()
     check scene.viewEntryCount() == 4
@@ -96,14 +148,14 @@ suite "NimKit render fragments":
     let cachedScene = root.buildRenderScene()
     check cachedScene == scene
     check cachedScene.frameGeneration() == firstGeneration
-    check sceneDrawCount == 1
+    check sceneDrawCount == 2
 
     custom.needsDisplay = true
     let updatedScene = root.buildRenderScene()
     check updatedScene == scene
     check updatedScene.frameGeneration() == firstGeneration + 1
     check updatedScene.rootFragmentIds() == firstFragmentIds
-    check sceneDrawCount == 2
+    check sceneDrawCount == 3
     check updatedScene.materialize().canonicalNodes() ==
       root.buildRenders().canonicalNodes()
 
@@ -112,6 +164,209 @@ suite "NimKit render fragments":
     discard root.buildRenderScene()
     check not scene.containsView(removedId)
     check scene.viewEntryCount() == 3
+
+  test "leaf invalidation preserves ancestor and sibling contributions":
+    let
+      root = newCountedSceneView(rect(0, 0, 180, 120), color(0.1, 0.1, 0.1))
+      parent = newCountedSceneView(rect(8, 9, 100, 80), color(0.2, 0.3, 0.4))
+      leaf = newCountedSceneView(rect(4, 5, 30, 20), color(0.7, 0.2, 0.1))
+      sibling = newCountedSceneView(rect(42, 5, 30, 20), color(0.1, 0.6, 0.2))
+    parent.addSubview(leaf)
+    parent.addSubview(sibling)
+    root.addSubview(parent)
+
+    let scene = root.buildRenderScene()
+    let
+      rootIds = scene.viewFragmentIds(root.renderViewId())
+      parentIds = scene.viewFragmentIds(parent.renderViewId())
+      leafIds = scene.viewFragmentIds(leaf.renderViewId())
+      siblingIds = scene.viewFragmentIds(sibling.renderViewId())
+      firstOutput = scene.materialize().canonicalNodes()
+
+    check root.drawCount == 1
+    check parent.drawCount == 1
+    check leaf.drawCount == 1
+    check sibling.drawCount == 1
+
+    leaf.drawColor = color(0.9, 0.5, 0.2)
+    leaf.needsDisplay = true
+    discard root.buildRenderScene()
+
+    check root.drawCount == 1
+    check parent.drawCount == 1
+    check leaf.drawCount == 2
+    check sibling.drawCount == 1
+    check scene.viewCaptureGeneration(root.renderViewId()) == 1
+    check scene.viewCaptureGeneration(parent.renderViewId()) == 1
+    check scene.viewCaptureGeneration(leaf.renderViewId()) == 2
+    check scene.viewCaptureGeneration(sibling.renderViewId()) == 1
+    check scene.viewFragmentIds(root.renderViewId()) == rootIds
+    check scene.viewFragmentIds(parent.renderViewId()) == parentIds
+    check scene.viewFragmentIds(leaf.renderViewId()) == leafIds
+    check scene.viewFragmentIds(sibling.renderViewId()) == siblingIds
+    check scene.materialize().canonicalNodes() != firstOutput
+
+  test "child reordering keeps view fragments and cached drawing":
+    let
+      root = newView(frame = rect(0, 0, 140, 90))
+      first = newCountedSceneView(rect(4, 5, 30, 20), color(0.8, 0.1, 0.1))
+      second = newCountedSceneView(rect(40, 5, 30, 20), color(0.1, 0.2, 0.8))
+    root.addSubview(first)
+    root.addSubview(second)
+
+    let scene = root.buildRenderScene()
+    let
+      firstIds = scene.viewFragmentIds(first.renderViewId())
+      secondIds = scene.viewFragmentIds(second.renderViewId())
+    root.insertSubview(second, 0)
+    discard root.buildRenderScene()
+
+    check first.drawCount == 1
+    check second.drawCount == 2
+    check scene.viewFragmentIds(first.renderViewId()) == firstIds
+    check scene.viewFragmentIds(second.renderViewId()) == secondIds
+    check scene.materialize().canonicalNodes() == root.buildRenders().canonicalNodes()
+
+  test "ancestor geometry changes recapture affected descendant contexts":
+    let
+      root = newCountedSceneView(rect(0, 0, 180, 120), color(0.1, 0.1, 0.1))
+      parent = newCountedSceneView(rect(8, 9, 100, 80), color(0.2, 0.3, 0.4))
+      child = newCountedSceneView(rect(4, 5, 30, 20), color(0.7, 0.2, 0.1))
+    parent.addSubview(child)
+    root.addSubview(parent)
+    let scene = root.buildRenderScene()
+
+    parent.frame = rect(20, 18, 100, 80)
+    discard root.buildRenderScene()
+
+    check root.drawCount == 1
+    check parent.drawCount == 2
+    check child.drawCount == 2
+    check scene.viewCaptureGeneration(root.renderViewId()) == 1
+    check scene.viewCaptureGeneration(parent.renderViewId()) == 2
+    check scene.viewCaptureGeneration(child.renderViewId()) == 2
+
+  test "appearance generation changes recapture inherited contributions":
+    let
+      root = newCountedSceneView(rect(0, 0, 100, 70), color(0.1, 0.1, 0.1))
+      child = newCountedSceneView(rect(4, 5, 30, 20), color(0.7, 0.2, 0.1))
+    root.addSubview(child)
+    let
+      firstAppearance = initAppearance(initTheme())
+      scene = root.buildRenderScene(firstAppearance)
+      secondAppearance = initAppearance(initTheme())
+
+    discard root.buildRenderScene(secondAppearance)
+
+    check root.drawCount == 2
+    check child.drawCount == 2
+    check scene.viewCaptureGeneration(root.renderViewId()) == 2
+    check scene.viewCaptureGeneration(child.renderViewId()) == 2
+
+  test "invalidation raised during draw remains pending":
+    let view = newCountedSceneView(rect(0, 0, 100, 70), color(0.1, 0.2, 0.3))
+    view.invalidatesDuringDraw = true
+
+    let scene = view.buildRenderScene()
+    let firstGeneration = scene.frameGeneration()
+    check view.drawCount == 1
+    check view.needsDisplay
+
+    discard view.buildRenderScene()
+    check view.drawCount == 2
+    check not view.needsDisplay
+    check scene.frameGeneration() == firstGeneration + 1
+
+  test "hidden views are swept and recaptured with the same view identity":
+    let
+      root = newView(frame = rect(0, 0, 100, 70))
+      child = newCountedSceneView(rect(4, 5, 30, 20), color(0.7, 0.2, 0.1))
+      childId = child.renderViewId()
+    root.addSubview(child)
+    let scene = root.buildRenderScene()
+    check scene.containsView(childId)
+
+    child.hidden = true
+    discard root.buildRenderScene()
+    check not scene.containsView(childId)
+    check child.drawCount == 1
+
+    child.hidden = false
+    discard root.buildRenderScene()
+    check scene.containsView(childId)
+    check child.drawCount == 2
+
+  test "a moved view receives independent fragments in its new scene":
+    let
+      firstRoot = newView(frame = rect(0, 0, 100, 70))
+      secondRoot = newView(frame = rect(0, 0, 100, 70))
+      child = newCountedSceneView(rect(4, 5, 30, 20), color(0.7, 0.2, 0.1))
+      childId = child.renderViewId()
+    firstRoot.addSubview(child)
+    let firstScene = firstRoot.buildRenderScene()
+
+    child.removeFromSuperview()
+    secondRoot.addSubview(child)
+    let
+      secondScene = secondRoot.buildRenderScene()
+      secondOutput = secondScene.materialize().canonicalNodes()
+
+    check firstScene.containsView(childId)
+    check secondScene.containsView(childId)
+    discard firstRoot.buildRenderScene()
+    check not firstScene.containsView(childId)
+    check secondScene.containsView(childId)
+    check secondScene.materialize().canonicalNodes() == secondOutput
+
+  test "escaped fragment attachment survives zero one and many roots":
+    let
+      root = newView(frame = rect(0, 0, 120, 80))
+      output = newMultiOutputSceneView(rect(5, 6, 60, 40))
+    root.addSubview(output)
+    let scene = root.buildRenderScene()
+    let
+      fragmentIds = scene.viewFragmentIds(output.renderViewId())
+      baseNodes = scene.materialize().canonicalNodes().len
+
+    output.escapedRootCount = 1
+    output.needsDisplay = true
+    discard root.buildRenderScene()
+    check scene.materialize().canonicalNodes().len == baseNodes + 1
+    check scene.viewFragmentIds(output.renderViewId()) == fragmentIds
+
+    output.escapedRootCount = 3
+    output.needsDisplay = true
+    discard root.buildRenderScene()
+    check scene.materialize().canonicalNodes().len == baseNodes + 3
+    check scene.viewFragmentIds(output.renderViewId()) == fragmentIds
+
+    output.escapedRootCount = 0
+    output.needsDisplay = true
+    discard root.buildRenderScene()
+    check scene.materialize().canonicalNodes().len == baseNodes
+    check scene.viewFragmentIds(output.renderViewId()) == fragmentIds
+
+  test "dynamic explicit layers retain depth-first insertion order":
+    let
+      root = newView(frame = rect(0, 0, 120, 80))
+      output = newMultiOutputSceneView(rect(5, 6, 60, 40))
+    root.addSubview(output)
+    output.drawsTooltip = true
+    output.drawsPopup = true
+
+    let scene = root.buildRenderScene()
+    check scene.materialize().renderLevels() ==
+      @[DefaultDrawLevel, TooltipDrawLevel, PopupDrawLevel]
+
+    output.drawsTooltip = false
+    output.needsDisplay = true
+    discard root.buildRenderScene()
+    check scene.materialize().renderLevels() == @[DefaultDrawLevel, PopupDrawLevel]
+
+    output.drawsPopup = false
+    output.needsDisplay = true
+    discard root.buildRenderScene()
+    check scene.materialize().renderLevels() == @[DefaultDrawLevel]
 
   test "resource manifests merge and retain their union":
     clearImageCache()
@@ -134,6 +389,28 @@ suite "NimKit render fragments":
     merged = nil
     check not hasImage(first.imageId())
     check not hasImage(second.imageId())
+
+  test "removed view resources leave the live manifest at the frame boundary":
+    clearImageCache()
+    let
+      image = newImageResource(testImage(7, 5))
+      root = newView(frame = rect(0, 0, 80, 50))
+      imageView = newImageView(image, frame = rect(3, 4, 20, 15))
+    root.addSubview(imageView)
+
+    let scene = root.buildRenderScene()
+    check scene.renderResources().imageCount() == 1
+    check hasImage(image.imageId())
+
+    imageView.removeFromSuperview()
+    discard root.buildRenderScene()
+    check scene.renderResources().imageCount() == 0
+    check scene.retiredResourceCount() == 1
+    check hasImage(image.imageId())
+
+    scene.acknowledgeRenderGeneration(scene.frameGeneration())
+    check scene.retiredResourceCount() == 0
+    check not hasImage(image.imageId())
 
   test "scene retains replaced manifests until acknowledgement":
     clearImageCache()

--- a/tests/nimkit/renderfragments.nim
+++ b/tests/nimkit/renderfragments.nim
@@ -1,9 +1,10 @@
-import std/unittest
+import std/[hashes, tables, unittest]
 
 import figdraw
 import pkg/pixie except draw
 
 import merenda/nimkit
+import merenda/nimkit/drawing/renderscenes as retainedScenes
 
 type
   SceneDrawView = ref object of View
@@ -17,6 +18,18 @@ type
     escapedRootCount: int
     drawsPopup: bool
     drawsTooltip: bool
+
+  TransformedSceneView = ref object of View
+    translation: Point
+
+  ResourceSceneView = ref object of View
+    image: ImageResource
+    style: TextStyle
+
+  RenderOperationContext = ref object of BackendContext
+    operations: seq[string]
+    entries: Table[Hash, figdraw.Rect]
+    entryMetadata: Table[Hash, AtlasEntryMeta]
 
   CanonicalRenderNode = object
     level: ZLevel
@@ -70,6 +83,112 @@ protocol MultiOutputSceneDrawing of ViewDrawingProtocol:
         color(0.2, 0.3, 0.8),
       )
 
+protocol TransformedSceneDrawing of ViewDrawingProtocol:
+  method draw(view: TransformedSceneView, context: DrawContext) =
+    let transform = context.addFig(
+      context.renderLayer,
+      context.renderParent,
+      Fig(
+        kind: nkTransform,
+        screenBox: figdraw.rect(1, 2, 20, 18),
+        transform: TransformStyle(
+          translation: vec2(view.translation.x, view.translation.y),
+          matrix: scale(vec3(1.25'f32, 0.75'f32, 1.0'f32)),
+          useMatrix: true,
+        ),
+      ),
+    )
+    discard context.addRenderRectangle(
+      context.renderLayer,
+      transform,
+      context.renderRectFor(rect(3, 4, 12, 9)),
+      color(0.6, 0.2, 0.8),
+    )
+
+protocol ResourceSceneDrawing of ViewDrawingProtocol:
+  method draw(view: ResourceSceneView, context: DrawContext) =
+    discard context.addImage(rect(2, 3, 10, 8), view.image)
+    discard context.addText(rect(2, 14, 50, 18), "cached", view.style)
+
+method drawRoundedRectSdf*(
+    context: RenderOperationContext,
+    rect: figdraw.Rect,
+    colors: array[4, ColorRGBA],
+    radii: CornerRadii2D[float32],
+    mode: SdfMode,
+    factor: float32,
+    spread: float32,
+    shapeSize: Vec2,
+) =
+  context.operations.add(
+    "rectangle:" & repr((rect, colors, radii, mode, factor, spread, shapeSize))
+  )
+
+method beginMask*(
+    context: RenderOperationContext,
+    clipRect: figdraw.Rect,
+    radii: CornerRadii2D[float32],
+) =
+  context.operations.add("beginMask:" & repr((clipRect, radii)))
+
+method endMask*(context: RenderOperationContext) =
+  context.operations.add("endMask")
+
+method popMask*(context: RenderOperationContext) =
+  context.operations.add("popMask")
+
+method saveTransform*(context: RenderOperationContext) =
+  context.operations.add("saveTransform")
+
+method restoreTransform*(context: RenderOperationContext) =
+  context.operations.add("restoreTransform")
+
+method translate*(context: RenderOperationContext, value: Vec2) =
+  context.operations.add("translate:" & repr(value))
+
+method applyTransform*(context: RenderOperationContext, value: Mat4) =
+  context.operations.add("applyTransform:" & repr(value))
+
+method supportsAtlasUsage*(context: RenderOperationContext): bool =
+  discard context
+
+method entriesPtr*(context: RenderOperationContext): ptr Table[Hash, figdraw.Rect] =
+  context.entries.addr
+
+method atlasEntryMetaPtr*(
+    context: RenderOperationContext
+): var Table[Hash, AtlasEntryMeta] =
+  context.entryMetadata
+
+method atlasSize*(context: RenderOperationContext): int =
+  discard context
+  64
+
+method atlasPackedArea*(context: RenderOperationContext): int =
+  discard context
+
+method putImage*(context: RenderOperationContext, key: Hash, image: Image) =
+  context.entries[key] = figdraw.rect(
+    0,
+    0,
+    image.width.float32 / context.atlasSize().float32,
+    image.height.float32 / context.atlasSize().float32,
+  )
+
+method putImage*(context: RenderOperationContext, image: ImgObj) =
+  case image.kind
+  of PixieImg:
+    context.putImage(image.id.Hash, image.pimg)
+  of FlippyImg:
+    if image.flippy.mipmaps.len > 0:
+      let pixels = image.flippy.mipmaps[0]
+      context.entries[image.id.Hash] = figdraw.rect(
+        0,
+        0,
+        pixels.width.float32 / context.atlasSize().float32,
+        pixels.height.float32 / context.atlasSize().float32,
+      )
+
 proc newSceneDrawView(frame: Rect): SceneDrawView =
   result = SceneDrawView()
   result.initViewFields(frame)
@@ -89,6 +208,34 @@ proc newMultiOutputSceneView(frame: Rect): MultiOutputSceneView =
   result = MultiOutputSceneView()
   result.initViewFields(frame)
   discard result.withProtocol(MultiOutputSceneDrawing)
+
+proc newTransformedSceneView(frame: Rect, translation: Point): TransformedSceneView =
+  result = TransformedSceneView(translation: translation)
+  result.initViewFields(frame)
+  discard result.withProtocol(TransformedSceneDrawing)
+
+proc newResourceSceneView(
+    frame: Rect, image: ImageResource, style: TextStyle
+): ResourceSceneView =
+  result = ResourceSceneView(image: image, style: style)
+  result.initViewFields(frame)
+  discard result.withProtocol(ResourceSceneDrawing)
+
+proc renderedOperations(renders: var Renders): seq[string] =
+  let context = RenderOperationContext(
+    entries: initTable[Hash, figdraw.Rect](),
+    entryMetadata: initTable[Hash, AtlasEntryMeta](),
+  )
+  context.renderRoot(renders)
+  context.operations
+
+proc renderedOperations(scene: RenderScene): seq[string] =
+  let context = RenderOperationContext(
+    entries: initTable[Hash, figdraw.Rect](),
+    entryMetadata: initTable[Hash, AtlasEntryMeta](),
+  )
+  retainedScenes.renderRoot(scene, context)
+  context.operations
 
 proc renderLevels(renders: Renders): seq[ZLevel] =
   for level, _ in renders.pairs():
@@ -367,6 +514,73 @@ suite "NimKit render fragments":
     output.needsDisplay = true
     discard root.buildRenderScene()
     check scene.materialize().renderLevels() == @[DefaultDrawLevel]
+
+  test "fragment traversal preserves clips transforms and shadows":
+    let
+      root = newView(frame = rect(0, 0, 120, 80))
+      transformed = newTransformedSceneView(rect(8, 9, 60, 40), initPoint(6, -3))
+      firstShadow = dropShadow(color(0, 0, 0, 0.4), y = 3.0, blur = 7.0)
+    root.clipsToBounds = true
+    transformed.shadow = @[firstShadow]
+    root.addSubview(transformed)
+
+    var monolithic = root.buildRenders()
+    let scene = root.buildRenderScene()
+    check scene.renderedOperations() == monolithic.renderedOperations()
+
+    transformed.translation = initPoint(-2, 5)
+    transformed.shadow = @[dropShadow(color(0.1, 0.2, 0.3, 0.5), x = 2.0, blur = 4.0)]
+    transformed.needsDisplay = true
+    discard root.buildRenderScene()
+
+    let
+      expectedRoot = newView(frame = rect(0, 0, 120, 80))
+      expectedTransformed =
+        newTransformedSceneView(rect(8, 9, 60, 40), initPoint(-2, 5))
+    expectedRoot.clipsToBounds = true
+    expectedTransformed.shadow =
+      @[dropShadow(color(0.1, 0.2, 0.3, 0.5), x = 2.0, blur = 4.0)]
+    expectedRoot.addSubview(expectedTransformed)
+    monolithic = expectedRoot.buildRenders()
+    check scene.renderedOperations() == monolithic.renderedOperations()
+
+  test "font and image replacement updates the live manifest":
+    clearImageCache()
+    let
+      firstImage = newImageResource(testImage(5, 5))
+      secondImage = newImageResource(testImage(7, 6))
+      firstStyle = TextStyle(
+        color: color(0.1, 0.2, 0.3), fontName: defaultFontName(), fontSize: 11.0
+      )
+      secondStyle = TextStyle(
+        color: color(0.7, 0.2, 0.1), fontName: defaultFontName(), fontSize: 17.0
+      )
+      firstFont = firstStyle.textFont()
+      secondFont = secondStyle.textFont()
+      view = newResourceSceneView(rect(0, 0, 80, 40), firstImage, firstStyle)
+    var monolithic = view.buildRenders()
+    let scene = view.buildRenderScene()
+
+    check scene.materialize().canonicalNodes() == monolithic.canonicalNodes()
+    check scene.renderResources().containsImage(firstImage.imageId())
+    check not scene.renderResources().containsImage(secondImage.imageId())
+    check scene.renderResources().containsFont(firstFont.fontId())
+    check not scene.renderResources().containsFont(secondFont.fontId())
+
+    view.image = secondImage
+    view.style = secondStyle
+    view.needsDisplay = true
+    discard view.buildRenderScene()
+
+    let expected = newResourceSceneView(rect(0, 0, 80, 40), secondImage, secondStyle)
+    monolithic = expected.buildRenders()
+
+    check scene.materialize().canonicalNodes() == monolithic.canonicalNodes()
+    check not scene.renderResources().containsImage(firstImage.imageId())
+    check scene.renderResources().containsImage(secondImage.imageId())
+    check not scene.renderResources().containsFont(firstFont.fontId())
+    check scene.renderResources().containsFont(secondFont.fontId())
+    check scene.retiredResourceCount() == 1
 
   test "resource manifests merge and retain their union":
     clearImageCache()

--- a/tests/nimkit/renderfragments.nim
+++ b/tests/nimkit/renderfragments.nim
@@ -15,6 +15,9 @@ type
     drawLevelValue: ZLevel
     invalidatesDuringDraw: bool
 
+  VisibleRectSceneView = ref object of View
+    drawCount: int
+
   MultiOutputSceneView = ref object of View
     escapedRootCount: int
     drawsPopup: bool
@@ -61,6 +64,12 @@ protocol CountedSceneDrawing of ViewDrawingProtocol:
     if view.invalidatesDuringDraw:
       view.invalidatesDuringDraw = false
       view.needsDisplay = true
+
+protocol VisibleRectSceneDrawing of ViewDrawingProtocol:
+  method draw(view: VisibleRectSceneView, context: DrawContext) =
+    inc view.drawCount
+    discard context.visibleRect()
+    context.addRectangle(rect(1, 2, 9, 7), color(0.2, 0.4, 0.8))
 
 protocol MultiOutputSceneDrawing of ViewDrawingProtocol:
   method draw(view: MultiOutputSceneView, context: DrawContext) =
@@ -207,6 +216,11 @@ proc newCountedSceneView(frame: Rect, drawColor: Color): CountedSceneView =
   result = CountedSceneView(drawColor: drawColor)
   result.initViewFields(frame)
   discard result.withProtocol(CountedSceneDrawing)
+
+proc newVisibleRectSceneView(frame: Rect): VisibleRectSceneView =
+  result = VisibleRectSceneView()
+  result.initViewFields(frame)
+  discard result.withProtocol(VisibleRectSceneDrawing)
 
 proc newMultiOutputSceneView(frame: Rect): MultiOutputSceneView =
   result = MultiOutputSceneView()
@@ -363,7 +377,7 @@ suite "NimKit render fragments":
       firstFragmentIds = scene.rootFragmentIds()
       materialized = scene.materialize()
 
-    check sceneDrawCount == 2
+    check sceneDrawCount == 1
     check materialized.renderLevels() == monolithic.renderLevels()
     check materialized.canonicalNodes() == monolithic.canonicalNodes()
     check scene.viewEntryCount() == 4
@@ -373,14 +387,14 @@ suite "NimKit render fragments":
     let cachedScene = root.buildRenderScene()
     check cachedScene == scene
     check cachedScene.frameGeneration() == firstGeneration
-    check sceneDrawCount == 2
+    check sceneDrawCount == 1
 
     custom.needsDisplay = true
     let updatedScene = root.buildRenderScene()
     check updatedScene == scene
     check updatedScene.frameGeneration() == firstGeneration + 1
     check updatedScene.rootFragmentIds() == firstFragmentIds
-    check sceneDrawCount == 3
+    check sceneDrawCount == 2
     check updatedScene.materialize().canonicalNodes() ==
       root.buildRenders().canonicalNodes()
 
@@ -470,6 +484,52 @@ suite "NimKit render fragments":
     check scene.viewCaptureGeneration(root.renderViewId()) == 1
     check scene.viewCaptureGeneration(parent.renderViewId()) == 2
     check scene.viewCaptureGeneration(child.renderViewId()) == 2
+
+  test "scroll placement preserves drawing that does not read the visible rect":
+    let
+      root = newView(frame = rect(0, 0, 180, 120))
+      viewport = newCountedSceneView(rect(0, 0, 100, 80), color(0.2, 0.3, 0.4))
+      document = newCountedSceneView(rect(0, 0, 100, 240), color(0.7, 0.2, 0.1))
+    viewport.clipsToBounds = true
+    viewport.addSubview(document)
+    root.addSubview(viewport)
+    let scene = root.buildRenderScene()
+    let
+      sceneIdentity = retainedScenes.sceneIdentity(scene)
+      initialGeneration = scene.frameGeneration()
+      documentFragments = scene.viewFragmentIds(document.renderViewId())
+      replica = retainedScenes.newRenderSceneReplica()
+    var initial = retainedScenes.newRenderSceneUpdate(scene, 0, 0)
+    retainedScenes.apply(replica, initial)
+
+    viewport.bounds = rect(0, 24, 100, 80)
+    discard root.buildRenderScene()
+    var update =
+      retainedScenes.newRenderSceneUpdate(scene, sceneIdentity, initialGeneration)
+
+    check viewport.drawCount == 2
+    check document.drawCount == 1
+    check scene.viewCaptureGeneration(document.renderViewId()) == 1
+    check scene.viewFragmentIds(document.renderViewId()) == documentFragments
+    check retainedScenes.capturedViewCount(update) == 1
+    retainedScenes.apply(replica, update)
+    check replica.materialize().canonicalNodes() == scene.materialize().canonicalNodes()
+
+  test "visible-rect drawing recaptures when scrolling changes its clip":
+    let
+      root = newView(frame = rect(0, 0, 180, 120))
+      viewport = newCountedSceneView(rect(0, 0, 100, 80), color(0.2, 0.3, 0.4))
+      document = newVisibleRectSceneView(rect(0, 0, 100, 240))
+    viewport.clipsToBounds = true
+    viewport.addSubview(document)
+    root.addSubview(viewport)
+    let scene = root.buildRenderScene()
+
+    viewport.bounds = rect(0, 24, 100, 80)
+    discard root.buildRenderScene()
+
+    check document.drawCount == 2
+    check scene.viewCaptureGeneration(document.renderViewId()) == 2
 
   test "appearance generation changes recapture inherited contributions":
     let

--- a/tests/nimkit/threading.nim
+++ b/tests/nimkit/threading.nim
@@ -11,9 +11,13 @@ import merenda/nimkit/app/windows
 import merenda/nimkit/foundation/selectors
 import merenda/nimkit/foundation/types as nimkitTypes
 import merenda/nimkit/drawing
+import merenda/nimkit/drawing/renderscenes as retainedScenes
 import merenda/nimkit/view/views
 
-type RaisingDrawView = ref object of View
+type
+  RaisingDrawView = ref object of View
+  ThreadResourceView = ref object of View
+    image: ImageResource
 
 protocol RaisingDrawing of ViewDrawingProtocol:
   method draw(view: RaisingDrawView, context: DrawContext) =
@@ -21,10 +25,21 @@ protocol RaisingDrawing of ViewDrawingProtocol:
     discard context
     raise newException(ValueError, "intentional drawing failure")
 
+protocol ThreadResourceDrawing of ViewDrawingProtocol:
+  method draw(view: ThreadResourceView, context: DrawContext) =
+    discard context.addImage(nimkitTypes.rect(2, 3, 12, 8), view.image)
+
 proc newRaisingDrawView(frame: nimkitTypes.Rect): RaisingDrawView =
   result = RaisingDrawView()
   initViewFields(result, frame)
   discard result.withProtocol(RaisingDrawing)
+
+proc newThreadResourceView(
+    frame: nimkitTypes.Rect, image: ImageResource
+): ThreadResourceView =
+  result = ThreadResourceView(image: image)
+  initViewFields(result, frame)
+  discard result.withProtocol(ThreadResourceDrawing)
 
 proc waitForRendererThread(client: nimkitBackend.ThreadRendererClient): int =
   for _ in 0 ..< 100:
@@ -109,6 +124,76 @@ suite "NimKit threading":
     require host.channels.pollLatestRender(latest)
     check latest.logicalSize == nimkitTypes.initSize(100.0, 20.0)
     check not host.channels.renders.tryRecv(latest)
+
+  test "fragment updates coalesce cumulatively from the acknowledged generation":
+    let
+      runtime = nimkitBackend.newThreadRenderer()
+      host = nimkitBackend.newThreadHostClient(runtime.client)
+      root = newView(frame = nimkitTypes.rect(0, 0, 180, 100))
+      first = newView(frame = nimkitTypes.rect(5, 5, 50, 30))
+      second = newView(frame = nimkitTypes.rect(60, 5, 50, 30))
+      logicalSize = nimkitTypes.initSize(180.0, 100.0)
+    root.addSubview(first)
+    root.addSubview(second)
+
+    let scene = root.buildRenderScene()
+    doAssert host.submitRenderScene(scene, logicalSize)
+    var initial: nimkitBackend.ThreadRenderSnapshot
+    require host.channels.renders.tryRecv(initial)
+    check initial.usesFragments
+    check initial.targetGeneration == 1
+    check retainedScenes.fullSnapshot(initial.sceneUpdate)
+    check retainedScenes.capturedViewCount(initial.sceneUpdate) == 3
+    check initial.status(1, 0, 0, 0) == nimkitBackend.trssAccepted
+    check initial.status(2, 0, 0, 0) == nimkitBackend.trssStaleTarget
+    check initial.status(1, initial.renderId, 0, 0) == nimkitBackend.trssStaleRender
+
+    let replica = retainedScenes.newRenderSceneReplica()
+    var initialUpdate = move initial.sceneUpdate
+    retainedScenes.apply(replica, initialUpdate)
+    host.acknowledgeRender(initial.renderId)
+    let acknowledgedGeneration = scene.frameGeneration()
+
+    first.backgroundColor = color(0.8, 0.2, 0.1)
+    first.needsDisplay = true
+    discard root.buildRenderScene()
+    doAssert host.submitRenderScene(scene, logicalSize)
+
+    second.backgroundColor = color(0.1, 0.7, 0.3)
+    second.needsDisplay = true
+    discard root.buildRenderScene()
+    doAssert host.submitRenderScene(scene, logicalSize)
+
+    var latest: nimkitBackend.ThreadRenderSnapshot
+    require host.channels.pollLatestRender(latest)
+    check latest.usesFragments
+    check not retainedScenes.fullSnapshot(latest.sceneUpdate)
+    check retainedScenes.baseGeneration(latest.sceneUpdate) == acknowledgedGeneration
+    check retainedScenes.capturedViewCount(latest.sceneUpdate) == 2
+    check latest.status(1, initial.renderId, retainedScenes.sceneIdentity(scene), 0) ==
+      nimkitBackend.trssSceneGap
+    check not host.channels.renders.tryRecv(latest)
+
+    var latestUpdate = move latest.sceneUpdate
+    check retainedScenes.canApply(
+      latestUpdate, retainedScenes.sceneIdentity(scene), acknowledgedGeneration
+    )
+    retainedScenes.apply(replica, latestUpdate)
+    check replica.materialize().len(0.ZLevel) == scene.materialize().len(0.ZLevel)
+    host.acknowledgeRender(latest.renderId)
+
+    let replacement = newView(frame = nimkitTypes.rect(0, 0, 180, 100))
+    let replacementScene = replacement.buildRenderScene()
+    doAssert host.submitRenderScene(replacementScene, logicalSize)
+    var barrier: nimkitBackend.ThreadRenderSnapshot
+    require host.channels.pollLatestRender(barrier)
+    check retainedScenes.fullSnapshot(barrier.sceneUpdate)
+
+    host.rejectRenderUpdate(barrier.renderId)
+    doAssert host.submitRenderScene(replacementScene, logicalSize)
+    var recovery: nimkitBackend.ThreadRenderSnapshot
+    require host.channels.pollLatestRender(recovery)
+    check retainedScenes.fullSnapshot(recovery.sceneUpdate)
 
   test "application loop stays on the platform thread when rendering is direct":
     let
@@ -210,3 +295,39 @@ suite "NimKit threading":
     check hasImage(second.imageId())
     host.clearRenderResources()
     check not hasImage(second.imageId())
+
+  test "fragment acknowledgements release the originating scene resources":
+    clearImageCache()
+    let
+      runtime = nimkitBackend.newThreadRenderer()
+      host = nimkitBackend.newThreadHostClient(runtime.client)
+      first = newImageResource(pixie.newImage(2, 2))
+      second = newImageResource(pixie.newImage(3, 3))
+      view = newThreadResourceView(nimkitTypes.rect(0, 0, 40, 30), first)
+      logicalSize = nimkitTypes.initSize(40.0, 30.0)
+    var scene = view.buildRenderScene()
+
+    doAssert host.submitRenderScene(scene, logicalSize)
+    var initial: nimkitBackend.ThreadRenderSnapshot
+    require host.channels.pollLatestRender(initial)
+    host.acknowledgeRender(initial.renderId)
+    check hasImage(first.imageId())
+
+    view.image = second
+    view.needsDisplay = true
+    discard view.buildRenderScene()
+    check scene.retiredResourceCount() == 1
+    doAssert host.submitRenderScene(scene, logicalSize)
+    var replacement: nimkitBackend.ThreadRenderSnapshot
+    require host.channels.pollLatestRender(replacement)
+    check hasImage(first.imageId())
+    check hasImage(second.imageId())
+
+    host.acknowledgeRender(replacement.renderId)
+    check scene.retiredResourceCount() == 0
+    check not hasImage(first.imageId())
+    check hasImage(second.imageId())
+    host.clearRenderResources()
+    view.invalidateRenderCache()
+    scene = nil
+    clearImageCache()

--- a/tests/tnimkit.nim
+++ b/tests/tnimkit.nim
@@ -5,9 +5,11 @@ import nimkit/application_icon
 import nimkit/backrefs_arc
 import nimkit/filesearch
 import nimkit/font_layout
+import nimkit/images
 import nimkit/markdownviews
 import nimkit/renderfragments
 import nimkit/resources
 import nimkit/svgimages
 import nimkit/svgpathloader
+import nimkit/threading
 import nimkit/urls


### PR DESCRIPTION
## Summary

- cache each visible view as stable placement, shell, clipped-content transform, self-drawing, child-placement, escaped-content transform, and explicit layer-root fragments
- update scrolling through retained transform nodes: bounds-origin changes reconcile structure without recapturing clean view drawing, while drawing that explicitly reads `DrawContext.visibleRect` still recaptures when its visible bounds change
- eliminate hidden retained-cache copies by mutating scene table entries in place and borrowing the resolved appearance during synchronous capture instead of copying full `RenderList` and theme values on every view walk
- invalidate only moving scroll chrome during scrolling; the document, clip view, and static scroll-view drawing stay retained
- render retained fragments directly on both synchronous and dedicated static renderer paths
- send cumulative, move-only scene updates from the last acknowledged generation; full placement order makes structural reconciliation deterministic while only changed drawing carries node payloads
- keep application and renderer fragment graphs independent, including deep ARC-isolated copies of nested glyph and drawable sequences
- bound and coalesce render submissions, reject stale target/render/scene generations, and recover with a full update after a gap or target replacement
- transfer only live font/image IDs, retain replaced resources through acknowledgement, and filter atlas-recovery replay to the accepted scene
- preserve lazy monolithic `buildRenders` materialization for compatibility and diagnostics; dynlib behavior is unchanged

## README scroll profile

Release-mode CPU-side profile on an Apple M3 Pro using the repository's 36,005-byte README in a 760 x 540 `MarkdownView`. Each value below is the median of five complete runs; each run scrolls bidirectionally for 240 measured frames after 20 warmups. GPU execution is excluded. Application preparation, bounded-channel handoff, renderer-replica application, acknowledgement, and renderer-facing topology traversal are serialized so aggregate CPU is comparable.

| Pipeline | wall median | wall p95 | CPU median | CPU p95 | prepare | transfer | apply/ack | traversal |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `main` monolithic | 11.545 ms | 12.308 ms | 11.544 ms | 12.306 ms | 11.023 ms | 0.000 ms | 0.001 ms | 0.455 ms |
| fragment-native | 0.047 ms | 0.051 ms | 0.047 ms | 0.050 ms | 0.024 ms | 0.001 ms | 0.002 ms | 0.014 ms |

Median aggregate CPU is 99.6% lower (about 246x faster), with both paths still measured over the same serialized CPU-side work. The Markdown document contribution was captured zero times during measured scrolling. Of 1,200 view placements, 238 (19.8%) carried changed drawing, corresponding to the small moving scrollbar contribution on changed frames; the document, clip view, and static scroll-view drawing remained retained.

The prior 1.483 ms fragment result was dominated by Nim value copies in cache lookups, not fragment rebuilding. Reading a `ViewRenderEntry` out of the table copied its retained render lists, including the Markdown glyph arrays, on every scroll frame. In-place table mutation plus a borrowed appearance snapshot reduced that fragment path by another 96.8%, from 1.483 ms to 0.047 ms median CPU.

FigDraw's `renderRoot(RenderFragments)` walks the existing `levels`, `roots`, and recursive `children` cursor topology. Fragment attachment constructs tracking metadata eagerly; clean traversal neither clones `RenderList`s nor invokes `materialize()`. The final profile traversed 15,600 existing nodes (65/frame) in 0.014 ms/frame median, versus 0.455 ms/frame for 12,000 monolithic nodes. No hidden whole-tree construction was found in the renderer path. Its remaining measurable micro-cost is a small `seq[RenderChild]` metadata copy from `getOrDefault` during child lookup; borrowing or iterating that slot directly is a separate FigDraw optimization, not a Merenda performance cliff.

Reproduce with:

```sh
atlas-run tests tests/benchmark_markdown_scroll.nim -- -d:release
atlas-run tests tests/benchmark_markdown_scroll.nim -- -d:release -d:fragmentNativeProfile
```

The benchmark constants are `intdefine`s, so a long sampling run can use `-d:ProfileFrames=300000`. That run held the same 0.047 ms wall / 0.046 ms CPU median and 0.053 ms / 0.052 ms p95 over 300,000 frames, with zero document captures.

## Validation

- `atlas-run tests`
- `atlas-run tests tnimkit`
- `atlas-run tests --compile-only examples/all_compile.nim`
- release-mode README scroll profiles on `main` and this branch
- 300,000-frame release sampling run

Coverage includes placement-only scrolling, visible-rectangle-dependent drawing, cumulative threaded coalescing, stale target/render/scene rejection, full layer and scene barriers, resource acknowledgement, renderer-thread atlas recovery, monolithic and renderer-operation equivalence, clips, transforms, shadows, layer ordering, removed views, and font/image replacement.

## Deferred

- FigDraw's optional debug topology validator
- borrowing FigDraw child metadata during traversal instead of copying its small sequence
- rasterized view/texture caching
- mutable fragment graphs shared across threads
- dynlib fragment integration
