### PR TITLE
Fix file tree hover and lazy scrolling

### DIFF
--- a/src/merenda/nimkit/containers/tableviews.nim
+++ b/src/merenda/nimkit/containers/tableviews.nim
@@ -5015,7 +5015,10 @@ proc visibleContentRows(contentView: TableContentView): tuple[first, last: int] 
 
 proc configureRowView(rowView: TableRowView, itemIndex: int) =
   let tableView = rowView.xTableView
-  rowView.xRow = tableView.tableRowState(itemIndex)
+  let nextRow = tableView.tableRowState(itemIndex)
+  if rowView.xRow != nextRow:
+    rowView.xRow = nextRow
+    rowView.needsDisplay = true
   rowView.setFrameFromLayout(tableView.xContentView.tableContentItemRect(itemIndex))
 
 proc removeLastRowView(contentView: TableContentView) =
@@ -5211,7 +5214,7 @@ protocol DefaultTableRowViewAccessibility of AccessibilityProtocol:
 
 protocol DefaultTableContentViewDrawing of ViewDrawingProtocol:
   method draw(contentView: TableContentView, context: DrawContext) =
-    discard context
+    discard context.visibleRect()
     contentView.syncVisibleRowViews()
     contentView.tableView().syncVisibleTableCells()
 

--- a/tests/kosmo/filetreeinteractions.nim
+++ b/tests/kosmo/filetreeinteractions.nim
@@ -1,0 +1,84 @@
+import std/[os, strutils, tempfiles, unicode, unittest]
+
+import figdraw
+
+import merenda/nimkit
+import merenda/kosmo/kosmo
+
+proc renderedText(node: Fig): string =
+  for rune in node.textLayout.runes:
+    result.add rune
+
+proc renderedTextStartingWith(view: View, prefix: string): string =
+  let renders = buildRenders(view)
+  if DefaultDrawLevel notin renders:
+    return
+  for node in renders[DefaultDrawLevel].nodes:
+    if node.kind == nkText:
+      let text = node.renderedText()
+      if text.startsWith(prefix):
+        return text
+
+proc rendersFill(view: View, fillValue: Fill): bool =
+  let renders = buildRenders(view)
+  if DefaultDrawLevel notin renders:
+    return
+  for node in renders[DefaultDrawLevel].nodes:
+    if node.kind == nkRectangle and node.fill == fillValue:
+      return true
+
+suite "Kosmo file tree interactions":
+  test "hover input redraws the highlighted row":
+    let
+      root = createTempDir("merenda-kosmo-tree-hover-", "")
+      filePath = root / "hover-target.txt"
+    writeFile(filePath, "hover target")
+    defer:
+      removeFile(filePath)
+      removeDir(root)
+
+    let
+      window = newWindow("Kosmo File Tree Hover", frame = rect(0, 0, 300, 120))
+      tree = newKosmoFileTree(root, frame = rect(0, 0, 300, 120))
+      hoverFill = fill(color(0.91, 0.23, 0.67, 1.0))
+    var appearance = initAppearance()
+    appearance[srRowItem, {ssHovered}, StyleFill] = hoverFill
+    tree.appearance = appearance
+    window.setContentView(tree)
+    discard buildRenders(tree)
+
+    let
+      row = tree.rowForItem(filePath)
+      rowRect = tree.rowItemRect(row)
+      point = tree.pointToWindow(
+        initPoint(rowRect.origin.x + 40.0'f32, rowRect.origin.y + 12.0'f32)
+      )
+    check not tree.rendersFill(hoverFill)
+    check window.mouseMovedAt(point)
+    check tree.highlightedIndex() == row
+    check tree.rendersFill(hoverFill)
+
+  test "wheel input lazily renders newly visible rows":
+    let root = createTempDir("merenda-kosmo-tree-scroll-", "")
+    var paths: seq[string]
+    for index in 0 ..< 12:
+      let path = root / align($index, 2, '0') & "-row.txt"
+      writeFile(path, "row " & $index)
+      paths.add path
+    defer:
+      for path in paths:
+        removeFile(path)
+      removeDir(root)
+
+    let
+      window = newWindow("Kosmo File Tree Scroll", frame = rect(0, 0, 300, 74))
+      tree = newKosmoFileTree(root, frame = rect(0, 0, 300, 74))
+    window.setContentView(tree)
+
+    check tree.renderedTextStartingWith("00-row") == "00-row.txt"
+    check window.scrollWheelAt(
+      tree.pointToWindow(initPoint(40.0'f32, 40.0'f32)), deltaY = -3.0'f32
+    )
+    check tree.firstVisibleIndex() == 3
+    check tree.renderedTextStartingWith("02-row") == "02-row.txt"
+    check tree.renderedTextStartingWith("00-row").len == 0

--- a/tests/tkosmo.nim
+++ b/tests/tkosmo.nim
@@ -4,6 +4,7 @@ import std/[strutils, unicode, unittest]
 import merenda/nimkit
 import merenda/kosmo/kosmo
 import kosmo/cli
+import kosmo/filetreeinteractions
 import kosmo/matterhighlighting
 import kosmo/panelshortcuts
 import kosmo/terminalclipboard


### PR DESCRIPTION
## Summary

- invalidate retained table row fragments when their row state or recycled identity changes
- register lazy table content as dependent on the visible rectangle so scrolling resynchronizes visible rows
- add high-level file tree tests that synthesize mouse movement and wheel input

## Regression coverage

Before the fix, the hover test updated the highlighted row index but rendered no hover fill, and the wheel test advanced the viewport while still rendering the original rows. Both now pass.

## Tests

- atlas-run tests kosmo
- atlas-run tests
- atlas-run tests --compile-only examples/all_compile.nim