### PR TITLE
Improve Markdown table overflow and tab close marks

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -37,7 +37,12 @@ jobs:
 
     - name: Install GrabNim
       run: |
-        curl -fsSL https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh | sh
+        grabnimInstaller="$(mktemp)"
+        curl --retry 3 --retry-all-errors --retry-delay 2 -fsSL \
+          https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh \
+          -o "$grabnimInstaller"
+        sh "$grabnimInstaller"
+        rm -f "$grabnimInstaller"
         echo "$HOME/.local/share/grabnim/current/bin" >> "$GITHUB_PATH"
         echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
 
@@ -142,7 +147,12 @@ jobs:
 
     - name: Install GrabNim
       run: |
-        curl -fsSL https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh | sh
+        grabnimInstaller="$(mktemp)"
+        curl --retry 3 --retry-all-errors --retry-delay 2 -fsSL \
+          https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh \
+          -o "$grabnimInstaller"
+        sh "$grabnimInstaller"
+        rm -f "$grabnimInstaller"
         echo "$HOME/.local/share/grabnim/current/bin" >> "$GITHUB_PATH"
         echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ bounded chunks between application frames. The displayed document is replaced
 atomically after the final chunk, keeping the main thread responsive without
 showing a partial document. It supports headings, inline styles, links, code,
 quotes, lists, thematic breaks, GFM tables, and native local images without
-embedding an HTML engine:
+embedding an HTML engine. Tables preserve short phrases and whole words, wrap
+longer cell prose to a 90%-of-viewport target, and scroll horizontally when
+their minimum readable width exceeds that target:
 
 ```nim
 import merenda/nimkit

--- a/src/merenda/nimkit/containers/documenttabs.nim
+++ b/src/merenda/nimkit/containers/documenttabs.nim
@@ -123,6 +123,8 @@ const
   DocumentTabHorizontalInset = 12.0'f32
   DocumentTabCloseWidth = 16.0'f32
   DocumentTabCloseSpacing = 7.0'f32
+  DocumentTabCloseMarkSize = 7.0'f32
+  DocumentTabCloseMarkWeight = 1.25'f32
   DocumentTabIndicatorSize = 2.0'f32
   DocumentTabAccentAlpha = 0.72'f32
   DocumentTabModifiedAccentAlpha = 0.52'f32
@@ -1528,9 +1530,12 @@ proc drawCloseButton(
       states,
     )
     markColor = context.appearance.resolveColor(styleContext, StyleMarkColor, textColor)
-    markStyle = context.appearance.tabTextStyle(styleContext, markColor)
-    markRect =
-      rect(rect.origin.x, rect.origin.y - 0.5'f32, rect.size.width, rect.size.height)
+    markCenter = initPoint(
+      rect.origin.x + rect.size.width * 0.5'f32,
+      rect.origin.y + rect.size.height * 0.5'f32,
+    )
+    markRadius = DocumentTabCloseMarkSize * 0.5'f32
+    markFill = fill(markColor)
     renderRect = context.renderRectFor(rect)
     buttonRoot = context.addRenderRectangle(
       DefaultDrawLevel,
@@ -1544,8 +1549,21 @@ proc drawCloseButton(
   context.drawChromeExtras(
     chrome, initChromeExtras(buttonRoot, renderRect, cornerRadius = radius)
   )
-  context.addText(
-    DefaultDrawLevel, parent, markRect, "×", markStyle, alignment = taCenter
+  discard context.addRenderLine(
+    DefaultDrawLevel,
+    parent,
+    initPoint(markCenter.x - markRadius, markCenter.y - markRadius),
+    initPoint(markCenter.x + markRadius, markCenter.y + markRadius),
+    markFill,
+    DocumentTabCloseMarkWeight,
+  )
+  discard context.addRenderLine(
+    DefaultDrawLevel,
+    parent,
+    initPoint(markCenter.x + markRadius, markCenter.y - markRadius),
+    initPoint(markCenter.x - markRadius, markCenter.y + markRadius),
+    markFill,
+    DocumentTabCloseMarkWeight,
   )
 
 proc drawDocumentTab(

--- a/src/merenda/nimkit/text/markdownviews.nim
+++ b/src/merenda/nimkit/text/markdownviews.nim
@@ -1617,6 +1617,16 @@ func isMarkdownRendering*(view: MarkdownView): bool =
   not view.isNil and
     (view.xActiveMarkdownRenderGeneration != 0 or view.xMarkdownTableResizePending)
 
+proc scheduleMarkdownTableReflowIfNeeded(view: MarkdownView) =
+  ## Keep the rendered table budget in sync when a geometry notification was
+  ## delivered before the next owner-thread poll.
+  if view.isNil or view.xMarkdownTableResizePending or
+      view.xActiveMarkdownGeneration != 0 or view.xActiveMarkdownRenderGeneration != 0 or
+      not view.xHasMarkdownTables:
+    return
+  if view.markdownTableColumnLimit() != view.xMarkdownTableColumnLimit:
+    view.scheduleMarkdownTableResize()
+
 func isMarkdownParsing*(view: MarkdownView): bool =
   ## Return whether parsing or incremental AST application is in progress.
   not view.isNil and (view.xActiveMarkdownGeneration != 0 or view.isMarkdownRendering())
@@ -1653,6 +1663,7 @@ proc pollMarkdownParsing*(view: MarkdownView): int {.discardable.} =
   if not view.isNil:
     result = getCurrentSigilThread().pollAll()
     result += drainMainThreadWork()
+    view.scheduleMarkdownTableReflowIfNeeded()
 
 proc waitForMarkdownRendering*(
     view: MarkdownView, timeoutMilliseconds: Natural = 5_000

--- a/src/merenda/nimkit/text/markdownviews.nim
+++ b/src/merenda/nimkit/text/markdownviews.nim
@@ -1348,11 +1348,7 @@ proc markdownTableColumnLimit(view: MarkdownView): int =
     return MarkdownTableDefaultColumnLimit
   let
     characterWidth = view.markdownTableCharacterWidth()
-    viewportWidth =
-      if view.scrollView().isNil:
-        view.bounds().size.width
-      else:
-        view.scrollView().viewportSize().width
+    viewportWidth = view.bounds().size.width
     availableWidth =
       max(viewportWidth - view.xMarkdownStyle.documentInsets.horizontal, characterWidth)
     measuredLimit = int(availableWidth * MarkdownTableViewportFraction / characterWidth)
@@ -1366,7 +1362,7 @@ proc markdownTableOverflowWidth(view: MarkdownView, tableColumnWidth: int): floa
   if view.isNil or tableColumnWidth <= view.xMarkdownTableColumnLimit:
     return
   let
-    viewportWidth = view.scrollView().viewportSize().width
+    viewportWidth = view.bounds().size.width
     contentWidth =
       float32(tableColumnWidth) * view.markdownTableCharacterWidth() /
       MarkdownTableViewportFraction

--- a/src/merenda/nimkit/text/markdownviews.nim
+++ b/src/merenda/nimkit/text/markdownviews.nim
@@ -1617,16 +1617,6 @@ func isMarkdownRendering*(view: MarkdownView): bool =
   not view.isNil and
     (view.xActiveMarkdownRenderGeneration != 0 or view.xMarkdownTableResizePending)
 
-proc scheduleMarkdownTableReflowIfNeeded(view: MarkdownView) =
-  ## Keep the rendered table budget in sync when a geometry notification was
-  ## delivered before the next owner-thread poll.
-  if view.isNil or view.xMarkdownTableResizePending or
-      view.xActiveMarkdownGeneration != 0 or view.xActiveMarkdownRenderGeneration != 0 or
-      not view.xHasMarkdownTables:
-    return
-  if view.markdownTableColumnLimit() != view.xMarkdownTableColumnLimit:
-    view.scheduleMarkdownTableResize()
-
 func isMarkdownParsing*(view: MarkdownView): bool =
   ## Return whether parsing or incremental AST application is in progress.
   not view.isNil and (view.xActiveMarkdownGeneration != 0 or view.isMarkdownRendering())
@@ -1663,7 +1653,6 @@ proc pollMarkdownParsing*(view: MarkdownView): int {.discardable.} =
   if not view.isNil:
     result = getCurrentSigilThread().pollAll()
     result += drainMainThreadWork()
-    view.scheduleMarkdownTableReflowIfNeeded()
 
 proc waitForMarkdownRendering*(
     view: MarkdownView, timeoutMilliseconds: Natural = 5_000

--- a/src/merenda/nimkit/text/markdownviews.nim
+++ b/src/merenda/nimkit/text/markdownviews.nim
@@ -52,7 +52,9 @@ const
   MarkdownTableMaximumColumnLimit = 160
   MarkdownTableColumnQuantum = 4
   MarkdownTableMinimumColumnWidth = 3
+  MarkdownTablePreferredCellWidth = 12
   MarkdownTableSeparatorWidth = 3
+  MarkdownTableViewportFraction = 0.9'f32
 
 type
   MarkdownImageLoader* = proc(url: string): ImageResource {.closure.}
@@ -117,6 +119,7 @@ type
     images: seq[MarkdownImagePresentation]
     imageUrls: seq[string]
     hasTables: bool
+    tableColumnWidth: int
 
   MarkdownBuilder = object
     text: string
@@ -130,6 +133,7 @@ type
     imageContentTypeLoader: MarkdownImageContentTypeLoader
     syntaxHighlighter: SyntaxHighlighter
     tableColumnLimit: int
+    tableColumnWidth: int
     hasTables: bool
 
   MarkdownTableAlignment = enum
@@ -410,6 +414,7 @@ proc addBlockBreak(builder: var MarkdownBuilder, attributes: TextAttributes) =
 proc add(builder: var MarkdownBuilder, rendered: sink MarkdownBuilder) =
   let offset = builder.runeLength
   builder.hasTables = builder.hasTables or rendered.hasTables
+  builder.tableColumnWidth = max(builder.tableColumnWidth, rendered.tableColumnWidth)
   builder.imageUrls.add(rendered.imageUrls)
   builder.text.add rendered.text
   builder.runeLength += rendered.runeLength
@@ -709,6 +714,19 @@ func naturalTableCellWidth(content: openArray[MarkdownTableRune]): int =
       pendingSpace = false
   max(result, lineWidth)
 
+func minimumTableCellWidth(content: openArray[MarkdownTableRune]): int =
+  var wordWidth = 0
+  for unit in content:
+    if unit.value == Rune('\n') or
+        (unit.value.isWhiteSpace and not unit.attributes.hasAttachment):
+      result = max(result, wordWidth)
+      wordWidth = 0
+    else:
+      inc wordWidth
+  result = max(result, wordWidth)
+  result =
+    max(result, min(content.naturalTableCellWidth(), MarkdownTablePreferredCellWidth))
+
 proc finishTableLine(
     lines: var seq[seq[MarkdownTableRune]],
     line: var seq[MarkdownTableRune],
@@ -732,19 +750,9 @@ proc appendTableWord(
   if line.len > 0 and line.len + spacing + word.len > limit:
     lines.finishTableLine(line, hasPendingSpace)
 
-  if word.len > limit:
-    if line.len > 0:
-      lines.finishTableLine(line, hasPendingSpace)
-    var offset = 0
-    while word.len - offset > limit:
-      lines.add word[offset ..< offset + limit]
-      offset += limit
-    if offset < word.len:
-      line = word[offset ..< word.len]
-  else:
-    if line.len > 0 and hasPendingSpace:
-      line.add pendingSpace
-    line.add word
+  if line.len > 0 and hasPendingSpace:
+    line.add pendingSpace
+  line.add word
   word = @[]
   hasPendingSpace = false
 
@@ -774,7 +782,9 @@ proc wrapTableCell(
   if line.len > 0 or result.len == 0:
     result.add move line
 
-func fittedTableWidths(naturalWidths: openArray[int], columnLimit: int): seq[int] =
+func fittedTableWidths(
+    naturalWidths, minimumWidths: openArray[int], columnLimit: int
+): seq[int] =
   if naturalWidths.len == 0:
     return
   let
@@ -785,25 +795,34 @@ func fittedTableWidths(naturalWidths: openArray[int], columnLimit: int): seq[int
     )
   var
     maximumWidth = MarkdownTableMinimumColumnWidth
+    minimumTotal = 0
     naturalTotal = 0
-  for width in naturalWidths:
-    let resolved = max(width, MarkdownTableMinimumColumnWidth)
-    maximumWidth = max(maximumWidth, resolved)
-    naturalTotal += resolved
+  for index, width in naturalWidths:
+    let
+      minimumWidth = max(minimumWidths[index], MarkdownTableMinimumColumnWidth)
+      naturalWidth = max(width, minimumWidth)
+    maximumWidth = max(maximumWidth, naturalWidth)
+    minimumTotal += minimumWidth
+    naturalTotal += naturalWidth
   if naturalTotal <= contentLimit:
-    for width in naturalWidths:
+    for index, width in naturalWidths:
+      result.add max(max(width, minimumWidths[index]), MarkdownTableMinimumColumnWidth)
+    return
+  if minimumTotal >= contentLimit:
+    for width in minimumWidths:
       result.add max(width, MarkdownTableMinimumColumnWidth)
     return
 
   var
-    low = MarkdownTableMinimumColumnWidth
+    low = 0
     high = maximumWidth
-    cap = low
+    cap = 0
   while low <= high:
     let candidate = (low + high) div 2
     var used = 0
-    for width in naturalWidths:
-      used += min(max(width, MarkdownTableMinimumColumnWidth), candidate)
+    for index, width in naturalWidths:
+      let minimumWidth = max(minimumWidths[index], MarkdownTableMinimumColumnWidth)
+      used += max(min(max(width, minimumWidth), candidate), minimumWidth)
     if used <= contentLimit:
       cap = candidate
       low = candidate + 1
@@ -811,15 +830,17 @@ func fittedTableWidths(naturalWidths: openArray[int], columnLimit: int): seq[int
       high = candidate - 1
 
   var used = 0
-  for width in naturalWidths:
-    let fitted = min(max(width, MarkdownTableMinimumColumnWidth), cap)
+  for index, width in naturalWidths:
+    let
+      minimumWidth = max(minimumWidths[index], MarkdownTableMinimumColumnWidth)
+      fitted = max(min(max(width, minimumWidth), cap), minimumWidth)
     result.add fitted
     used += fitted
   var remaining = contentLimit - used
   while remaining > 0:
     var distributed = false
     for index, naturalWidth in naturalWidths:
-      let target = max(naturalWidth, MarkdownTableMinimumColumnWidth)
+      let target = max(naturalWidth, minimumWidths[index])
       if result[index] < target and remaining > 0:
         inc result[index]
         dec remaining
@@ -901,17 +922,26 @@ proc renderTable(
   if columnCount == 0:
     return
 
-  var naturalWidths = newSeq[int](columnCount)
+  var
+    naturalWidths = newSeq[int](columnCount)
+    minimumWidths = newSeq[int](columnCount)
   for row in rows:
     for index, cell in row.cells:
       naturalWidths[index] =
         max(naturalWidths[index], cell.content.naturalTableCellWidth())
+      minimumWidths[index] =
+        max(minimumWidths[index], cell.content.minimumTableCellWidth())
   let widths = naturalWidths.fittedTableWidths(
+    minimumWidths,
     if builder.tableColumnLimit > 0:
       builder.tableColumnLimit
     else:
-      MarkdownTableDefaultColumnLimit
+      MarkdownTableDefaultColumnLimit,
   )
+  var tableColumnWidth = MarkdownTableSeparatorWidth * (columnCount - 1)
+  for width in widths:
+    tableColumnWidth += width
+  builder.tableColumnWidth = max(builder.tableColumnWidth, tableColumnWidth)
   var separatorAttributes = tableAttributes
   separatorAttributes.foregroundColor = builder.style.ruleColor
 
@@ -1049,6 +1079,7 @@ proc renderBlockquote(
     mapped.range = initTextRange(start, stop - start)
     builder.images.add mapped
   builder.hasTables = builder.hasTables or quoted.hasTables
+  builder.tableColumnWidth = max(builder.tableColumnWidth, quoted.tableColumnWidth)
 
 proc addHighlightedCode(
     builder: var MarkdownBuilder, source, language: string, attributes: TextAttributes
@@ -1140,6 +1171,7 @@ proc toMarkdownDocument(builder: sink MarkdownBuilder): MarkdownDocument =
     images: builder.images,
     imageUrls: builder.imageUrls,
     hasTables: builder.hasTables,
+    tableColumnWidth: builder.tableColumnWidth,
   )
 
 proc parseMarkdownRoot(
@@ -1244,6 +1276,7 @@ protocol MarkdownTextViewDrawing of ViewDrawingProtocol:
     TextView(textView).drawTextViewContents(context)
 
 func markdownImageCacheKey(view: MarkdownView, url: string): string
+proc markdownTableOverflowWidth(view: MarkdownView, tableColumnWidth: int): float32
 
 proc pruneMarkdownImageCache(view: MarkdownView, imageUrls: openArray[string]) =
   var activeKeys = initTable[string, bool]()
@@ -1277,6 +1310,8 @@ proc applyMarkdownDocument(view: MarkdownView, document: sink MarkdownDocument) 
   textView.codeBlockStyle = view.xMarkdownStyle.codeBlockStyle
   textView.markdownImages = document.images
   view.xHasMarkdownTables = document.hasTables
+  view.minimumWrappedDocumentWidth =
+    view.markdownTableOverflowWidth(document.tableColumnWidth)
   view.textStorage = document.storage
   view.pruneMarkdownImageCache(document.imageUrls)
   textView.needsDisplay = true
@@ -1300,16 +1335,19 @@ proc resolvedDefaultMarkdownUrlAssetLoader(): UrlAssetLoader =
 
 proc renderCurrentMarkdownDocument(view: MarkdownView)
 
+proc markdownTableCharacterWidth(view: MarkdownView): float32 =
+  let codeStyle = TextStyle(
+    color: view.xMarkdownStyle.textColor,
+    fontName: view.xMarkdownStyle.codeFontName,
+    fontSize: max(view.xMarkdownStyle.bodyFontSize, 1.0'f32),
+  )
+  max(textNaturalSize("M", codeStyle).width, 1.0'f32)
+
 proc markdownTableColumnLimit(view: MarkdownView): int =
   if view.isNil:
     return MarkdownTableDefaultColumnLimit
   let
-    codeStyle = TextStyle(
-      color: view.xMarkdownStyle.textColor,
-      fontName: view.xMarkdownStyle.codeFontName,
-      fontSize: max(view.xMarkdownStyle.bodyFontSize, 1.0'f32),
-    )
-    characterWidth = max(textNaturalSize("M", codeStyle).width, 1.0'f32)
+    characterWidth = view.markdownTableCharacterWidth()
     viewportWidth =
       if view.scrollView().isNil:
         view.bounds().size.width
@@ -1317,11 +1355,24 @@ proc markdownTableColumnLimit(view: MarkdownView): int =
         view.scrollView().viewportSize().width
     availableWidth =
       max(viewportWidth - view.xMarkdownStyle.documentInsets.horizontal, characterWidth)
-    measuredLimit = int(availableWidth / characterWidth)
+    measuredLimit = int(availableWidth * MarkdownTableViewportFraction / characterWidth)
     quantizedLimit =
       (measuredLimit div MarkdownTableColumnQuantum) * MarkdownTableColumnQuantum
   clamp(
     quantizedLimit, MarkdownTableMinimumColumnLimit, MarkdownTableMaximumColumnLimit
+  )
+
+proc markdownTableOverflowWidth(view: MarkdownView, tableColumnWidth: int): float32 =
+  if view.isNil or tableColumnWidth <= view.xMarkdownTableColumnLimit:
+    return
+  let
+    viewportWidth = view.scrollView().viewportSize().width
+    contentWidth =
+      float32(tableColumnWidth) * view.markdownTableCharacterWidth() /
+      MarkdownTableViewportFraction
+  max(
+    viewportWidth + 1.0'f32,
+    contentWidth + view.xMarkdownStyle.documentInsets.horizontal,
   )
 
 proc scheduleMarkdownTableResize(view: MarkdownView) =

--- a/src/merenda/nimkit/text/texteditors.nim
+++ b/src/merenda/nimkit/text/texteditors.nim
@@ -39,6 +39,7 @@ type
     xTextView: TextView
     xTextInsets: EdgeInsets
     xWraps: bool
+    xMinimumWrappedDocumentWidth: float32
     xMinimumDocumentSize: Size
     xMeasurement: TextEditorMeasurement
 
@@ -101,7 +102,21 @@ proc `wraps=`*(editor: TextEditor, wraps: bool) =
   if editor.xWraps == wraps:
     return
   editor.xWraps = wraps
-  editor.xScrollView.hasHorizontalScroller = not wraps
+  editor.xScrollView.hasHorizontalScroller =
+    not wraps or editor.xMinimumWrappedDocumentWidth > 0.0'f32
+  editor.updateTextEditorLayout()
+
+proc minimumWrappedDocumentWidth*(editor: TextEditor): float32 =
+  ## Return the minimum document width retained while text wrapping stays enabled.
+  editor.xMinimumWrappedDocumentWidth
+
+proc `minimumWrappedDocumentWidth=`*(editor: TextEditor, width: float32) =
+  ## Allow wrapped content to overflow horizontally when `width` exceeds the viewport.
+  let normalized = max(width, 0.0'f32)
+  if editor.xMinimumWrappedDocumentWidth == normalized:
+    return
+  editor.xMinimumWrappedDocumentWidth = normalized
+  editor.xScrollView.hasHorizontalScroller = not editor.xWraps or normalized > 0.0'f32
   editor.updateTextEditorLayout()
 
 proc minimumDocumentSize*(editor: TextEditor): Size =
@@ -265,7 +280,11 @@ proc textDocumentSize(
 
   let
     insets = editor.xTextInsets
-    width = if editor.xWraps: viewportWidth else: DefaultTextEditorMeasureWidth
+    width =
+      if editor.xWraps:
+        max(viewportWidth, editor.xMinimumWrappedDocumentWidth)
+      else:
+        DefaultTextEditorMeasureWidth
     measurement = editor.measuredText(width)
     textWidth =
       if measurement.hasText:
@@ -279,7 +298,7 @@ proc textDocumentSize(
         defaultFontSize()
     documentWidth =
       if editor.xWraps:
-        viewportWidth
+        max(viewportWidth, editor.xMinimumWrappedDocumentWidth)
       else:
         max(max(textWidth, viewportWidth), editor.xMinimumDocumentSize.width)
   initSize(
@@ -633,6 +652,7 @@ proc initTextEditorFields*(
   editor.background = color(0.0, 0.0, 0.0, 0.0)
   editor.xTextInsets = insets(6.0, 7.0, 6.0, 7.0)
   editor.xWraps = wraps
+  editor.xMinimumWrappedDocumentWidth = 0.0'f32
   editor.xMinimumDocumentSize =
     initSize(DefaultTextEditorWidth, DefaultTextEditorHeight)
   editor.acceptsFirstResponder = true
@@ -649,7 +669,8 @@ proc initTextEditorFields*(
     initTextContainer(initSize(0.0, 0.0), editor.xTextInsets, wraps)
   editor.xScrollView = newScrollView(documentView = editor.xTextView)
   editor.xScrollView.hasVerticalScroller = true
-  editor.xScrollView.hasHorizontalScroller = not wraps
+  editor.xScrollView.hasHorizontalScroller =
+    not wraps or editor.xMinimumWrappedDocumentWidth > 0.0'f32
   editor.xScrollView.autohidePolicy = sapWhenNeeded
   editor.xScrollView.borderType = svbBezelBorder
   editor.xScrollView.drawsBackground = true

--- a/tests/nimkit/documenttabs.nim
+++ b/tests/nimkit/documenttabs.nim
@@ -274,6 +274,13 @@ proc renderedText(node: Fig): string =
   for rune in node.textLayout.runes:
     result.add rune
 
+func hasDrawableOp(node: Fig, kind: DrawableKind): bool =
+  if node.kind != nkDrawable:
+    return
+  for op in node.drawOps:
+    if op.kind == kind:
+      return true
+
 proc renderedRect(node: Fig): nimkitTypes.Rect =
   nimkitTypes.rect(
     node.screenBox.x.float32, node.screenBox.y.float32, node.screenBox.w.float32,
@@ -648,19 +655,45 @@ suite "nimkit document tabs":
 
     discard tabs.addDocumentTabItem(selected)
 
-    proc closeSymbolRect(theme: Theme): nimkitTypes.Rect =
+    proc closeMarkRect(theme: Theme): nimkitTypes.Rect =
       let renders = buildRenders(tabs, initAppearance(theme))
       for node in renders[DefaultDrawLevel].nodes:
-        if node.kind == nkText and node.renderedText() == "×":
+        if node.hasDrawableOp(dkLine):
           return node.renderedRect()
 
     let tabRect = tabs.documentTabRect(0)
     for theme in [initTheme(), initMacOSTheme(), initMacOSDarkTheme()]:
-      check closeSymbolRect(theme).center().x < tabRect.center().x
+      check closeMarkRect(theme).center().x < tabRect.center().x
 
     var builder = initThemeBuilder(initTheme())
     builder[srDocumentTab, StyleCloseButtonPosition] = styleKeyword(dtcbRight)
-    check closeSymbolRect(builder.finish()).center().x > tabRect.center().x
+    check closeMarkRect(builder.finish()).center().x > tabRect.center().x
+
+  test "document tab close marks use centered vector lines":
+    let
+      tabs = newDocumentTabs(frame = rect(0, 0, 360, 34))
+      selected = newDocumentTabItem("Selected", "selected")
+    discard tabs.addDocumentTabItem(selected)
+
+    let
+      renders = buildRenders(tabs)
+      tabCenter = tabs.documentTabRect(0).center()
+    var
+      markRects: seq[nimkitTypes.Rect]
+      closeTextFound = false
+    for node in renders[DefaultDrawLevel].nodes:
+      if node.kind == nkText and node.renderedText() in ["x", "×"]:
+        closeTextFound = true
+      elif node.hasDrawableOp(dkLine):
+        markRects.add node.renderedRect()
+        check node.drawStroke.weight > 0.0'f32
+
+    require markRects.len == 2
+    check not closeTextFound
+    for markRect in markRects:
+      check abs(markRect.center().y - tabCenter.y) <= 0.01'f32
+    check abs(markRects[0].center().x - markRects[1].center().x) <= 0.01'f32
+    check abs(markRects[0].center().y - markRects[1].center().y) <= 0.01'f32
 
   test "delegates can veto selection closing and moving while signals fire":
     let
@@ -825,7 +858,7 @@ suite "nimkit document tabs":
       planFound = false
       budgetFound = false
       nextFound = false
-      closeSymbolFound = false
+      closeMarkFound = false
       closeTextFound = false
 
     for node in renders[DefaultDrawLevel].nodes:
@@ -837,15 +870,15 @@ suite "nimkit document tabs":
           budgetFound = true
         elif text == ">":
           nextFound = true
-        elif text == "×":
-          closeSymbolFound = true
-        elif text == "x":
+        elif text in ["x", "×"]:
           closeTextFound = true
+      elif node.hasDrawableOp(dkLine):
+        closeMarkFound = true
 
     check planFound
     check budgetFound
     check nextFound
-    check closeSymbolFound
+    check closeMarkFound
     check not closeTextFound
 
   test "document tab scroll buttons resolve document tab button theme fill":

--- a/tests/nimkit/markdownviews.nim
+++ b/tests/nimkit/markdownviews.nim
@@ -769,6 +769,55 @@ Press <kbd>Enter</kbd>.
         foundContinuation = true
     check foundContinuation
 
+  test "GFM table wrapping preserves short phrases and whole words":
+    let
+      source =
+        "| A | B | C | D | E | F | G | H | I | J | K | L |\n" &
+        "| - | - | - | - | - | - | - | - | - | - | - | - |\n" &
+        "| CPU p95 | CPU p95 | CPU p95 | CPU p95 | CPU p95 | CPU p95 | " &
+        "CPU p95 | CPU p95 | CPU p95 | CPU p95 | CPU p95 | CPU p95 |"
+      lines = markdownTextStorage(source).stringValue().splitLines()
+
+    check lines[0].runeLen > 100
+    check lines[^1].count("CPU p95") == 12
+
+    let longWord = "uninterrupted_identifier_that_must_remain_whole"
+    let wordLines = markdownTextStorage(
+        "| Name | Value |\n| - | - |\n| key | " & longWord & " |"
+      )
+      .stringValue()
+      .splitLines()
+    check wordLines[^1].contains(longWord)
+
+  test "wide GFM tables use horizontal overflow while Markdown still wraps":
+    let
+      source =
+        "A deliberately long paragraph that should continue to use wrapped text " &
+        "layout even when the table below needs horizontal overflow. ".repeat(4) & "\n\n" &
+        "| A | B | C | D | E | F | G | H |\n" & "| - | - | - | - | - | - | - | - |\n" &
+        "| CPU p95 | CPU p95 | CPU p95 | CPU p95 | CPU p95 | CPU p95 | " &
+        "CPU p95 | CPU p95 |"
+      view = newMarkdownView(source, frame = rect(0, 0, 300, 240))
+    require view.waitForMarkdownParsing()
+    discard buildRenders(view)
+    require view.waitForMarkdownLayout()
+
+    check view.wraps
+    check view.scrollView().hasHorizontalScroller
+    check view.scrollView().maximumContentOffset().x > 0.0'f32
+    check view.textView().layoutManager().lineCount() >
+      view.textStorage().stringValue().splitLines().len.Natural
+
+  test "compact GFM tables stay within the Markdown viewport":
+    let view = newMarkdownView(
+      "| Metric | Value |\n| - | - |\n| CPU | 42% |", frame = rect(0, 0, 420, 200)
+    )
+    require view.waitForMarkdownParsing()
+    discard buildRenders(view)
+    require view.waitForMarkdownLayout()
+
+    check view.scrollView().maximumContentOffset().x == 0.0'f32
+
   test "GFM tables reflow once the Markdown viewport settles":
     let
       source =

--- a/tests/nimkit/markdownviews.nim
+++ b/tests/nimkit/markdownviews.nim
@@ -831,7 +831,8 @@ Press <kbd>Enter</kbd>.
     require view.waitForMarkdownParsing()
     let narrowLineCount = view.textStorage().stringValue().splitLines().len
 
-    view.frame = rect(0, 0, 900, 240)
+    # Crosses the first whole-word wrap threshold even with wide fallback fonts.
+    view.frame = rect(0, 0, 1_600, 240)
     require view.waitForMarkdownRendering()
     let wideLineCount = view.textStorage().stringValue().splitLines().len
 

--- a/tests/nimkit/markdownviews.nim
+++ b/tests/nimkit/markdownviews.nim
@@ -831,7 +831,6 @@ Press <kbd>Enter</kbd>.
     let narrowLineCount = view.textStorage().stringValue().splitLines().len
 
     view.frame = rect(0, 0, 900, 240)
-    view.layoutSubtreeIfNeeded()
     require view.waitForMarkdownRendering()
     let wideLineCount = view.textStorage().stringValue().splitLines().len
 


### PR DESCRIPTION
## Summary

- size Markdown tables toward 90% of the viewport before horizontal overflow
- preserve whole words and short phrases such as CPU p95 while wrapping longer cell prose
- retain wrapped Markdown layout while exposing wide tables through the existing horizontal scroller
- replace the font-rendered document-tab close glyph with centered vector strokes
- cover compact, wrapped, overflowing, and vector-close-mark behavior

## Testing

- atlas-run tests nimkit
- atlas-run tests kosmo
- atlas-run tests
- atlas-run tests --compile-only examples/all_compile.nim