### PR TITLE
Fix Markdown paragraph wrapping beside wide tables

### DIFF
--- a/src/merenda/nimkit/drawing/drawing.nim
+++ b/src/merenda/nimkit/drawing/drawing.nim
@@ -1,4 +1,4 @@
-import std/[os, strutils, tables, unicode]
+import std/[hashes, os, strutils, tables, unicode]
 
 import pkg/bumpy
 
@@ -386,6 +386,120 @@ proc normalizeLineAdvances(layout: var GlyphArrangement) =
     layout.bounding.h = max(maximumY - minimumY, 0.0'f32)
     layout.maxSize.y = max(layout.maxSize.y, layout.bounding.h)
 
+func paragraphIndices(runes: openArray[Rune]): seq[int] =
+  result = newSeq[int](runes.len + 1)
+  var
+    paragraphIndex = 0
+    previousWasCarriageReturn = false
+  for index, rune in runes:
+    result[index] = paragraphIndex
+    if rune == Rune('\r'):
+      inc paragraphIndex
+    elif rune == Rune('\n') and not previousWasCarriageReturn:
+      inc paragraphIndex
+    previousWasCarriageReturn = rune == Rune('\r')
+  result[^1] = paragraphIndex
+
+func lineSourceIndex(layout: GlyphArrangement, line: Slice[int]): int =
+  result = layout.sourceRunes.len
+  for glyphIndex in line:
+    result = min(result, layout.arrangedGlyphs[glyphIndex].source.runeStart)
+  result = clamp(result, 0, layout.sourceRunes.len)
+
+func linesByParagraph(
+    layout: GlyphArrangement, indices: openArray[int]
+): seq[seq[Slice[int]]] =
+  let paragraphCount =
+    if indices.len == 0:
+      1
+    else:
+      indices[^1] + 1
+  result = newSeq[seq[Slice[int]]](paragraphCount)
+  for line in layout.lineGlyphRanges():
+    let sourceIndex = layout.lineSourceIndex(line)
+    result[indices[sourceIndex]].add line
+
+func paragraphStarts(indices: openArray[int]): seq[int] =
+  let paragraphCount =
+    if indices.len == 0:
+      1
+    else:
+      indices[^1] + 1
+  result = newSeq[int](paragraphCount)
+  var paragraphIndex = 1
+  for sourceIndex in 1 ..< indices.len:
+    if indices[sourceIndex] != indices[sourceIndex - 1]:
+      result[paragraphIndex] = sourceIndex
+      inc paragraphIndex
+
+proc paragraphLineBreakModes(
+    storage: TextStorage, indices: openArray[int]
+): seq[TextLineBreakMode] =
+  let starts = indices.paragraphStarts()
+  result = newSeq[TextLineBreakMode](starts.len)
+  for paragraphIndex, start in starts:
+    if not storage.isNil and storage.len > 0:
+      result[paragraphIndex] =
+        storage.attributesAt(min(start, storage.len - 1)).paragraphStyle.lineBreakMode
+    else:
+      result[paragraphIndex] = tlbmWordWrapping
+
+func canCombineLineBreakLayouts(wrapped, unwrapped: GlyphArrangement): bool =
+  wrapped.sourceRunes == unwrapped.sourceRunes and
+    wrapped.arrangedGlyphs.len == unwrapped.arrangedGlyphs.len and
+    wrapped.positions.len == unwrapped.positions.len and
+    wrapped.selectionRects.len == unwrapped.selectionRects.len
+
+proc mixedLineBreakLayout(
+    wrapped, unwrapped: GlyphArrangement, storage: TextStorage
+): GlyphArrangement =
+  if not wrapped.canCombineLineBreakLayouts(unwrapped) or
+      unwrapped.arrangedGlyphs.len == 0:
+    return wrapped
+
+  let
+    indices = unwrapped.sourceRunes.paragraphIndices()
+    modes = storage.paragraphLineBreakModes(indices)
+    wrappedLines = wrapped.linesByParagraph(indices)
+    unwrappedLines = unwrapped.linesByParagraph(indices)
+  result = unwrapped
+  result.lines = @[]
+  result.arrangedGlyphs = newSeq[ArrangedGlyph](wrapped.arrangedGlyphs.len)
+  result.positions = newSeq[Vec2](wrapped.positions.len)
+  result.selectionRects = newSeq[bumpy.Rect](wrapped.selectionRects.len)
+  var visited = newSeq[bool](wrapped.arrangedGlyphs.len)
+
+  for paragraphIndex, mode in modes:
+    let selectedLines =
+      if mode == tlbmClipping:
+        unwrappedLines[paragraphIndex]
+      else:
+        wrappedLines[paragraphIndex]
+    let source = if mode == tlbmClipping: unwrapped else: wrapped
+    for line in selectedLines:
+      result.lines.add line
+      for glyphIndex in line:
+        result.arrangedGlyphs[glyphIndex] = source.arrangedGlyphs[glyphIndex]
+        result.positions[glyphIndex] = source.positions[glyphIndex]
+        result.selectionRects[glyphIndex] = source.selectionRects[glyphIndex]
+        visited[glyphIndex] = true
+
+  for wasVisited in visited:
+    if not wasVisited:
+      return wrapped
+
+  var layoutHash = hash((wrapped.contentHash, result.contentHash))
+  for mode in modes:
+    layoutHash = layoutHash !& hash(mode)
+  result.contentHash = !$layoutHash
+
+proc usesMixedLineBreakModes(storage: TextStorage): bool =
+  if storage.isNil:
+    return
+  for run in storage.runs:
+    if run.attributes.paragraphStyle.lineBreakMode == tlbmClipping:
+      return true
+
 proc textLayoutImpl(
     rect: nimkitTypes.Rect,
     storage: TextStorage,
@@ -415,7 +529,48 @@ proc textLayoutImpl(
       font.underline = attributes.hasUnderline
       font.strikethrough = attributes.hasStrikethrough
       spans.add((fs(font, fill(attributes.foregroundColor.rgba)), text))
-  if rasterize:
+  if wrap and storage.usesMixedLineBreakModes():
+    let
+      wrapped =
+        if rasterize:
+          typeset(
+            rect.toFigRect,
+            spans,
+            hAlign = alignment.toFontHorizontal,
+            vAlign = Top,
+            minContent = false,
+            wrap = true,
+          )
+        else:
+          typesetForMeasurement(
+            rect.toFigRect,
+            spans,
+            hAlign = alignment.toFontHorizontal,
+            vAlign = Top,
+            minContent = false,
+            wrap = true,
+          )
+      unwrapped =
+        if rasterize:
+          typeset(
+            rect.toFigRect,
+            spans,
+            hAlign = alignment.toFontHorizontal,
+            vAlign = Top,
+            minContent = false,
+            wrap = false,
+          )
+        else:
+          typesetForMeasurement(
+            rect.toFigRect,
+            spans,
+            hAlign = alignment.toFontHorizontal,
+            vAlign = Top,
+            minContent = false,
+            wrap = false,
+          )
+    result = mixedLineBreakLayout(wrapped, unwrapped, storage)
+  elif rasterize:
     result = typeset(
       rect.toFigRect,
       spans,

--- a/src/merenda/nimkit/text/markdownviews.nim
+++ b/src/merenda/nimkit/text/markdownviews.nim
@@ -54,6 +54,7 @@ const
   MarkdownTableMinimumColumnWidth = 3
   MarkdownTablePreferredCellWidth = 12
   MarkdownTableSeparatorWidth = 3
+  MarkdownTableFontScale = 0.9'f32
   MarkdownTableViewportFraction = 0.9'f32
 
 type
@@ -891,6 +892,9 @@ proc renderTable(
 ) =
   var tableAttributes = attributes
   tableAttributes.fontName = builder.style.codeFontName
+  tableAttributes.fontSize =
+    max(builder.style.bodyFontSize * MarkdownTableFontScale, 1.0'f32)
+  tableAttributes.paragraphStyle.lineBreakMode = tlbmClipping
   var rows: seq[MarkdownTableRow]
   for section in table.children:
     let isHeader = section of markdownParser.THead
@@ -1339,7 +1343,7 @@ proc markdownTableCharacterWidth(view: MarkdownView): float32 =
   let codeStyle = TextStyle(
     color: view.xMarkdownStyle.textColor,
     fontName: view.xMarkdownStyle.codeFontName,
-    fontSize: max(view.xMarkdownStyle.bodyFontSize, 1.0'f32),
+    fontSize: max(view.xMarkdownStyle.bodyFontSize * MarkdownTableFontScale, 1.0'f32),
   )
   max(textNaturalSize("M", codeStyle).width, 1.0'f32)
 

--- a/src/merenda/nimkit/text/texteditors.nim
+++ b/src/merenda/nimkit/text/texteditors.nim
@@ -280,11 +280,7 @@ proc textDocumentSize(
 
   let
     insets = editor.xTextInsets
-    width =
-      if editor.xWraps:
-        max(viewportWidth, editor.xMinimumWrappedDocumentWidth)
-      else:
-        DefaultTextEditorMeasureWidth
+    width = if editor.xWraps: viewportWidth else: DefaultTextEditorMeasureWidth
     measurement = editor.measuredText(width)
     textWidth =
       if measurement.hasText:
@@ -298,7 +294,7 @@ proc textDocumentSize(
         defaultFontSize()
     documentWidth =
       if editor.xWraps:
-        max(viewportWidth, editor.xMinimumWrappedDocumentWidth)
+        max(max(viewportWidth, editor.xMinimumWrappedDocumentWidth), textWidth)
       else:
         max(max(textWidth, viewportWidth), editor.xMinimumDocumentSize.width)
   initSize(
@@ -313,14 +309,19 @@ func closeEnough(left, right: Size): bool =
   abs(left.width - right.width) <= TextEditorLayoutEpsilon and
     abs(left.height - right.height) <= TextEditorLayoutEpsilon
 
-proc applyTextEditorLayout(editor: TextEditor, frame: Rect, documentSize: Size) =
+proc applyTextEditorLayout(
+    editor: TextEditor, frame: Rect, viewportSize, documentSize: Size
+) =
   editor.xScrollView.setFrameFromLayout(frame)
   editor.xTextView.setFrameFromLayout(
     rect(0.0, 0.0, documentSize.width, documentSize.height)
   )
   if not editor.xTextView.layoutManager().usesBackgroundLayout():
+    let textContainerSize = initSize(
+      if editor.xWraps: viewportSize.width else: documentSize.width, documentSize.height
+    )
     editor.xTextView.textContainer =
-      initTextContainer(documentSize, editor.xTextInsets, editor.xWraps)
+      initTextContainer(textContainerSize, editor.xTextInsets, editor.xWraps)
   editor.xScrollView.tile()
 
 proc updateTextEditorLayout(editor: TextEditor) =
@@ -339,7 +340,7 @@ proc updateTextEditorLayout(editor: TextEditor) =
     if nextSize.closeEnough(documentSize):
       break
     documentSize = nextSize
-  editor.applyTextEditorLayout(frame, documentSize)
+  editor.applyTextEditorLayout(frame, viewport, documentSize)
 
 protocol DefaultTextEditorLayout of ViewLayoutProtocol:
   method layoutIntrinsicContentSize(editor: TextEditor): IntrinsicSize =

--- a/tests/nimkit/markdownviews.nim
+++ b/tests/nimkit/markdownviews.nim
@@ -790,6 +790,18 @@ Press <kbd>Enter</kbd>.
       .splitLines()
     check wordLines[^1].contains(longWord)
 
+  test "GFM tables use a smaller font than Markdown body text":
+    let
+      style = initMarkdownStyle()
+      storage = markdownTextStorage(
+        "Body prose.\n\n| Metric | Value |\n| - | - |\n| CPU p95 | 42 ms |",
+        style = style,
+      )
+
+    check storage.attributesFor("Body prose").fontSize == style.bodyFontSize
+    check storage.attributesFor("Metric").fontSize == style.bodyFontSize * 0.9'f32
+    check storage.attributesFor("CPU p95").fontSize == style.bodyFontSize * 0.9'f32
+
   test "wide GFM tables use horizontal overflow while Markdown still wraps":
     let
       source =
@@ -806,8 +818,25 @@ Press <kbd>Enter</kbd>.
     check view.wraps
     check view.scrollView().hasHorizontalScroller
     check view.scrollView().maximumContentOffset().x > 0.0'f32
-    check view.textView().layoutManager().lineCount() >
-      view.textStorage().stringValue().splitLines().len.Natural
+    let
+      rendered = view.textStorage().stringValue()
+      paragraphStop = rendered.runeIndexOf("\n\n")
+      tableStart = paragraphStop + 2
+      tableLineLength = rendered.runeSubStr(tableStart).runeIndexOf("\n")
+
+    require paragraphStop > 0
+    require tableLineLength > 0
+    let
+      paragraphRects = view.textView().selectionRects(initTextRange(0, paragraphStop))
+      tableRects =
+        view.textView().selectionRects(initTextRange(tableStart, tableLineLength))
+      viewportWidth = view.scrollView().viewportSize().width
+
+    check paragraphRects.len > 1
+    for rect in paragraphRects:
+      check rect.maxX <= viewportWidth + 0.001'f32
+    check tableRects.len == 1
+    check tableRects[0].maxX > viewportWidth
 
   test "compact GFM tables stay within the Markdown viewport":
     let view = newMarkdownView(


### PR DESCRIPTION
## Summary
- keep normal Markdown paragraphs wrapped to the visible viewport when a table needs horizontal overflow
- preserve wide table rows as one horizontally scrollable line and size table text at 90% of body text
- add layout and font-scale regression coverage

## Validation
- `atlas-run tests`
- `atlas-run tests --compile-only examples/all_compile.nim`