### PR TITLE
Use Matter for Markdown syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,10 @@ Language-tagged fenced code blocks use the same frontend-neutral
 `SyntaxTokenSpan` values; `MarkdownStyle.syntaxTokenColors` maps their classes to
 presentation colors. The Markdown parser still owns all document structure and
 inline styling—the syntax highlighter never receives the Markdown source outside
-the contents of a tagged fence. NimKit's built-in SynEdit classifier is the
-default, while a nil highlighter or unknown language retains the ordinary
-monospace `codeColor`.
+the contents of a tagged fence. Matter's bundled TextMate grammars are the
+default in both NimKit and Kosmo, while SynEdit and Moe remain available as
+alternative highlighters. A nil highlighter or unknown language retains the
+ordinary monospace `codeColor`.
 
 ## Cached URL Assets
 

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -17,6 +17,7 @@ requires "cborious"
 requires "unicodedb >= 0.14.0"
 requires "faststreams >= 0.5.1"
 requires "gh:elcritch/nim-markdown#devel[regex]"
+requires "gh:elcritch/matter >= 0.2.2"
 requires "gh:elcritch/terminex >= 0.2.1"
 requires "https://github.com/Araq/iconbundler"
 

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -2370,7 +2370,9 @@ proc newKosmoEditorPane(editorView: KosmoEditorView): KosmoEditorPane =
     markdownView = KosmoMarkdownView()
     markdownControls = newKosmoMarkdownControls(editorView)
     activeIndicator = newKosmoPaneIndicator()
-  markdownView.initMarkdownViewFields(syntaxHighlighter = moeSyntaxHighlighter)
+  markdownView.initMarkdownViewFields(
+    syntaxHighlighter = nimkit.matterSyntaxHighlighter
+  )
   markdownView.editorView = editorView.unsafeWeakRef()
   result = KosmoEditorPane(
     documentTabs: editorView.documentTabs,

--- a/src/merenda/nimkit.nim
+++ b/src/merenda/nimkit.nim
@@ -43,6 +43,7 @@ import ./nimkit/controls/matrices
 import ./nimkit/controls/menus
 import ./nimkit/app/modelcontrollers
 import ./nimkit/text/markdownviews
+import ./nimkit/text/matterhighlighting
 import ./nimkit/text/monotextviews
 import ./nimkit/text/syneditviews
 import ./nimkit/text/syntaxhighlighting
@@ -130,6 +131,7 @@ export matrices
 export menus
 export modelcontrollers
 export markdownviews
+export matterhighlighting
 export monotextviews
 export syneditviews
 export syntaxhighlighting

--- a/src/merenda/nimkit/text/markdownviews.nim
+++ b/src/merenda/nimkit/text/markdownviews.nim
@@ -32,7 +32,7 @@ import ../themes
 import ../view/views
 import ./markdownhtmlimages
 import ./markdownparsing
-import ./syneditviews
+import ./matterhighlighting
 import ./syntaxhighlighting
 import ./texteditors
 import ./textstorage
@@ -40,6 +40,7 @@ import ./texttypes
 
 export texteditors
 export textstorage
+export matterhighlighting
 export syntaxhighlighting
 export texttypes
 
@@ -1152,7 +1153,7 @@ proc markdownDocument(
     style = initMarkdownStyle(),
     imageLoader: MarkdownImageLoader = nil,
     imageContentTypeLoader: MarkdownImageContentTypeLoader = nil,
-    syntaxHighlighter: SyntaxHighlighter = synEditSyntaxHighlighter,
+    syntaxHighlighter: SyntaxHighlighter = matterSyntaxHighlighter,
 ): MarkdownDocument =
   var builder = MarkdownBuilder(
     style: style,
@@ -1171,7 +1172,7 @@ proc markdownDocument(
     config: MarkdownParserConfig = nil,
     imageLoader: MarkdownImageLoader = nil,
     imageContentTypeLoader: MarkdownImageContentTypeLoader = nil,
-    syntaxHighlighter: SyntaxHighlighter = synEditSyntaxHighlighter,
+    syntaxHighlighter: SyntaxHighlighter = matterSyntaxHighlighter,
 ): MarkdownDocument =
   source.parseMarkdownRoot(config).markdownDocument(
     style, imageLoader, imageContentTypeLoader, syntaxHighlighter
@@ -1181,7 +1182,7 @@ proc markdownTextStorage*(
     source: string,
     style = initMarkdownStyle(),
     config: MarkdownParserConfig = nil,
-    syntaxHighlighter: SyntaxHighlighter = synEditSyntaxHighlighter,
+    syntaxHighlighter: SyntaxHighlighter = matterSyntaxHighlighter,
 ): TextStorage =
   ## Parses `source` and returns native attributed text without creating a view.
   ## A nil configuration selects GFM so tables and strikethrough work by default.
@@ -1846,7 +1847,7 @@ proc initMarkdownViewFields*(
     imageBasePath = "",
     imageLoader: MarkdownImageLoader = nil,
     urlAssetLoader: UrlAssetLoader = nil,
-    syntaxHighlighter: SyntaxHighlighter = synEditSyntaxHighlighter,
+    syntaxHighlighter: SyntaxHighlighter = matterSyntaxHighlighter,
 ) =
   ## Initializes a custom `MarkdownView` subtype.
   ##
@@ -1893,7 +1894,7 @@ proc newMarkdownView*(
     imageBasePath = "",
     imageLoader: MarkdownImageLoader = nil,
     urlAssetLoader: UrlAssetLoader = nil,
-    syntaxHighlighter: SyntaxHighlighter = synEditSyntaxHighlighter,
+    syntaxHighlighter: SyntaxHighlighter = matterSyntaxHighlighter,
 ): MarkdownView =
   ## Creates a scrollable, selectable, read-only Markdown document view.
   ##

--- a/src/merenda/nimkit/text/matterhighlighting.nim
+++ b/src/merenda/nimkit/text/matterhighlighting.nim
@@ -1,0 +1,252 @@
+## Matter's TextMate grammars adapted to NimKit's frontend-neutral syntax spans.
+##
+## Grammar archives are embedded at compile time so installed applications do
+## not need to locate Matter's package data at runtime. Each thread lazily
+## compiles and caches only the grammars it uses.
+
+import std/[compilesettings, options, os, strutils, tables, unicode]
+
+import matter
+
+import ./syntaxhighlighting
+import ./texttypes
+
+type EmbeddedGrammarArchive = tuple[path, contents: string]
+
+const ZipLocalHeader = "PK\x03\x04"
+
+proc findMatterPackageRoot(): string {.compileTime.} =
+  for searchPath in querySettingSeq(MultipleValueSetting.searchPaths):
+    let
+      sourceDir = searchPath
+      packageRoot = sourceDir.parentDir
+    if fileExists(sourceDir / "matter.nim") and
+        dirExists(packageRoot / "data" / "grammars"):
+      return packageRoot
+  raise newException(ValueError, "could not locate Matter's grammar archives")
+
+const MatterPackageRoot = findMatterPackageRoot()
+
+template embedGrammarArchive(package: untyped): untyped =
+  (
+    path: package.dataArchivePath,
+    contents: staticRead(MatterPackageRoot / package.dataArchivePath),
+  )
+
+const EmbeddedGrammarArchives = [
+  embedGrammarArchive(vscodeCppPackage),
+  embedGrammarArchive(vscodeCsharpPackage),
+  embedGrammarArchive(vscodeDiffPackage),
+  embedGrammarArchive(vscodeDockerPackage),
+  embedGrammarArchive(vscodeGitBasePackage),
+  embedGrammarArchive(vscodeGoPackage),
+  embedGrammarArchive(vscodeHtmlPackage),
+  embedGrammarArchive(vscodeJavaPackage),
+  embedGrammarArchive(vscodeJavascriptPackage),
+  embedGrammarArchive(vscodeLatexPackage),
+  embedGrammarArchive(vscodeLogPackage),
+  embedGrammarArchive(vscodeLuaPackage),
+  embedGrammarArchive(vscodeMarkdownPackage),
+  embedGrammarArchive(vscodeRustPackage),
+  embedGrammarArchive(vscodeShellscriptPackage),
+  embedGrammarArchive(vscodeTypescriptPackage),
+  embedGrammarArchive(vscodeXmlPackage),
+  embedGrammarArchive(vscodeYamlPackage),
+  embedGrammarArchive(vscodeJsonPackage),
+  embedGrammarArchive(vscodePythonPackage),
+  embedGrammarArchive(nimVscodePackage),
+  embedGrammarArchive(fishPackage),
+  embedGrammarArchive(haskellPackage),
+  embedGrammarArchive(hyprlangPackage),
+  embedGrammarArchive(tomlPackage),
+  embedGrammarArchive(lispPackage),
+  embedGrammarArchive(astroPackage),
+  embedGrammarArchive(tclPackage),
+]
+
+var
+  matterGrammarCache {.threadvar.}: Table[string, Grammar]
+  matterGrammarCacheInitialized {.threadvar.}: bool
+
+func littleEndian16(contents: string, offset: int): int =
+  ord(contents[offset]) or (ord(contents[offset + 1]) shl 8)
+
+func littleEndian32(contents: string, offset: int): int =
+  ord(contents[offset]) or (ord(contents[offset + 1]) shl 8) or
+    (ord(contents[offset + 2]) shl 16) or (ord(contents[offset + 3]) shl 24)
+
+func archiveContents(path: string): string =
+  for archive in EmbeddedGrammarArchives:
+    if archive.path == path:
+      return archive.contents
+
+proc readStoredZipMember(contents, member: string): string =
+  var offset = 0
+  while offset + 30 <= contents.len and
+      contents[offset ..< offset + ZipLocalHeader.len] == ZipLocalHeader:
+    let
+      flags = contents.littleEndian16(offset + 6)
+      compression = contents.littleEndian16(offset + 8)
+      compressedSize = contents.littleEndian32(offset + 18)
+      nameSize = contents.littleEndian16(offset + 26)
+      extraSize = contents.littleEndian16(offset + 28)
+      nameStart = offset + 30
+      dataStart = nameStart + nameSize + extraSize
+      dataStop = dataStart + compressedSize
+    if flags != 0 or compression != 0 or dataStop > contents.len:
+      raise newException(MatterError, "invalid bundled Matter grammar archive")
+    if contents[nameStart ..< nameStart + nameSize] == member:
+      return contents[dataStart ..< dataStop]
+    offset = dataStop
+  raise newException(MatterError, "missing bundled Matter grammar: " & member)
+
+func normalizedMatterLanguage(language: string): string =
+  let name = language.strip().toLowerAscii()
+  case name
+  of "c++", "cc", "cxx", "hpp", "hxx": "cpp"
+  of "c#", "cs": "csharp"
+  of "docker": "dockerfile"
+  of "golang": "go"
+  of "hs": "haskell"
+  of "htm": "html"
+  of "js": "javascript"
+  of "luau": "lua"
+  of "md": "markdown"
+  of "nims", "nimble": "nim"
+  of "py": "python"
+  of "rs": "rust"
+  of "sh", "bash": "shell"
+  of "tex": "latex"
+  of "ts": "typescript"
+  of "yml": "yaml"
+  else: name
+
+proc grammarForLanguage(language: string): Grammar =
+  let modeName = language.normalizedMatterLanguage()
+  if modeName.len == 0:
+    return
+  if not matterGrammarCacheInitialized:
+    matterGrammarCache = initTable[string, Grammar]()
+    matterGrammarCacheInitialized = true
+  if matterGrammarCache.hasKey(modeName):
+    return matterGrammarCache[modeName]
+
+  let primary = findMoeGrammar(modeName)
+  if primary.isNone:
+    matterGrammarCache[modeName] = nil
+    return
+
+  let registry = newRegistry()
+  for contribution in importedGrammars(modeName):
+    let archive = archiveContents(contribution.dataArchivePath)
+    if archive.len == 0:
+      raise newException(
+        MatterError, "missing bundled Matter archive: " & contribution.dataArchivePath
+      )
+    registry.addGrammar(
+      parseRawGrammar(
+        archive.readStoredZipMember(contribution.archiveMember),
+        contribution.archiveMember,
+      )
+    )
+  result = registry.loadGrammar(primary.get.scopeName)
+  matterGrammarCache[modeName] = result
+
+func scopeMatches(scope, prefix: string): bool =
+  scope == prefix or
+    (scope.len > prefix.len and scope.startsWith(prefix) and scope[prefix.len] == '.')
+
+func hasScope(scopes: openArray[string], prefixes: openArray[string]): bool =
+  for scope in scopes:
+    for prefix in prefixes:
+      if scope.scopeMatches(prefix):
+        return true
+
+func syntaxTokenClass(scopes: openArray[string]): SyntaxTokenClass =
+  if scopes.hasScope(["comment"]):
+    stcComment
+  elif scopes.hasScope(["string", "regexp"]):
+    stcString
+  elif scopes.hasScope(["constant.numeric"]):
+    stcNumber
+  elif scopes.hasScope(["meta.preprocessor", "keyword.control.directive"]):
+    stcPreprocessor
+  elif scopes.hasScope(["keyword.operator"]):
+    stcOperator
+  elif scopes.hasScope(["keyword", "storage", "constant.language"]):
+    stcKeyword
+  elif scopes.hasScope(["punctuation"]):
+    stcPunctuation
+  elif scopes.hasScope(["entity", "support", "variable"]):
+    stcIdentifier
+  else:
+    stcOther
+
+proc byteRuneMap(source: string): seq[int] =
+  result = newSeq[int](source.len + 1)
+  var
+    byteIndex = 0
+    runeIndex = 0
+  while byteIndex < source.len:
+    let nextByte = min(byteIndex + max(runeLenAt(source, byteIndex), 1), source.len)
+    for index in byteIndex ..< nextByte:
+      result[index] = runeIndex
+    byteIndex = nextByte
+    inc runeIndex
+  result[source.len] = runeIndex
+
+proc addSpan(
+    spans: var seq[SyntaxTokenSpan],
+    byteToRune: openArray[int],
+    startByte, stopByte: int,
+    tokenClass: SyntaxTokenClass,
+) =
+  if tokenClass == stcOther:
+    return
+  let
+    start = max(0, min(startByte, byteToRune.high))
+    stop = max(start, min(stopByte, byteToRune.high))
+    startRune = byteToRune[start]
+    stopRune = byteToRune[stop]
+  if stopRune <= startRune:
+    return
+  if spans.len > 0 and spans[^1].tokenClass == tokenClass and
+      spans[^1].range.maxIndex == startRune:
+    spans[^1].range.length =
+      (int(spans[^1].range.length) + stopRune - startRune).Natural
+  else:
+    spans.add SyntaxTokenSpan(
+      range: initTextRange(startRune, stopRune - startRune), tokenClass: tokenClass
+    )
+
+proc matterSyntaxHighlighter*(source, language: string): seq[SyntaxTokenSpan] =
+  ## Classify `source` with Matter's bundled TextMate grammar for `language`.
+  ## Unknown language names return no spans. Returned ranges use rune offsets.
+  if source.len == 0:
+    return
+  let grammar = grammarForLanguage(language)
+  if grammar.isNil:
+    return
+
+  let byteToRune = source.byteRuneMap()
+  var
+    lineStart = 0
+    ruleStack: StateStack
+  while lineStart < source.len:
+    var lineStop = source.find('\n', lineStart)
+    if lineStop < 0:
+      lineStop = source.len
+    var contentStop = lineStop
+    if contentStop > lineStart and source[contentStop - 1] == '\r':
+      dec contentStop
+
+    let tokenized = grammar.tokenizeLine(source[lineStart ..< contentStop], ruleStack)
+    for token in tokenized.tokens:
+      result.addSpan(
+        byteToRune,
+        lineStart + token.startIndex,
+        lineStart + token.endIndex,
+        token.scopes.syntaxTokenClass(),
+      )
+    ruleStack = tokenized.ruleStack
+    lineStart = lineStop + 1

--- a/tests/kosmo/matterhighlighting.nim
+++ b/tests/kosmo/matterhighlighting.nim
@@ -1,0 +1,28 @@
+## Matter highlighting in Kosmo Markdown previews.
+import std/[strutils, unicode, unittest]
+
+import merenda/kosmo/kosmo
+import merenda/nimkit
+
+proc runeIndexOf(source, needle: string): int =
+  result = -1
+  let byteIndex = source.find(needle)
+  if byteIndex >= 0:
+    result = source[0 ..< byteIndex].runeLen
+
+suite "Kosmo Matter highlighting":
+  test "Markdown previews use Matter for fenced code":
+    let frontend = newKosmoApplication(
+      newApplication("Kosmo Matter Highlighting Test"), monitorsGitStatus = false
+    )
+    defer:
+      frontend.close()
+
+    let preview = frontend.editorPane.markdownView
+    preview.markdown = "```go\nfunc main() {}\n```"
+    require preview.waitForMarkdownParsing()
+    require preview.waitForMarkdownRendering()
+    let funcIndex = preview.textStorage().stringValue().runeIndexOf("func")
+    require funcIndex >= 0
+    check preview.textStorage().attributesAt(funcIndex).foregroundColor ==
+      preview.markdownStyle().syntaxTokenColors[stcKeyword]

--- a/tests/nimkit/markdownviews.nim
+++ b/tests/nimkit/markdownviews.nim
@@ -563,6 +563,26 @@ fencedToken value
       style.syntaxTokenColors[stcKeyword]
     check storage.attributesFor("indentedToken").foregroundColor == style.codeColor
 
+  test "Matter maps TextMate scopes and language aliases to neutral rune spans":
+    let
+      source = "proc answer = 42\n#[ first\ncontinued ]#\necho \"κόσμος\""
+      spans = matterSyntaxHighlighter(source, "nims")
+
+    check spans.syntaxTokenAt(source.runeIndexOf("proc")) == stcKeyword
+    check spans.syntaxTokenAt(source.runeIndexOf("answer")) == stcIdentifier
+    check spans.syntaxTokenAt(source.runeIndexOf("42")) == stcNumber
+    check spans.syntaxTokenAt(source.runeIndexOf("continued")) == stcComment
+    check spans.syntaxTokenAt(source.runeIndexOf("\"κόσμος\"")) == stcString
+    check matterSyntaxHighlighter("value", "not-a-language").len == 0
+
+  test "Markdown uses Matter for fenced languages outside SynEdit's classifier":
+    let
+      style = initMarkdownStyle()
+      storage = markdownTextStorage("```go\nfunc main() {}\n```")
+
+    check storage.attributesFor("func").foregroundColor ==
+      style.syntaxTokenColors[stcKeyword]
+
   test "unknown fenced languages retain the ordinary code color":
     let
       style = initMarkdownStyle()

--- a/tests/tkosmo.nim
+++ b/tests/tkosmo.nim
@@ -4,6 +4,7 @@ import std/[strutils, unicode, unittest]
 import merenda/nimkit
 import merenda/kosmo/kosmo
 import kosmo/cli
+import kosmo/matterhighlighting
 import kosmo/panelshortcuts
 import kosmo/terminalclipboard
 


### PR DESCRIPTION
## Summary

- add a NimKit adapter for Matter TextMate grammars with embedded assets and per-thread lazy caches
- make Matter the default fenced-code highlighter for NimKit Markdown views and Kosmo previews
- retain SynEdit and Moe as optional highlighters and document the new default
- cover scope mapping, aliases, Unicode, multiline state, and a real Kosmo preview

## Testing

- atlas-run tests
- atlas-run tests nimkit
- atlas-run tests kosmo
- atlas-run tests --compile-only examples/all_compile.nim
- nim check --hints:off src/merenda/nimkit/text/matterhighlighting.nim
- git diff --check