### PR TITLE
Add stable render slots for scrolling and text updates

### DIFF
--- a/TODO-fragments.md
+++ b/TODO-fragments.md
@@ -506,11 +506,25 @@ compare generations; the render walk now borrows appearances synchronously and
 caches only `ThemeGeneration`.
 
 A second view-design pass separated bounds-origin movement from self drawing.
-Stable clipped and escaped content transforms now absorb scrolling, and scroll
-invalidation targets the moving scroller rather than the unchanged scroll-view
-background. A focused test verifies that a layout-owned bounds-origin update can
-reach an independent renderer replica with zero view captures, while a descendant
-that reads `DrawContext.visibleRect` is still recaptured.
+Stable clipped and escaped content transforms now absorb scrolling through the
+generic `View.bounds=` path as well as `ClipView`, rather than relying on a
+Markdown-specific call site. A focused test verifies that a normal bounds-origin
+update can reach an independent renderer replica with zero view captures, while a
+descendant slot that reads `DrawContext.visibleRect` is still recaptured.
+
+Each view now owns an ordered set of stable render slots. Existing widgets
+automatically draw into a default content slot, while composite widgets can split
+their drawing across `drawUnderlay`, `draw`, and `drawOverlay` phases to implement
+patterns such as `[header] [content] [footer]` around child views. Slot revisions,
+resource manifests, escaped roots, explicit layers, replica updates, and fragment
+identities are all retained independently.
+
+Text views use one slot per visual glyph line, with separate selection/find and
+caret slots. Dirty Markdown and editor updates therefore replace only visually
+changed lines instead of transferring the complete glyph arrangement. Monospaced
+text views similarly retain their surface, viewport dependency, visible rows, and
+cursor independently; terminal cell changes and cursor motion no longer rebuild
+unchanged rows.
 
 FigDraw's `renderRoot(RenderFragments)` iterates `levels`, `roots`, and recursive
 `children` cursors directly. Fragment attachment builds its `RenderEntries`
@@ -524,6 +538,19 @@ lookup table; the long-running sample identifies that as the main remaining
 traversal micro-cost. It does not copy `Fig` nodes or build a render tree, and at
 0.014 ms here it is not a Merenda-side performance cliff. Avoiding that metadata
 copy is a separate FigDraw optimization.
+
+## Follow-up work
+
+- [x] Generalize the Markdown viewer's retained translate-node scrolling
+      optimization and apply it consistently to every scrolling view.
+- [x] Investigate whether monospaced text views, including editors and terminals,
+      can use Fig fragments to make updates cheaper.
+- [x] Audit the view implementations for every current widget and adopt stable
+      fragment slots where appropriate, following patterns such as `[header]
+      [content] [footer]`.
+- [x] Optimize dirty Markdown updates with visual-line render fragments. Scrolling
+      and selection changes retain unchanged glyph lines, and renderer updates
+      transfer only the line, underlay, or caret slots that actually changed.
 
 ## Delivery sequence
 

--- a/src/merenda/nimkit/containers/scrollviews.nim
+++ b/src/merenda/nimkit/containers/scrollviews.nim
@@ -372,10 +372,14 @@ protocol DefaultClipViewGeometry of ViewProtocol:
     let constrained = rect(clipView.constrainScrollPoint(bounds.origin), bounds.size)
     if clipView.xBounds == constrained:
       return
+    let previousBounds = clipView.xBounds
     clipView.xBounds = rect(constrained.origin, constrained.size)
     emit clipView.layoutInputChanged(lirBounds)
     emit clipView.geometryDidChange()
-    clipView.needsDisplay = true
+    if previousBounds.size == constrained.size:
+      clipView.markRenderStructureChanged()
+    else:
+      clipView.needsDisplay = true
     clipView.xScrollView.reflectScrolledClipView(clipView)
 
 proc horizontalHeaderRect(scrollView: ScrollView): Rect =

--- a/src/merenda/nimkit/containers/tableviews.nim
+++ b/src/merenda/nimkit/containers/tableviews.nim
@@ -2300,6 +2300,8 @@ proc invalidateTableRows(tableView: TableView) =
   if not scroller.isNil:
     scroller.needsDisplay = true
   tableView.xContentView.needsDisplay = true
+  for rowView in tableView.xContentView.xRowViews:
+    rowView.needsDisplay = true
   tableView.needsDisplay = true
 
 proc uncachedRowHeightForRow(tableView: TableView, index: int): float32 =

--- a/src/merenda/nimkit/drawing/drawing.nim
+++ b/src/merenda/nimkit/drawing/drawing.nim
@@ -80,17 +80,36 @@ const
       ]
   TextEllipsis = "…"
 
-type DrawContext* = ref object
-  xRenders: Renders
-  xLayer: ZLevel
-  xParent: FigIdx
-  xViewParent: FigIdx
-  xRenderOrigin: nimkitTypes.Point
-  xBounds: nimkitTypes.Rect
-  xVisibleRect: nimkitTypes.Rect
-  xUsesVisibleRect: bool
-  xAppearance: Appearance
-  xResources: RenderResourceManifest
+type
+  RenderSlotCapture* = object
+    ## Captured or retained drawing for one stable slot inside a view.
+    slotId*: RenderSlotId
+    position*: RenderSlotPosition
+    revision*: uint64
+    captured*: bool
+    renders*: Renders
+    resources*: RenderResourceManifest
+    usesVisibleRect*: bool
+
+  DrawContext* = ref object
+    xRenders: Renders
+    xLayer: ZLevel
+    xParent: FigIdx
+    xViewParent: FigIdx
+    xRenderOrigin: nimkitTypes.Point
+    xBounds: nimkitTypes.Rect
+    xVisibleRect: nimkitTypes.Rect
+    xUsesVisibleRect: bool
+    xAppearance: Appearance
+    xResources: RenderResourceManifest
+    xCapturesSlots: bool
+    xSlotShell: Fig
+    xDefaultSlotRevision: uint64
+    xCachedSlotRevisions: Table[RenderSlotId, uint64]
+    xForcedSlots: Table[RenderSlotId, bool]
+    xForceAllSlots: bool
+    xSlotCaptures: seq[RenderSlotCapture]
+    xActiveSlot: int
 
 var defaultTypefaceIds {.threadvar.}: Table[string, TypefaceId]
 
@@ -798,6 +817,7 @@ proc initDrawContext*(): DrawContext =
     xRenders: Renders(layers: initOrderedTable[ZLevel, RenderList]()),
     xLayer: DefaultDrawLevel,
     xResources: initRenderResourceManifest(),
+    xActiveSlot: -1,
   )
   result.xRenders.layers[DefaultDrawLevel] = RenderList()
 
@@ -811,6 +831,9 @@ proc beginDraw*(
     appearance: Appearance,
     layer = DefaultDrawLevel,
 ) =
+  context.xCapturesSlots = false
+  context.xSlotCaptures.setLen(0)
+  context.xActiveSlot = -1
   context.xLayer = layer
   context.xParent = parent
   context.xViewParent = viewParent
@@ -820,24 +843,149 @@ proc beginDraw*(
   context.xUsesVisibleRect = false
   context.xAppearance = appearance
 
+proc beginRenderSlotCapture*(
+    context: DrawContext,
+    shell: Fig,
+    renderOrigin: nimkitTypes.Point,
+    bounds: nimkitTypes.Rect,
+    visibleRect: nimkitTypes.Rect,
+    appearance: Appearance,
+    defaultRevision: uint64,
+    cachedRevisions: Table[RenderSlotId, uint64],
+    forcedSlots: openArray[RenderSlotId],
+    forceAll = false,
+    layer = DefaultDrawLevel,
+) =
+  ## Prepares a view draw whose named outputs become independently retained slots.
+  context.xRenders = nil
+  context.xResources = nil
+  context.xLayer = layer
+  context.xParent = (-1).FigIdx
+  context.xViewParent = (-1).FigIdx
+  context.xRenderOrigin = renderOrigin
+  context.xBounds = bounds
+  context.xVisibleRect = visibleRect
+  context.xUsesVisibleRect = false
+  context.xAppearance = appearance
+  context.xCapturesSlots = true
+  context.xSlotShell = shell
+  context.xDefaultSlotRevision = defaultRevision
+  context.xCachedSlotRevisions = cachedRevisions
+  context.xForcedSlots = initTable[RenderSlotId, bool]()
+  for slot in forcedSlots:
+    context.xForcedSlots[slot] = true
+  context.xForceAllSlots = forceAll
+  context.xSlotCaptures.setLen(0)
+  context.xActiveSlot = -1
+
+proc renderSlotIndex(context: DrawContext, slot: RenderSlotId): int =
+  for index, capture in context.xSlotCaptures:
+    if capture.slotId == slot:
+      return index
+  -1
+
+proc activateRenderSlot(context: DrawContext, index: int) =
+  context.xActiveSlot = index
+  if index < 0 or not context.xSlotCaptures[index].captured:
+    context.xRenders = nil
+    context.xResources = nil
+    context.xParent = (-1).FigIdx
+    context.xViewParent = (-1).FigIdx
+    return
+  context.xRenders = context.xSlotCaptures[index].renders
+  context.xResources = context.xSlotCaptures[index].resources
+  context.xParent = context.xRenders.layers[context.xLayer].rootIds[0]
+  context.xViewParent = (-1).FigIdx
+
+proc beginRenderSlot*(
+    context: DrawContext,
+    slot: RenderSlotId,
+    revision: uint64,
+    position = rspBeforeSubviews,
+): bool =
+  ## Selects one stable drawing slot and reports whether it needs recapturing.
+  ##
+  ## Callers must only emit drawing operations when this returns `true`. Every
+  ## draw must enumerate all of its current slots so removed slots can be detached.
+  if context.isNil:
+    raise newException(ValueError, "cannot draw a render slot with a nil context")
+  if not context.xCapturesSlots:
+    return true
+  var index = context.renderSlotIndex(slot)
+  if index >= 0:
+    let capture = context.xSlotCaptures[index]
+    if capture.revision != revision or capture.position != position:
+      raise newException(
+        ValueError, "a render slot cannot change revision or position within one draw"
+      )
+  else:
+    let captured =
+      context.xForceAllSlots or slot in context.xForcedSlots or
+      slot notin context.xCachedSlotRevisions or
+      context.xCachedSlotRevisions[slot] != revision
+    var renders: Renders
+    var resources: RenderResourceManifest
+    if captured:
+      renders = Renders(layers: initOrderedTable[ZLevel, RenderList]())
+      renders.layers[context.xLayer] = RenderList()
+      discard renders.addRoot(context.xLayer, context.xSlotShell)
+      resources = initRenderResourceManifest()
+    context.xSlotCaptures.add RenderSlotCapture(
+      slotId: slot,
+      position: position,
+      revision: revision,
+      captured: captured,
+      renders: renders,
+      resources: resources,
+    )
+    index = context.xSlotCaptures.high
+  context.activateRenderSlot(index)
+  context.xSlotCaptures[index].captured
+
+proc ensureDefaultRenderSlot(context: DrawContext) =
+  if context.xCapturesSlots and context.xActiveSlot < 0:
+    discard context.beginRenderSlot(
+      0.RenderSlotId, context.xDefaultSlotRevision, rspBeforeSubviews
+    )
+
+proc takeRenderSlotCaptures*(context: DrawContext): seq[RenderSlotCapture] =
+  ## Moves the ordered slot captures out of a completed retained view draw.
+  if context.isNil or not context.xCapturesSlots:
+    return
+  if context.xSlotCaptures.len == 0:
+    discard context.beginRenderSlot(
+      0.RenderSlotId, context.xDefaultSlotRevision, rspBeforeSubviews
+    )
+  result = move context.xSlotCaptures
+  context.xActiveSlot = -1
+  context.xRenders = nil
+  context.xResources = nil
+
 proc renderList*(context: DrawContext): RenderList =
+  context.ensureDefaultRenderSlot()
+  if context.xRenders.isNil:
+    return RenderList()
   if DefaultDrawLevel in context.xRenders.layers:
     return context.xRenders.layers[DefaultDrawLevel]
   RenderList()
 
 proc renderParent*(context: DrawContext): FigIdx =
+  context.ensureDefaultRenderSlot()
   context.xParent
 
 proc renderLayer*(context: DrawContext): ZLevel =
   context.xLayer
 
 proc renderViewParent*(context: DrawContext): FigIdx =
+  context.ensureDefaultRenderSlot()
   context.xViewParent
 
 proc renders*(context: DrawContext): Renders =
+  context.ensureDefaultRenderSlot()
   context.xRenders
 
 proc resources*(context: DrawContext): RenderResourceManifest =
+  context.ensureDefaultRenderSlot()
   context.xResources
 
 proc appearance*(context: DrawContext): Appearance =
@@ -860,7 +1008,10 @@ proc bounds*(context: DrawContext): nimkitTypes.Rect =
   context.xBounds
 
 proc visibleRect*(context: DrawContext): nimkitTypes.Rect =
+  context.ensureDefaultRenderSlot()
   context.xUsesVisibleRect = true
+  if context.xCapturesSlots and context.xActiveSlot >= 0:
+    context.xSlotCaptures[context.xActiveSlot].usesVisibleRect = true
   context.xVisibleRect
 
 proc drawingDependsOnVisibleRect*(context: DrawContext): bool =
@@ -870,6 +1021,9 @@ proc drawingDependsOnVisibleRect*(context: DrawContext): bool =
 proc addFig*(
     context: DrawContext, layer: ZLevel, parent: FigIdx, node: Fig
 ): FigIdx {.discardable.} =
+  context.ensureDefaultRenderSlot()
+  if context.xRenders.isNil:
+    raise newException(ValueError, "cannot draw an unchanged render slot")
   if parent == (-1).FigIdx:
     context.xRenders.addRoot(layer, node)
   else:
@@ -1133,6 +1287,7 @@ proc addText*(
     style: TextStyle,
     alignment = taLeft,
 ): FigIdx {.discardable.} =
+  context.ensureDefaultRenderSlot()
   let renderedRect = context.renderRectFor(rect)
   let layout = textLayout(renderedRect, text, style, alignment)
   context.xResources.addFonts(layout)
@@ -1161,6 +1316,7 @@ proc addText*(
     style: TextStyle,
     alignment = taLeft,
 ): FigIdx {.discardable.} =
+  context.ensureDefaultRenderSlot()
   let renderedRect = context.renderRectFor(rect)
   let layout = textLayout(renderedRect, text, style, alignment)
   context.xResources.addFonts(layout)
@@ -1187,6 +1343,7 @@ proc addText*(
 proc addText*(
     context: DrawContext, rect: nimkitTypes.Rect, layout: GlyphArrangement
 ): FigIdx {.discardable.} =
+  context.ensureDefaultRenderSlot()
   context.xResources.addFonts(layout)
   context.addFig(textNode(context.renderRectFor(rect), layout))
 
@@ -1198,6 +1355,7 @@ proc addImage*(
 ): FigIdx {.discardable.} =
   if image.isNil:
     return (-1).FigIdx
+  context.ensureDefaultRenderSlot()
   context.xResources.addImage(image)
   context.addFig(imageNode(context.renderRectFor(rect), image, fill(tint.rgba)))
 
@@ -1211,6 +1369,7 @@ proc addImage*(
 ): FigIdx {.discardable.} =
   if image.isNil:
     return (-1).FigIdx
+  context.ensureDefaultRenderSlot()
   context.xResources.addImage(image)
   context.addFig(
     layer, parent, imageNode(context.renderRectFor(rect), image, fill(tint.rgba))
@@ -1354,6 +1513,7 @@ proc addSvgMtsdfLayers(
   if svg.layers.len == 0 or svg.size.width <= 0.0'f32 or svg.size.height <= 0.0'f32:
     return (-1).FigIdx
 
+  context.ensureDefaultRenderSlot()
   let target = context.renderRectFor(rect)
   result = (-1).FigIdx
   for svgLayer in svg.layers:
@@ -1468,6 +1628,7 @@ proc addSelectedText*(
     selectedLocation, selectedLength: int,
     selectionColor: nimkitTypes.Color,
 ): FigIdx {.discardable.} =
+  context.ensureDefaultRenderSlot()
   context.xResources.addFonts(layout)
   var node = textNode(context.renderRectFor(rect), layout)
   node.selectTextNode(selectedLocation, selectedLength, selectionColor)

--- a/src/merenda/nimkit/drawing/drawing.nim
+++ b/src/merenda/nimkit/drawing/drawing.nim
@@ -1033,6 +1033,7 @@ proc addFig*(context: DrawContext, parent: FigIdx, node: Fig): FigIdx {.discarda
   context.addFig(context.xLayer, parent, node)
 
 proc addFig*(context: DrawContext, node: Fig): FigIdx {.discardable.} =
+  context.ensureDefaultRenderSlot()
   context.addFig(context.xParent, node)
 
 proc addRenderRectangle*(
@@ -1094,6 +1095,7 @@ proc addRenderRectangle*(
     lightMaskContent = false,
     cornerRadii = initCornerRadii(0.0'f32),
 ): FigIdx {.discardable.} =
+  context.ensureDefaultRenderSlot()
   context.addRenderRectangle(
     context.xParent, rect, fillValue, strokeColor, strokeWidth, cornerRadius, shadows,
     clips, maskContent, roundedCorners, lightMaskContent, cornerRadii,
@@ -1174,6 +1176,7 @@ proc addRenderLine*(
     fillValue: Fill,
     weight: float32,
 ): FigIdx {.discardable.} =
+  context.ensureDefaultRenderSlot()
   context.addRenderLine(context.xParent, start, stop, fillValue, weight)
 
 proc addRenderCircle*(
@@ -1203,6 +1206,7 @@ proc addRenderCircle*(
 proc addRenderCircle*(
     context: DrawContext, center: nimkitTypes.Point, fillValue: Fill, radius: float32
 ): FigIdx {.discardable.} =
+  context.ensureDefaultRenderSlot()
   context.addRenderCircle(context.xParent, center, fillValue, radius)
 
 proc addRenderDrawable*(
@@ -1254,6 +1258,7 @@ proc addRenderDrawable*(
     drawSteps = 0'u16,
     drawAa = 0.0'f32,
 ): FigIdx {.discardable.} =
+  context.ensureDefaultRenderSlot()
   context.addRenderDrawable(
     context.xParent, rect, drawOps, fillValue, stroke, drawSteps, drawAa
   )
@@ -1604,6 +1609,7 @@ proc addSvgMtsdf*(
     sdThreshold = 0.5'f32,
 ): FigIdx {.discardable.} =
   ## Draws an SVG using its source fill and stroke colors.
+  context.ensureDefaultRenderSlot()
   context.addSvgMtsdf(
     context.xLayer, context.xParent, rect, svg, strokeWeight, sdThreshold
   )
@@ -1617,6 +1623,7 @@ proc addSvgMtsdf*(
     sdThreshold = 0.5'f32,
 ): FigIdx {.discardable.} =
   ## Draws an SVG with one caller-selected tint replacing its source paints.
+  context.ensureDefaultRenderSlot()
   context.addSvgMtsdf(
     context.xLayer, context.xParent, rect, svg, fillValue, strokeWeight, sdThreshold
   )
@@ -1658,6 +1665,7 @@ proc addFocusRing*(
   )
 
 proc addFocusRing*(context: DrawContext, rect: nimkitTypes.Rect, box: ControlBoxStyle) =
+  context.ensureDefaultRenderSlot()
   let parent =
     if box.focusRingInset < 0.0'f32: context.xViewParent else: context.xParent
   context.addFocusRing(context.xLayer, parent, rect, box)
@@ -1697,4 +1705,5 @@ proc addComboBoxArrow*(
 proc addComboBoxArrow*(
     context: DrawContext, rect: nimkitTypes.Rect, color: nimkitTypes.Color
 ) =
+  context.ensureDefaultRenderSlot()
   context.addComboBoxArrow(context.xParent, rect, color)

--- a/src/merenda/nimkit/drawing/rendering.nim
+++ b/src/merenda/nimkit/drawing/rendering.nim
@@ -1,4 +1,4 @@
-import std/options
+import std/[options, tables]
 
 when defined(useNativeDynlib):
   import figdraw/dynlib
@@ -167,6 +167,7 @@ proc renderViewInto(
     view, level, placement.contentParent, nodeParent, placement.contentOrigin,
     appearance,
   )
+  discard view.sendLocalIfHandled(drawUnderlay(), context)
   discard view.sendLocalIfHandled(draw(), context)
 
   for child in view.subviews:
@@ -174,6 +175,12 @@ proc renderViewInto(
       context, child, appearance, placement.contentParent, level,
       placement.contentOrigin,
     )
+
+  context.beginDraw(
+    view, level, placement.contentParent, nodeParent, placement.contentOrigin,
+    appearance,
+  )
+  discard view.sendLocalIfHandled(drawOverlay(), context)
 
 when not defined(useNativeDynlib):
   type DisplayRevisionSnapshot = object
@@ -250,16 +257,17 @@ when not defined(useNativeDynlib):
     source.rootIds.setLen(0)
 
   proc captureViewFrame(
+      scene: RenderScene,
       view: View,
       viewId: RenderViewId,
       parentViewId: RenderViewId,
       cacheKey: RenderViewCacheKey,
       appearance: ptr Appearance,
   ): RenderViewFrame =
-    let context = initDrawContext()
     let localFrame =
       rect(0.0'f32, 0.0'f32, cacheKey.frame.size.width, cacheKey.frame.size.height)
-    let rootIdx = context.addRenderRectangle(
+    let shellContext = initDrawContext()
+    let shellRoot = shellContext.addRenderRectangle(
       cacheKey.level,
       (-1).FigIdx,
       localFrame,
@@ -267,16 +275,38 @@ when not defined(useNativeDynlib):
       shadows = view.shadow,
       clips = view.clipsToBounds,
     )
+    let shell = shellContext.renders.layers[cacheKey.level].nodes[shellRoot.int]
+
+    var cachedRevisions = initTable[RenderSlotId, uint64]()
+    for state in scene.viewSlotCacheStates(viewId):
+      cachedRevisions[state.slotId] = state.revision
+    let
+      forceAll = scene.requiresFullViewCapture(viewId, cacheKey)
+      forcedSlots = scene.forcedVisibleRectSlots(viewId, cacheKey.visibleRect)
+      context = initDrawContext()
+      defaultRevision = view.renderSlotRevision(0.RenderSlotId)
+    context.beginRenderSlotCapture(
+      shell,
+      ZeroPoint,
+      view.bounds,
+      view.visibleRect,
+      appearance[],
+      defaultRevision,
+      cachedRevisions,
+      forcedSlots,
+      forceAll,
+      cacheKey.level,
+    )
 
     if view.usesThemedRootBackground(cacheKey.isRoot):
-      context.addRootBackgroundPinstripes(
-        view, cacheKey.level, rootIdx, localFrame, appearance[]
-      )
+      if context.beginRenderSlot(0.RenderSlotId, defaultRevision):
+        context.addRootBackgroundPinstripes(
+          view, cacheKey.level, context.renderParent, localFrame, appearance[]
+        )
 
-    context.beginDraw(
-      view, cacheKey.level, rootIdx, (-1).FigIdx, ZeroPoint, appearance[]
-    )
+    discard view.sendLocalIfHandled(drawUnderlay(), context)
     discard view.sendLocalIfHandled(draw(), context)
+    discard view.sendLocalIfHandled(drawOverlay(), context)
 
     result = RenderViewFrame(
       viewId: viewId,
@@ -285,28 +315,40 @@ when not defined(useNativeDynlib):
       placementChanged: true,
       captured: true,
       placement: cacheKey.placementNode(),
+      shell: shell,
       contentTransform: cacheKey.contentTransformNode(),
       escapedTransform: cacheKey.contentTransformNode(),
-      resources: context.resources,
-      usesVisibleRect: context.drawingDependsOnVisibleRect(),
     )
-    var ownLayer = move context.renders.layers[cacheKey.level]
-    if rootIdx.int == 0 and ownLayer.rootIds == @[rootIdx]:
-      ownLayer.takeOnlyRootChildren(rootIdx, result.shell, result.selfContents)
-    else:
-      result.shell = ownLayer.nodes[rootIdx.int]
-      result.shell.parent = (-1).FigIdx
-      result.shell.childCount = 0
-      for child in ownLayer.nodes.childIndex(rootIdx):
-        ownLayer.appendSubtree(child, result.selfContents)
-      for escapedRoot in ownLayer.rootIds:
-        if escapedRoot != rootIdx:
-          ownLayer.appendSubtree(escapedRoot, result.escapedContents)
-    for level, list in context.renders.pairs():
-      if level != cacheKey.level and list.nodes.len > 0:
-        result.extraLayers.add RenderLayerContribution(
-          level: level, contents: list.wrapInPlacement(cacheKey.layerTransformNode())
-        )
+    var captures = context.takeRenderSlotCaptures()
+    result.slots = newSeqOfCap[RenderViewSlotFrame](captures.len)
+    for capture in captures.mitems:
+      var frameSlot = RenderViewSlotFrame(
+        slotId: capture.slotId,
+        position: capture.position,
+        revision: capture.revision,
+        captured: capture.captured,
+        resources: move capture.resources,
+        usesVisibleRect: capture.usesVisibleRect,
+      )
+      if capture.captured:
+        var ownLayer = move capture.renders.layers[cacheKey.level]
+        let rootIdx = ownLayer.rootIds[0]
+        if rootIdx.int == 0 and ownLayer.rootIds == @[rootIdx]:
+          var ignoredShell: Fig
+          ownLayer.takeOnlyRootChildren(rootIdx, ignoredShell, frameSlot.contents)
+        else:
+          for child in ownLayer.nodes.childIndex(rootIdx):
+            ownLayer.appendSubtree(child, frameSlot.contents)
+          for escapedRoot in ownLayer.rootIds:
+            if escapedRoot != rootIdx:
+              ownLayer.appendSubtree(escapedRoot, frameSlot.escapedContents)
+        for level, list in capture.renders.pairs():
+          if level != cacheKey.level and list.nodes.len > 0:
+            frameSlot.extraLayers.add RenderLayerContribution(
+              level: level,
+              contents: list.wrapInPlacement(cacheKey.layerTransformNode()),
+            )
+      result.slots.add move frameSlot
 
   proc collectRenderFrames(
       scene: RenderScene,
@@ -345,7 +387,9 @@ when not defined(useNativeDynlib):
 
     let capture = scene.needsViewCapture(viewId, cacheKey)
     if capture:
-      frames.add view.captureViewFrame(viewId, parentViewId, cacheKey, appearance)
+      frames.add scene.captureViewFrame(
+        view, viewId, parentViewId, cacheKey, appearance
+      )
     else:
       frames.add RenderViewFrame(
         viewId: viewId,

--- a/src/merenda/nimkit/drawing/renderscenes.nim
+++ b/src/merenda/nimkit/drawing/renderscenes.nim
@@ -44,6 +44,18 @@ type
     level*: ZLevel
     contents*: RenderList
 
+  RenderViewSlotFrame* = object
+    ## One ordered, independently replaceable part of a view's own drawing.
+    slotId*: RenderSlotId
+    position*: RenderSlotPosition
+    revision*: uint64
+    captured*: bool
+    contents*: RenderList
+    escapedContents*: RenderList
+    extraLayers*: seq[RenderLayerContribution]
+    resources*: RenderResourceManifest
+    usesVisibleRect*: bool
+
   RenderViewFrame* = object
     ## One visible view's changed placement and optional drawing contribution.
     viewId*: RenderViewId
@@ -55,16 +67,25 @@ type
     shell*: Fig
     contentTransform*: Fig
     escapedTransform*: Fig
-    selfContents*: RenderList
-    escapedContents*: RenderList
-    extraLayers*: seq[RenderLayerContribution]
-    resources*: RenderResourceManifest
-    usesVisibleRect*: bool
+    slots*: seq[RenderViewSlotFrame]
 
   ViewPlacement = object
     viewId: RenderViewId
     parentViewId: RenderViewId
     level: ZLevel
+
+  ViewRenderSlotEntry = object
+    position: RenderSlotPosition
+    revision: uint64
+    contents: RenderList
+    escapedContents: RenderList
+    extraLayers: seq[RenderLayerContribution]
+    resources: RenderResourceManifest
+    usesVisibleRect: bool
+    handle: RenderFragmentHandle
+    escapedHandle: RenderFragmentHandle
+    extraHandles: Table[ZLevel, RenderFragmentHandle]
+    changeGeneration: uint64
 
   ViewRenderEntry = object
     cacheKey: RenderViewCacheKey
@@ -72,11 +93,8 @@ type
     shell: Fig
     contentTransform: Fig
     escapedTransform: Fig
-    selfContents: RenderList
-    escapedContents: RenderList
-    extraLayers: seq[RenderLayerContribution]
-    resources: RenderResourceManifest
-    usesVisibleRect: bool
+    slots: Table[RenderSlotId, ViewRenderSlotEntry]
+    slotOrder: seq[RenderSlotId]
     placementHandle: RenderFragmentHandle
     placementCursor: RenderCursor
     shellHandle: RenderFragmentHandle
@@ -85,13 +103,17 @@ type
     contentCursor: RenderCursor
     escapedTransformHandle: RenderFragmentHandle
     escapedTransformCursor: RenderCursor
-    selfHandle: RenderFragmentHandle
-    escapedHandle: RenderFragmentHandle
-    extraHandles: Table[ZLevel, RenderFragmentHandle]
     externalParent: RenderViewId
     captureGeneration: uint64
     changeGeneration: uint64
     captureChangeGeneration: uint64
+
+  RenderSlotCacheState* = object
+    ## Cached slot metadata used to plan a partial view recapture.
+    slotId*: RenderSlotId
+    position*: RenderSlotPosition
+    revision*: uint64
+    usesVisibleRect*: bool
 
   RetiredRenderResources = object
     releaseGeneration: uint64
@@ -277,20 +299,59 @@ proc replaceContents*(
   scene.perViewMode = false
   scene.liveResources = resources
 
+proc requiresFullViewCapture*(
+    scene: RenderScene, viewId: RenderViewId, cacheKey: RenderViewCacheKey
+): bool =
+  ## Reports whether every drawing slot must be recaptured for this view.
+  if scene.isNil or not scene.perViewMode or viewId notin scene.viewEntries:
+    return true
+  let cached = scene.viewEntries[viewId].cacheKey
+  cached.appearanceGeneration != cacheKey.appearanceGeneration or
+    cached.frame.size != cacheKey.frame.size or
+    cached.bounds.size != cacheKey.bounds.size or cached.level != cacheKey.level or
+    cached.isRoot != cacheKey.isRoot
+
+proc viewSlotCacheStates*(
+    scene: RenderScene, viewId: RenderViewId
+): seq[RenderSlotCacheState] =
+  ## Returns slot revisions in their current drawing order.
+  if scene.isNil or not scene.perViewMode or viewId notin scene.viewEntries:
+    return
+  let entry = addr scene.viewEntries[viewId]
+  result = newSeqOfCap[RenderSlotCacheState](entry[].slotOrder.len)
+  for slotId in entry[].slotOrder:
+    let slot = addr entry[].slots[slotId]
+    result.add RenderSlotCacheState(
+      slotId: slotId,
+      position: slot[].position,
+      revision: slot[].revision,
+      usesVisibleRect: slot[].usesVisibleRect,
+    )
+
+proc forcedVisibleRectSlots*(
+    scene: RenderScene, viewId: RenderViewId, visibleRect: Rect
+): seq[RenderSlotId] =
+  ## Returns cached slots whose drawing depends on a changed visible rectangle.
+  if scene.isNil or not scene.perViewMode or viewId notin scene.viewEntries:
+    return
+  let entry = addr scene.viewEntries[viewId]
+  if entry[].cacheKey.visibleRect == visibleRect:
+    return
+  for slotId in entry[].slotOrder:
+    if entry[].slots[slotId].usesVisibleRect:
+      result.add slotId
+
 proc needsViewCapture*(
     scene: RenderScene, viewId: RenderViewId, cacheKey: RenderViewCacheKey
 ): bool =
-  ## Reports whether this scene lacks a current contribution for `viewId`.
-  if scene.isNil or not scene.perViewMode or viewId notin scene.viewEntries:
+  ## Reports whether this scene needs at least one current drawing slot.
+  if scene.requiresFullViewCapture(viewId, cacheKey):
     return true
   let entry = addr scene.viewEntries[viewId]
-  let cached = entry[].cacheKey
-  cached.displayRevision != cacheKey.displayRevision or
-    cached.appearanceGeneration != cacheKey.appearanceGeneration or
-    cached.frame.size != cacheKey.frame.size or
-    cached.bounds.size != cacheKey.bounds.size or
-    (entry[].usesVisibleRect and cached.visibleRect != cacheKey.visibleRect) or
-    cached.level != cacheKey.level or cached.isRoot != cacheKey.isRoot
+  entry[].cacheKey.displayRevision != cacheKey.displayRevision or (
+    entry[].cacheKey.visibleRect != cacheKey.visibleRect and
+    scene.forcedVisibleRectSlots(viewId, cacheKey.visibleRect).len > 0
+  )
 
 proc needsViewPlacementUpdate*(
     scene: RenderScene, viewId: RenderViewId, cacheKey: RenderViewCacheKey
@@ -315,6 +376,11 @@ proc validateFrames(frames: openArray[RenderViewFrame]) =
       raise newException(ValueError, "render frame contains a duplicate view identity")
     if frame.parentViewId.uint64 != 0 and frame.parentViewId notin levels:
       raise newException(ValueError, "render frame parent must precede its child")
+    var slots = initTable[RenderSlotId, bool]()
+    for slot in frame.slots:
+      if slot.slotId in slots:
+        raise newException(ValueError, "render frame contains a duplicate slot")
+      slots[slot.slotId] = true
     levels[frame.viewId] = frame.cacheKey.level
 
 proc nextPlacements(frames: openArray[RenderViewFrame]): seq[ViewPlacement] =
@@ -349,9 +415,11 @@ proc desiredLevels(
   for frame in frames:
     if not result.containsLevel(frame.cacheKey.level):
       result.add frame.cacheKey.level
-    for extra in scene.viewEntries[frame.viewId].extraLayers:
-      if not result.containsLevel(extra.level):
-        result.add extra.level
+    let entry = addr scene.viewEntries[frame.viewId]
+    for slotId in entry[].slotOrder:
+      for extra in entry[].slots[slotId].extraLayers:
+        if not result.containsLevel(extra.level):
+          result.add extra.level
 
 proc attachRoot(
     scene: RenderScene, level: ZLevel, contents: var RenderList
@@ -401,7 +469,6 @@ proc attachViewEntry(
     raise
       newException(ValueError, "a view content fragment must contain exactly one root")
   entry.contentCursor = contentRoots[0]
-  entry.selfHandle = scene.attachChild(entry.contentCursor, entry.selfContents)
 
   var escapedTransformList = entry.escapedTransform.nodeRenderList()
   entry.escapedTransformHandle =
@@ -412,18 +479,22 @@ proc attachViewEntry(
       ValueError, "an escaped content fragment must contain exactly one root"
     )
   entry.escapedTransformCursor = escapedTransformRoots[0]
-  entry.escapedHandle =
-    scene.attachChild(entry.escapedTransformCursor, entry.escapedContents)
-
-  entry.extraHandles = initTable[ZLevel, RenderFragmentHandle]()
-  for extra in entry.extraLayers.mitems:
-    entry.extraHandles[extra.level] = scene.attachRoot(extra.level, extra.contents)
+  for slotId in entry.slotOrder:
+    let slot = addr entry.slots[slotId]
+    slot[].handle = scene.attachChild(entry.contentCursor, slot[].contents)
+    slot[].escapedHandle =
+      scene.attachChild(entry.escapedTransformCursor, slot[].escapedContents)
+    slot[].extraHandles = initTable[ZLevel, RenderFragmentHandle]()
+    for extra in slot[].extraLayers.mitems:
+      slot[].extraHandles[extra.level] = scene.attachRoot(extra.level, extra.contents)
   entry.externalParent = parent
 
 proc detachEntry(scene: RenderScene, entry: ViewRenderEntry) =
-  for _, handle in entry.extraHandles:
-    if scene.tree.isValid(handle):
-      scene.tree.removeFragment(handle)
+  for slotId in entry.slotOrder:
+    let slot = entry.slots[slotId]
+    for _, handle in slot.extraHandles:
+      if scene.tree.isValid(handle):
+        scene.tree.removeFragment(handle)
   if scene.tree.isValid(entry.placementHandle):
     scene.tree.removeFragment(entry.placementHandle)
 
@@ -450,69 +521,81 @@ proc refreshPlacementNodes(entry: var ViewRenderEntry, cacheKey: RenderViewCache
     vec2(-contentTranslation.x, -contentTranslation.y)
   entry.escapedTransform.transform.translation =
     entry.contentTransform.transform.translation
-  for extra in entry.extraLayers.mitems:
-    if extra.contents.rootIds.len != 1:
-      raise newException(ValueError, "an extra-layer placement must have one root")
-    let root = extra.contents.rootIds[0]
-    if extra.contents.nodes[root.int].kind != nkTransform:
-      raise
-        newException(ValueError, "an extra-layer placement root must be a transform")
-    extra.contents.nodes[root.int].transform.translation = vec2(
-      cacheKey.frame.origin.x - cacheKey.bounds.origin.x,
-      cacheKey.frame.origin.y - cacheKey.bounds.origin.y,
-    )
+  for slotId in entry.slotOrder:
+    for extra in entry.slots[slotId].extraLayers.mitems:
+      if extra.contents.rootIds.len != 1:
+        raise newException(ValueError, "an extra-layer placement must have one root")
+      let root = extra.contents.rootIds[0]
+      if extra.contents.nodes[root.int].kind != nkTransform:
+        raise
+          newException(ValueError, "an extra-layer placement root must be a transform")
+      extra.contents.nodes[root.int].transform.translation = vec2(
+        cacheKey.frame.origin.x - cacheKey.bounds.origin.x,
+        cacheKey.frame.origin.y - cacheKey.bounds.origin.y,
+      )
 
 proc updatePlacementEntry(scene: RenderScene, entry: var ViewRenderEntry) =
   scene.tree.updateNode(entry.placementCursor, entry.placement)
   scene.tree.updateNode(entry.contentCursor, entry.contentTransform)
   scene.tree.updateNode(entry.escapedTransformCursor, entry.escapedTransform)
-  for extra in entry.extraLayers:
-    let roots = scene.tree.fragmentRoots(entry.extraHandles[extra.level])
-    if roots.len != 1:
-      raise newException(ValueError, "an extra-layer fragment must have one root")
-    scene.tree.updateNode(roots[0], extra.contents.nodes[extra.contents.rootIds[0].int])
+  for slotId in entry.slotOrder:
+    let slot = addr entry.slots[slotId]
+    for extra in slot[].extraLayers:
+      let roots = scene.tree.fragmentRoots(slot[].extraHandles[extra.level])
+      if roots.len != 1:
+        raise newException(ValueError, "an extra-layer fragment must have one root")
+      scene.tree.updateNode(
+        roots[0], extra.contents.nodes[extra.contents.rootIds[0].int]
+      )
 
-proc updateCapturedEntry(scene: RenderScene, entry: var ViewRenderEntry) =
+proc updateCapturedSlot(scene: RenderScene, slot: var ViewRenderSlotEntry) =
+  if scene.replicaMode:
+    slot.handle = scene.tree.replaceFragment(slot.handle, move slot.contents)
+    slot.escapedHandle =
+      scene.tree.replaceFragment(slot.escapedHandle, move slot.escapedContents)
+  else:
+    slot.handle =
+      scene.tree.replaceFragment(slot.handle, slot.contents.copyRenderList())
+    slot.escapedHandle = scene.tree.replaceFragment(
+      slot.escapedHandle, slot.escapedContents.copyRenderList()
+    )
+
+  var retained = initTable[ZLevel, bool]()
+  for extra in slot.extraLayers.mitems:
+    retained[extra.level] = true
+    if extra.level in slot.extraHandles:
+      if scene.replicaMode:
+        slot.extraHandles[extra.level] = scene.tree.replaceFragment(
+          slot.extraHandles[extra.level], move extra.contents
+        )
+      else:
+        slot.extraHandles[extra.level] = scene.tree.replaceFragment(
+          slot.extraHandles[extra.level], extra.contents.copyRenderList()
+        )
+    else:
+      slot.extraHandles[extra.level] = scene.attachRoot(extra.level, extra.contents)
+
+  var removed: seq[ZLevel]
+  for level in slot.extraHandles.keys:
+    if level notin retained:
+      removed.add level
+  for level in removed:
+    let handle = slot.extraHandles[level]
+    if scene.tree.isValid(handle):
+      scene.tree.removeFragment(handle)
+    slot.extraHandles.del(level)
+
+proc updateCapturedEntry(
+    scene: RenderScene,
+    entry: var ViewRenderEntry,
+    capturedSlots: openArray[RenderSlotId],
+) =
   scene.tree.updateNode(entry.placementCursor, entry.placement)
   scene.tree.updateNode(entry.shellCursor, entry.shell)
   scene.tree.updateNode(entry.contentCursor, entry.contentTransform)
   scene.tree.updateNode(entry.escapedTransformCursor, entry.escapedTransform)
-  if scene.replicaMode:
-    entry.selfHandle =
-      scene.tree.replaceFragment(entry.selfHandle, move entry.selfContents)
-    entry.escapedHandle =
-      scene.tree.replaceFragment(entry.escapedHandle, move entry.escapedContents)
-  else:
-    entry.selfHandle =
-      scene.tree.replaceFragment(entry.selfHandle, entry.selfContents.copyRenderList())
-    entry.escapedHandle = scene.tree.replaceFragment(
-      entry.escapedHandle, entry.escapedContents.copyRenderList()
-    )
-
-  var retained = initTable[ZLevel, bool]()
-  for extra in entry.extraLayers.mitems:
-    retained[extra.level] = true
-    if extra.level in entry.extraHandles:
-      if scene.replicaMode:
-        entry.extraHandles[extra.level] = scene.tree.replaceFragment(
-          entry.extraHandles[extra.level], move extra.contents
-        )
-      else:
-        entry.extraHandles[extra.level] = scene.tree.replaceFragment(
-          entry.extraHandles[extra.level], extra.contents.copyRenderList()
-        )
-    else:
-      entry.extraHandles[extra.level] = scene.attachRoot(extra.level, extra.contents)
-
-  var removed: seq[ZLevel]
-  for level in entry.extraHandles.keys:
-    if level notin retained:
-      removed.add level
-  for level in removed:
-    let handle = entry.extraHandles[level]
-    if scene.tree.isValid(handle):
-      scene.tree.removeFragment(handle)
-    entry.extraHandles.del(level)
+  for slotId in capturedSlots:
+    scene.updateCapturedSlot(entry.slots[slotId])
 
 proc moveViewEntry(
     scene: RenderScene, entry: var ViewRenderEntry, parent: RenderViewId
@@ -540,7 +623,11 @@ proc reconcileOrders(
     rootOrders[level] = @[]
   for frame in frames:
     viewLevels[frame.viewId] = frame.cacheKey.level
-    childOrders[frame.viewId] = @[scene.viewEntries[frame.viewId].selfHandle]
+    childOrders[frame.viewId] = @[]
+    let entry = addr scene.viewEntries[frame.viewId]
+    for slotId in entry[].slotOrder:
+      if entry[].slots[slotId].position == rspBeforeSubviews:
+        childOrders[frame.viewId].add entry[].slots[slotId].handle
 
   for frame in frames:
     let
@@ -550,19 +637,25 @@ proc reconcileOrders(
       rootOrders[frame.cacheKey.level].add entry[].placementHandle
     else:
       childOrders[parent].add entry[].placementHandle
-    for extra in entry[].extraLayers:
-      rootOrders[extra.level].add entry[].extraHandles[extra.level]
+    for slotId in entry[].slotOrder:
+      let slot = addr entry[].slots[slotId]
+      for extra in slot[].extraLayers:
+        rootOrders[extra.level].add slot[].extraHandles[extra.level]
 
   for frame in frames:
     let entry = addr scene.viewEntries[frame.viewId]
+    var escapedOrder: seq[RenderFragmentHandle]
+    for slotId in entry[].slotOrder:
+      let slot = addr entry[].slots[slotId]
+      if slot[].position == rspAfterSubviews:
+        childOrders[frame.viewId].add slot[].handle
+      escapedOrder.add slot[].escapedHandle
     scene.tree.reorderChildFragments(
       entry[].placementCursor, [entry[].shellHandle, entry[].escapedTransformHandle]
     )
     scene.tree.reorderChildFragments(entry[].shellCursor, [entry[].contentHandle])
     scene.tree.reorderChildFragments(entry[].contentCursor, childOrders[frame.viewId])
-    scene.tree.reorderChildFragments(
-      entry[].escapedTransformCursor, [entry[].escapedHandle]
-    )
+    scene.tree.reorderChildFragments(entry[].escapedTransformCursor, escapedOrder)
   scene.rootFragments.setLen(0)
   for level in levels:
     scene.tree.reorderRootFragments(level, rootOrders[level])
@@ -573,7 +666,38 @@ proc mergeEntryResources(
 ): RenderResourceManifest =
   result = initRenderResourceManifest()
   for frame in frames:
-    result.addResources(scene.viewEntries[frame.viewId].resources)
+    let entry = addr scene.viewEntries[frame.viewId]
+    for slotId in entry[].slotOrder:
+      result.addResources(entry[].slots[slotId].resources)
+
+proc detachSlot(scene: RenderScene, slot: ViewRenderSlotEntry) =
+  for _, handle in slot.extraHandles:
+    if scene.tree.isValid(handle):
+      scene.tree.removeFragment(handle)
+  if scene.tree.isValid(slot.handle):
+    scene.tree.removeFragment(slot.handle)
+  if scene.tree.isValid(slot.escapedHandle):
+    scene.tree.removeFragment(slot.escapedHandle)
+
+proc attachEmptySlot(
+    scene: RenderScene, entry: var ViewRenderEntry, slotId: RenderSlotId
+) =
+  let slot = addr entry.slots[slotId]
+  var contents = RenderList()
+  slot[].handle = scene.attachChild(entry.contentCursor, contents)
+  var escaped = RenderList()
+  slot[].escapedHandle = scene.attachChild(entry.escapedTransformCursor, escaped)
+  slot[].extraHandles = initTable[ZLevel, RenderFragmentHandle]()
+
+proc frameSlotIds(frame: RenderViewFrame): seq[RenderSlotId] =
+  result = newSeqOfCap[RenderSlotId](frame.slots.len)
+  for slot in frame.slots:
+    result.add slot.slotId
+
+proc capturedSlotIds(frame: RenderViewFrame): seq[RenderSlotId] =
+  for slot in frame.slots:
+    if slot.captured:
+      result.add slot.slotId
 
 proc reconcile*(
     scene: RenderScene, frames: var seq[RenderViewFrame], baseLevel: ZLevel
@@ -581,9 +705,9 @@ proc reconcile*(
   ## Reconciles one frame while retaining clean per-view drawing fragments.
   ##
   ## `frames` must be in depth-first view order, with parents before children.
-  ## A captured entry atomically updates its placement, shell, self, escaped, and
-  ## extra-layer outputs. Placement-only entries update retained transforms. Clean
-  ## entries only participate in ordering.
+  ## A captured entry atomically updates only its changed named slots. Placement-
+  ## only entries update retained transforms. Clean entries only participate in
+  ## ordering.
   if scene.isNil:
     raise newException(ValueError, "cannot update a nil render scene")
   frames.validateFrames()
@@ -596,6 +720,8 @@ proc reconcile*(
     seen = initTable[RenderViewId, bool]()
     changedViews: seq[RenderViewId]
     capturedViews: seq[RenderViewId]
+    addedSlots = initTable[RenderViewId, seq[RenderSlotId]]()
+    removedSlots = initTable[RenderViewId, seq[RenderSlotId]]()
 
   for frame in frames.mitems:
     seen[frame.viewId] = true
@@ -611,21 +737,51 @@ proc reconcile*(
 
     if not existed:
       scene.viewEntries[frame.viewId] =
-        ViewRenderEntry(extraHandles: initTable[ZLevel, RenderFragmentHandle]())
+        ViewRenderEntry(slots: initTable[RenderSlotId, ViewRenderSlotEntry]())
     let entry = addr scene.viewEntries[frame.viewId]
     if frame.captured:
-      if existed and not entry[].extraLayers.sameLayerShape(frame.extraLayers):
+      let nextSlotOrder = frame.frameSlotIds()
+      if existed and entry[].slotOrder != nextSlotOrder:
         topologyChanged = true
+      if existed:
+        for slotId in entry[].slotOrder:
+          if slotId notin nextSlotOrder:
+            removedSlots.mgetOrPut(frame.viewId, @[]).add slotId
+        for slot in frame.slots:
+          if slot.slotId notin entry[].slots:
+            if not slot.captured:
+              raise newException(ValueError, "a new render slot must include a capture")
+            addedSlots.mgetOrPut(frame.viewId, @[]).add slot.slotId
+          else:
+            let cachedSlot = addr entry[].slots[slot.slotId]
+            if cachedSlot[].position != slot.position or
+                slot.captured and
+                not cachedSlot[].extraLayers.sameLayerShape(slot.extraLayers):
+              topologyChanged = true
+      else:
+        for slot in frame.slots:
+          if not slot.captured:
+            raise newException(ValueError, "a new render view needs every slot capture")
+
       entry[].cacheKey = frame.cacheKey
       entry[].placement = move frame.placement
       entry[].shell = move frame.shell
       entry[].contentTransform = move frame.contentTransform
       entry[].escapedTransform = move frame.escapedTransform
-      entry[].selfContents = move frame.selfContents
-      entry[].escapedContents = move frame.escapedContents
-      entry[].extraLayers = move frame.extraLayers
-      entry[].resources = move frame.resources
-      entry[].usesVisibleRect = frame.usesVisibleRect
+      entry[].slotOrder = nextSlotOrder
+      for slot in frame.slots.mitems:
+        if slot.slotId notin entry[].slots:
+          entry[].slots[slot.slotId] =
+            ViewRenderSlotEntry(extraHandles: initTable[ZLevel, RenderFragmentHandle]())
+        let cachedSlot = addr entry[].slots[slot.slotId]
+        cachedSlot[].position = slot.position
+        cachedSlot[].revision = slot.revision
+        if slot.captured:
+          cachedSlot[].contents = move slot.contents
+          cachedSlot[].escapedContents = move slot.escapedContents
+          cachedSlot[].extraLayers = move slot.extraLayers
+          cachedSlot[].resources = move slot.resources
+          cachedSlot[].usesVisibleRect = slot.usesVisibleRect
       entry[].captureGeneration.advance()
       capturedViews.add frame.viewId
       changedViews.add frame.viewId
@@ -657,14 +813,31 @@ proc reconcile*(
     scene.viewEntries[viewId].changeGeneration = nextGeneration
   for viewId in capturedViews:
     scene.viewEntries[viewId].captureChangeGeneration = nextGeneration
+  for frame in frames:
+    if frame.captured:
+      for slot in frame.slots:
+        if slot.captured:
+          scene.viewEntries[frame.viewId].slots[slot.slotId].changeGeneration =
+            nextGeneration
   if rebuild:
     scene.fullTransferGeneration = nextGeneration
 
   if rebuild:
+    for viewId, slotIds in removedSlots:
+      for slotId in slotIds:
+        scene.viewEntries[viewId].slots.del(slotId)
     for viewId in removed:
       scene.viewEntries.del(viewId)
     scene.rebuildTree(frames, levels)
   else:
+    for viewId, slotIds in removedSlots:
+      for slotId in slotIds:
+        scene.detachSlot(scene.viewEntries[viewId].slots[slotId])
+        scene.viewEntries[viewId].slots.del(slotId)
+    for viewId, slotIds in addedSlots:
+      for slotId in slotIds:
+        scene.attachEmptySlot(scene.viewEntries[viewId], slotId)
+
     if topologyChanged:
       var viewLevels = initTable[RenderViewId, ZLevel]()
       for frame in frames:
@@ -676,13 +849,15 @@ proc reconcile*(
         else:
           scene.moveViewEntry(entry[], frame.externalParent(viewLevels))
           if frame.captured:
-            scene.updateCapturedEntry(entry[])
+            scene.updateCapturedEntry(entry[], frame.capturedSlotIds())
           elif frame.placementChanged:
             scene.updatePlacementEntry(entry[])
     else:
       for frame in frames:
         if frame.captured:
-          scene.updateCapturedEntry(scene.viewEntries[frame.viewId])
+          scene.updateCapturedEntry(
+            scene.viewEntries[frame.viewId], frame.capturedSlotIds()
+          )
         elif frame.placementChanged:
           scene.updatePlacementEntry(scene.viewEntries[frame.viewId])
 
@@ -718,8 +893,10 @@ proc transferFrame(
     entry: ViewRenderEntry,
     placement: ViewPlacement,
     placementChanged: bool,
-    captured: bool,
+    acknowledgedGeneration: uint64,
+    full: bool,
 ): RenderViewFrame =
+  let captured = full or entry.captureChangeGeneration > acknowledgedGeneration
   result = RenderViewFrame(
     viewId: placement.viewId,
     parentViewId: placement.parentViewId,
@@ -732,10 +909,22 @@ proc transferFrame(
     result.shell = entry.shell.isolateFig()
     result.contentTransform = entry.contentTransform.isolateFig()
     result.escapedTransform = entry.escapedTransform.isolateFig()
-    result.selfContents = entry.selfContents.isolateRenderList()
-    result.escapedContents = entry.escapedContents.isolateRenderList()
-    result.extraLayers = entry.extraLayers.copyLayerContributions()
-    result.usesVisibleRect = entry.usesVisibleRect
+    result.slots = newSeqOfCap[RenderViewSlotFrame](entry.slotOrder.len)
+    for slotId in entry.slotOrder:
+      let slot = entry.slots[slotId]
+      let slotCaptured = full or slot.changeGeneration > acknowledgedGeneration
+      var frameSlot = RenderViewSlotFrame(
+        slotId: slotId,
+        position: slot.position,
+        revision: slot.revision,
+        captured: slotCaptured,
+        usesVisibleRect: slot.usesVisibleRect,
+      )
+      if slotCaptured:
+        frameSlot.contents = slot.contents.isolateRenderList()
+        frameSlot.escapedContents = slot.escapedContents.isolateRenderList()
+        frameSlot.extraLayers = slot.extraLayers.copyLayerContributions()
+      result.slots.add move frameSlot
 
 proc newRenderSceneUpdate*(
     scene: RenderScene,
@@ -768,7 +957,8 @@ proc newRenderSceneUpdate*(
     result.frames.add entry[].transferFrame(
       placement,
       full or entry[].changeGeneration > acknowledgedGeneration,
-      full or entry[].captureChangeGeneration > acknowledgedGeneration,
+      acknowledgedGeneration,
+      full,
     )
   result.resources = scene.liveResources.snapshot()
 
@@ -791,6 +981,13 @@ func capturedViewCount*(update: RenderSceneUpdate): Natural =
   for frame in update.frames:
     if frame.captured:
       inc result
+
+func capturedRenderSlotCount*(update: RenderSceneUpdate): Natural =
+  ## Counts independently transferred view slots in this update.
+  for frame in update.frames:
+    for slot in frame.slots:
+      if slot.captured:
+        inc result
 
 func viewCount*(update: RenderSceneUpdate): Natural =
   update.frames.len.Natural
@@ -823,6 +1020,11 @@ proc apply*(scene: RenderScene, update: var RenderSceneUpdate) =
       if not frame.captured:
         raise
           newException(ValueError, "a full render-scene update must capture every view")
+      for slot in frame.slots:
+        if not slot.captured:
+          raise newException(
+            ValueError, "a full render-scene update must capture every view slot"
+          )
   discard scene.reconcile(update.frames, update.baseLevel)
   scene.identity = update.sceneIdentity
   scene.generation = update.generation
@@ -888,7 +1090,7 @@ proc viewCaptureGeneration*(scene: RenderScene, id: RenderViewId): uint64 =
     result = scene.viewEntries[id].captureGeneration
 
 proc viewFragmentIds*(scene: RenderScene, id: RenderViewId): seq[uint64] =
-  ## Returns stable placement, shell, content, self, and escaped IDs for diagnostics.
+  ## Returns stable transform and ordered slot IDs for diagnostics.
   if scene.isNil or id notin scene.viewEntries:
     return
   let entry = addr scene.viewEntries[id]
@@ -896,12 +1098,33 @@ proc viewFragmentIds*(scene: RenderScene, id: RenderViewId): seq[uint64] =
     entry[].placementHandle,
     entry[].shellHandle,
     entry[].contentHandle,
-    entry[].selfHandle,
     entry[].escapedTransformHandle,
-    entry[].escapedHandle,
   ]:
     if scene.tree.isValid(handle):
       result.add handle.fragmentId()
+  for slotId in entry[].slotOrder:
+    for handle in [entry[].slots[slotId].handle, entry[].slots[slotId].escapedHandle]:
+      if scene.tree.isValid(handle):
+        result.add handle.fragmentId()
+
+proc viewRenderSlotFragmentId*(
+    scene: RenderScene, id: RenderViewId, slotId: RenderSlotId
+): uint64 =
+  ## Returns the stable normal-content fragment identity for one view slot.
+  if scene.isNil or id notin scene.viewEntries or
+      slotId notin scene.viewEntries[id].slots:
+    return
+  let handle = scene.viewEntries[id].slots[slotId].handle
+  if scene.tree.isValid(handle):
+    result = handle.fragmentId()
+
+proc viewRenderSlotChangeGeneration*(
+    scene: RenderScene, id: RenderViewId, slotId: RenderSlotId
+): uint64 =
+  ## Returns the scene generation that most recently replaced one slot.
+  if not scene.isNil and id in scene.viewEntries and
+      slotId in scene.viewEntries[id].slots:
+    result = scene.viewEntries[id].slots[slotId].changeGeneration
 
 proc viewEntryCount*(scene: RenderScene): Natural =
   if not scene.isNil:

--- a/src/merenda/nimkit/foundation/selectors.nim
+++ b/src/merenda/nimkit/foundation/selectors.nim
@@ -228,7 +228,9 @@ protocol CollectionCommandProtocol:
 
 protocol ViewDrawingProtocol:
   method drawLevel*(): ZLevel {.optional.}
+  method drawUnderlay*(context: DrawContext) {.optional.}
   method draw*(context: DrawContext) {.optional.}
+  method drawOverlay*(context: DrawContext) {.optional.}
 
 protocol ViewLayoutProtocol:
   method layoutIntrinsicContentSize*(): IntrinsicSize {.optional.}

--- a/src/merenda/nimkit/foundation/types.nim
+++ b/src/merenda/nimkit/foundation/types.nim
@@ -20,6 +20,13 @@ when not defined(gcArc) and not defined(gcOrc) and not defined(gcAtomicArc) and
   {.error: "NimKit requires --mm:arc, --mm:orc, or --mm:atomicArc".}
 
 type
+  RenderSlotId* = distinct uint64
+    ## Stable identity for one independently replaceable part of a view's drawing.
+
+  RenderSlotPosition* = enum
+    rspBeforeSubviews
+    rspAfterSubviews
+
   Point* = object
     x*: float32
     y*: float32
@@ -262,6 +269,13 @@ func initLanguageTag*(value: string): LanguageTag =
   LanguageTag(normalized.replace('_', '-'))
 
 func `$`*(language: LanguageTag): string {.borrow.}
+func `==`*(a, b: RenderSlotId): bool {.borrow.}
+func hash*(slot: RenderSlotId): Hash {.borrow.}
+
+func initRenderSlotId*(namespace, index: uint32): RenderSlotId =
+  ## Combines an application-defined namespace and local index without hashing.
+  RenderSlotId((uint64(namespace) shl 32) or uint64(index))
+
 func `==`*(a, b: LanguageTag): bool {.borrow.}
 func hash*(language: LanguageTag): Hash {.borrow.}
 

--- a/src/merenda/nimkit/text/fieldeditors.nim
+++ b/src/merenda/nimkit/text/fieldeditors.nim
@@ -369,8 +369,14 @@ protocol DefaultFieldEditorMenuCommands of MenuCommandProtocol:
     discard editor.finishEditing(terCancel)
 
 protocol DefaultFieldEditorDrawing of ViewDrawingProtocol:
+  method drawUnderlay(editor: FieldEditor, context: DrawContext) =
+    TextView(editor).drawTextViewUnderlay(context)
+
   method draw(editor: FieldEditor, context: DrawContext) =
-    TextView(editor).drawTextViewContents(context)
+    TextView(editor).drawTextViewText(context)
+
+  method drawOverlay(editor: FieldEditor, context: DrawContext) =
+    TextView(editor).drawTextViewOverlay(context)
 
 proc initFieldEditorFields*(editor: FieldEditor) =
   initTextViewFields(editor, installDefaultProtocols = false)

--- a/src/merenda/nimkit/text/markdownviews.nim
+++ b/src/merenda/nimkit/text/markdownviews.nim
@@ -7,7 +7,7 @@
 ## explicitly, remote images load through a Chronos worker, and unavailable
 ## images use linked alt text.
 
-import std/[lists, math, monotimes, os, strutils, tables, times, unicode]
+import std/[algorithm, lists, math, monotimes, os, strutils, tables, times, unicode]
 
 when not defined(useNativeDynlib):
   import std/hashes
@@ -1259,25 +1259,38 @@ proc imageRect(
   rect(anchor.origin.x, anchor.origin.y, drawSize.width, drawSize.height)
 
 protocol MarkdownTextViewDrawing of ViewDrawingProtocol:
-  method draw(textView: MarkdownTextView, context: DrawContext) =
+  method drawUnderlay(textView: MarkdownTextView, context: DrawContext) =
     let style = textView.codeBlockStyle
     if style.backgroundColor.a > 0.0'f32 or
         (style.outlineColor.a > 0.0'f32 and style.outlineWidth > 0.0'f32):
+      var blockRects: seq[Rect]
       for range in textView.codeBlockRanges:
         let blockRect = textView.codeBlockRect(range, style.padding)
         if not blockRect.isEmpty:
-          discard context.addRenderRectangle(
-            context.renderRectFor(blockRect),
-            fill(style.backgroundColor),
-            style.outlineColor,
-            max(style.outlineWidth, 0.0'f32),
-            max(style.cornerRadius, 0.0'f32),
-          )
+          blockRects.add blockRect
+      blockRects.sort(
+        proc(left, right: Rect): int =
+          cmp(left.minY, right.minY)
+      )
+      for blockRect in blockRects:
+        discard context.addRenderRectangle(
+          context.renderRectFor(blockRect),
+          fill(style.backgroundColor),
+          style.outlineColor,
+          max(style.outlineWidth, 0.0'f32),
+          max(style.cornerRadius, 0.0'f32),
+        )
     for presentation in textView.markdownImages:
       let rect = textView.imageRect(presentation)
       if not rect.isEmpty:
         discard context.addImage(rect, presentation.image)
-    TextView(textView).drawTextViewContents(context)
+    TextView(textView).drawTextViewUnderlay(context)
+
+  method draw(textView: MarkdownTextView, context: DrawContext) =
+    TextView(textView).drawTextViewText(context)
+
+  method drawOverlay(textView: MarkdownTextView, context: DrawContext) =
+    TextView(textView).drawTextViewOverlay(context)
 
 func markdownImageCacheKey(view: MarkdownView, url: string): string
 proc markdownTableOverflowWidth(view: MarkdownView, tableColumnWidth: int): float32

--- a/src/merenda/nimkit/text/monotextviews.nim
+++ b/src/merenda/nimkit/text/monotextviews.nim
@@ -1,4 +1,4 @@
-import std/[math, unicode]
+import std/[hashes, math, unicode]
 
 when defined(useNativeDynlib):
   from figdraw/dynlib import
@@ -26,6 +26,14 @@ const
   DefaultMonoFontName* = DefaultMonospaceFontName
   DefaultMonoTabWidth* = 2
   DefaultMonoPadding* = 6.0'f32
+  MonoTextSurfaceRenderSlot* = initRenderSlotId(0x4d4f4e4f'u32, 1)
+  MonoTextViewportRenderSlot* = initRenderSlotId(0x4d4f4e4f'u32, 2)
+  MonoTextCursorRenderSlot* = initRenderSlotId(0x4d4f4e4f'u32, 3)
+  MonoTextRowRenderSlotNamespace = 0x4d524f57'u32
+
+func monoTextRowRenderSlotId*(row: int): RenderSlotId =
+  ## Returns the stable retained-render slot for one grid row.
+  initRenderSlotId(MonoTextRowRenderSlotNamespace, max(row, 0).uint32)
 
 type
   MonoTextTrait* = enum
@@ -241,7 +249,11 @@ proc recomputeMaxColumns(view: MonoTextView) =
 proc invalidateTextGeometry(view: MonoTextView) =
   view.recomputeMaxColumns()
   view.invalidateIntrinsicContentSize()
-  view.needsDisplay = true
+  view.setNeedsDisplayInRenderSlot(MonoTextViewportRenderSlot)
+  view.setNeedsDisplayInRenderSlot(MonoTextCursorRenderSlot)
+
+proc invalidateCursorDrawing(view: MonoTextView) =
+  view.setNeedsDisplayInRenderSlot(MonoTextCursorRenderSlot)
 
 proc ensureLine(view: MonoTextView, row: int) =
   if row < 0:
@@ -545,7 +557,7 @@ proc replaceGrid*(
   if dimensionsChanged:
     view.invalidateTextGeometry()
   else:
-    view.needsDisplay = true
+    view.setNeedsDisplayInRenderSlot(MonoTextViewportRenderSlot)
   view.postAccessibilityNotification(anValueChanged)
   view.postCursorSelectionChanged(previousCursor)
 
@@ -627,7 +639,7 @@ proc scrollGridRows*(
       cells[column] = replacementCells[replacementRow * columnCount + column]
     view.xLines[firstReplacementRow + replacementRow] = MonoTextLine(cells: move(cells))
 
-  view.needsDisplay = true
+  view.setNeedsDisplayInRenderSlot(MonoTextViewportRenderSlot)
   view.postAccessibilityNotification(anValueChanged)
 
 proc setLine*(view: MonoTextView, row: int, text: string) =
@@ -742,7 +754,7 @@ proc setCursorPosition*(view: MonoTextView, row, column: int) =
   view.xCursorRow = row
   view.xCursorColumn = column
   view.clampCursor()
-  view.needsDisplay = true
+  view.invalidateCursorDrawing()
   view.postCursorSelectionChanged(previousCursor)
 
 proc cursorVisible*(view: MonoTextView): bool =
@@ -752,7 +764,7 @@ proc `cursorVisible=`*(view: MonoTextView, value: bool) =
   if view.xCursorVisible == value:
     return
   view.xCursorVisible = value
-  view.needsDisplay = true
+  view.invalidateCursorDrawing()
 
 proc cursorStyle*(view: MonoTextView): MonoTextCursorStyle =
   view.xCursorStyle
@@ -761,7 +773,7 @@ proc `cursorStyle=`*(view: MonoTextView, style: MonoTextCursorStyle) =
   if view.xCursorStyle == style:
     return
   view.xCursorStyle = style
-  view.needsDisplay = true
+  view.invalidateCursorDrawing()
 
 proc tabWidth*(view: MonoTextView): int =
   view.xTabWidth
@@ -779,7 +791,7 @@ proc `textColor=`*(view: MonoTextView, color: nimkitTypes.Color) =
   if view.xTextColor == color:
     return
   view.xTextColor = color
-  view.needsDisplay = true
+  view.setNeedsDisplayInRenderSlot(MonoTextViewportRenderSlot)
 
 proc cursorColor*(view: MonoTextView): nimkitTypes.Color =
   if view.xCursorColor.a > 0.0'f32:
@@ -791,7 +803,7 @@ proc `cursorColor=`*(view: MonoTextView, color: nimkitTypes.Color) =
   if view.xCursorColor == color:
     return
   view.xCursorColor = color
-  view.needsDisplay = true
+  view.invalidateCursorDrawing()
 
 proc gridOffset*(view: MonoTextView): nimkitTypes.Point =
   ## Return the visual translation applied to the cell grid and cursor.
@@ -802,7 +814,8 @@ proc `gridOffset=`*(view: MonoTextView, offset: nimkitTypes.Point) =
   if view.xGridOffset == offset:
     return
   view.xGridOffset = offset
-  view.needsDisplay = true
+  view.setNeedsDisplayInRenderSlot(MonoTextViewportRenderSlot)
+  view.invalidateCursorDrawing()
 
 proc fontName*(view: MonoTextView): string =
   if view.xFontName.len > 0:
@@ -1119,7 +1132,7 @@ proc moveCursorHorizontal(view: MonoTextView, delta: int) =
     elif view.xCursorRow + 1 < view.xLines.len:
       inc view.xCursorRow
       view.xCursorColumn = 0
-  view.needsDisplay = true
+  view.invalidateCursorDrawing()
   view.postCursorSelectionChanged(previousCursor)
 
 proc moveCursorVertical(view: MonoTextView, delta: int) =
@@ -1127,7 +1140,7 @@ proc moveCursorVertical(view: MonoTextView, delta: int) =
   view.xCursorRow = (view.xCursorRow + delta).clampIndex(0, view.xLines.high)
   view.xCursorColumn =
     view.xCursorColumn.clampIndex(0, view.xLines[view.xCursorRow].cells.len)
-  view.needsDisplay = true
+  view.invalidateCursorDrawing()
   view.postCursorSelectionChanged(previousCursor)
 
 proc handleEditorKey(view: MonoTextView, event: KeyEvent): bool =
@@ -1147,13 +1160,13 @@ proc handleEditorKey(view: MonoTextView, event: KeyEvent): bool =
   of keyHome:
     let previousCursor = view.cursorTextIndex()
     view.xCursorColumn = 0
-    view.needsDisplay = true
+    view.invalidateCursorDrawing()
     view.postCursorSelectionChanged(previousCursor)
     true
   of keyEnd:
     let previousCursor = view.cursorTextIndex()
     view.xCursorColumn = view.xLines[view.xCursorRow].cells.len
-    view.needsDisplay = true
+    view.invalidateCursorDrawing()
     view.postCursorSelectionChanged(previousCursor)
     true
   of keyBackspace:
@@ -1397,6 +1410,34 @@ proc drawMonoTextSurface(
   if view.isFocusVisible() and view.focusRingType() != frtNone:
     context.addFocusRing(frame, style.box)
 
+proc monoTextRowRevision(
+    view: MonoTextView,
+    row: int,
+    font: FigFont,
+    metrics: MonoTextMetrics,
+    textInsets: EdgeInsets,
+    textColor: nimkitTypes.Color,
+): uint64 =
+  var value = hash(row)
+  value = value !& hash(repr(font))
+  value = value !& hash(metrics.cellWidth)
+  value = value !& hash(metrics.lineHeight)
+  value = value !& hash(repr(textInsets))
+  value = value !& hash(repr(textColor))
+  for cell in view.xLines[row].cells:
+    value = value !& hash(cell.text)
+    value = value !& hash(repr(cell.foregroundColor))
+    value = value !& hash(repr(cell.backgroundColor))
+    value = value !& hash(repr(cell.decorationColor))
+    value = value !& hash(cell.hasForegroundColor)
+    value = value !& hash(cell.hasBackgroundColor)
+    value = value !& hash(cell.hasDecorationColor)
+    value = value !& hash(cell.traits)
+    value = value !& hash(cell.decorations)
+  result = uint64(cast[uint](!$value))
+  if result == 0:
+    result = 1
+
 proc drawMonoText(view: MonoTextView, context: DrawContext) =
   if view.xLines.len == 0:
     return
@@ -1404,9 +1445,16 @@ proc drawMonoText(view: MonoTextView, context: DrawContext) =
     style = context.appearance.resolveMonoTextStyle(view.monoTextStyleContext())
     textInsets = view.monoTextGridInsets(style)
     textColor = view.resolvedTextColor(style)
-    cursorColor = view.resolvedCursorColor(style)
     metrics = view.monoTextMetrics()
     font = view.monoFont()
+
+  let surfaceRevision = view.renderSlotRevision(MonoTextSurfaceRenderSlot)
+  if context.beginRenderSlot(MonoTextSurfaceRenderSlot, surfaceRevision):
+    view.drawMonoTextSurface(context, style)
+
+  let viewportRevision = view.renderSlotRevision(MonoTextViewportRenderSlot)
+  discard context.beginRenderSlot(MonoTextViewportRenderSlot, viewportRevision)
+  let
     visible = context.visibleRect()
     rowStart = max(
       int(floor(max(visible.origin.y - textInsets.top, 0.0'f32) / metrics.lineHeight)),
@@ -1425,23 +1473,34 @@ proc drawMonoText(view: MonoTextView, context: DrawContext) =
       colStart,
     )
 
-  view.drawMonoTextSurface(context, style)
-
   for row in rowStart ..< rowStop:
-    let line = view.xLines[row]
-    var column = min(colStart, line.cells.len)
-    let lastColumn = min(max(colStop, column), line.cells.len)
-    while column < lastColumn:
-      let startColumn = column
-      inc column
-      while column < lastColumn and
-          line.cells[startColumn].sameRunStyle(line.cells[column], textColor):
+    let slot = monoTextRowRenderSlotId(row)
+    if context.beginRenderSlot(
+      slot, view.monoTextRowRevision(row, font, metrics, textInsets, textColor)
+    ):
+      let line = view.xLines[row]
+      var column = min(colStart, line.cells.len)
+      let lastColumn = min(max(colStop, column), line.cells.len)
+      while column < lastColumn:
+        let startColumn = column
         inc column
-      view.drawRun(
-        context, font, row, startColumn, column, metrics, textInsets, textColor
-      )
+        while column < lastColumn and
+            line.cells[startColumn].sameRunStyle(line.cells[column], textColor):
+          inc column
+        view.drawRun(
+          context, font, row, startColumn, column, metrics, textInsets, textColor
+        )
 
+proc drawMonoTextCursor(view: MonoTextView, context: DrawContext) =
+  let revision = view.renderSlotRevision(MonoTextCursorRenderSlot)
+  if not context.beginRenderSlot(MonoTextCursorRenderSlot, revision, rspAfterSubviews):
+    return
   if view.xCursorVisible and view.isFocused():
+    let
+      style = context.appearance.resolveMonoTextStyle(view.monoTextStyleContext())
+      textInsets = view.monoTextGridInsets(style)
+      cursorColor = view.resolvedCursorColor(style)
+      metrics = view.monoTextMetrics()
     discard
       context.addRectangle(view.cursorRect(metrics, textInsets), fill(cursorColor.rgba))
 
@@ -1462,6 +1521,9 @@ proc monoTextIntrinsicSize(view: MonoTextView): IntrinsicSize =
 protocol DefaultMonoTextViewDrawing of ViewDrawingProtocol:
   method draw(view: MonoTextView, context: DrawContext) =
     view.drawMonoText(context)
+
+  method drawOverlay(view: MonoTextView, context: DrawContext) =
+    view.drawMonoTextCursor(context)
 
 protocol DefaultMonoTextViewLayout of ViewLayoutProtocol:
   method layoutIntrinsicContentSize(view: MonoTextView): IntrinsicSize =

--- a/src/merenda/nimkit/text/textviews.nim
+++ b/src/merenda/nimkit/text/textviews.nim
@@ -1,4 +1,9 @@
-import std/[math, options, strutils, unicode]
+import std/[hashes, math, options, strutils, unicode]
+
+when defined(useNativeDynlib):
+  from figdraw/dynlib import GlyphArrangement, lineGlyphRanges
+else:
+  from figdraw import GlyphArrangement, lineGlyphRanges
 
 import sigils/core
 
@@ -193,6 +198,19 @@ type
     xSelectingWithMouse: bool
     xDraggingSession: DraggingSession
 
+const
+  TextUnderlayRenderSlot* = initRenderSlotId(0x54455854'u32, 1)
+  TextLineRenderSlotNamespace = 0x544c494e'u32
+  TextOverlayRenderSlot* = initRenderSlotId(0x54455854'u32, 2)
+
+func textLineRenderSlotId*(line: int): RenderSlotId =
+  ## Returns the stable retained-render slot for one visual text line.
+  initRenderSlotId(TextLineRenderSlotNamespace, max(line, 0).uint32)
+
+proc invalidateTextSelectionDrawing(textView: TextView) =
+  textView.setNeedsDisplayInRenderSlot(TextUnderlayRenderSlot)
+  textView.setNeedsDisplayInRenderSlot(TextOverlayRenderSlot)
+
 proc syncLayout(textView: TextView)
 proc clearMarkedText(textView: TextView)
 proc textViewStringValue(textView: TextView): string
@@ -349,7 +367,7 @@ proc showInsertionPoint(textView: TextView) =
   if textView.xInsertionPointVisible:
     return
   textView.xInsertionPointVisible = true
-  textView.needsDisplay = true
+  textView.setNeedsDisplayInRenderSlot(TextOverlayRenderSlot)
 
 proc isControlInput(rune: Rune): bool =
   let code = rune.int
@@ -708,13 +726,13 @@ proc `selectionColor=`*(textView: TextView, color: Color) =
     return
   textView.xSelectionColor = color
   textView.xHasSelectionColorOverride = true
-  textView.needsDisplay = true
+  textView.setNeedsDisplayInRenderSlot(TextUnderlayRenderSlot)
 
 proc clearSelectionColorOverride*(textView: TextView) =
   if not textView.xHasSelectionColorOverride:
     return
   textView.xHasSelectionColorOverride = false
-  textView.needsDisplay = true
+  textView.setNeedsDisplayInRenderSlot(TextUnderlayRenderSlot)
 
 proc selectedTextAttributes*(textView: TextView): TextAttributes =
   if not textView.xHasSelectedTextAttributes:
@@ -749,7 +767,7 @@ proc `insertionPointColor=`*(textView: TextView, color: Color) =
   if textView.xInsertionPointColor == color:
     return
   textView.xInsertionPointColor = color
-  textView.needsDisplay = true
+  textView.setNeedsDisplayInRenderSlot(TextOverlayRenderSlot)
 
 proc insertionPointVisible*(textView: TextView): bool =
   textView.xInsertionPointVisible
@@ -758,7 +776,7 @@ proc `insertionPointVisible=`*(textView: TextView, visible: bool) =
   if textView.xInsertionPointVisible == visible:
     return
   textView.xInsertionPointVisible = visible
-  textView.needsDisplay = true
+  textView.setNeedsDisplayInRenderSlot(TextOverlayRenderSlot)
 
 proc insertionPointBlinkPeriod*(textView: TextView): float32 =
   textView.xInsertionPointBlinkPeriod
@@ -936,7 +954,7 @@ proc setTextViewSelectedRange(textView: TextView, value: TextRange) =
   textView.xSelectedRanges = @[clamped]
   textView.updateTypingAttributesForSelection()
   textView.showInsertionPoint()
-  textView.needsDisplay = true
+  textView.invalidateTextSelectionDrawing()
   textView.dispatchSelectionChanged(previousRanges)
 
 proc stringValue*(textView: TextView): string =
@@ -973,7 +991,7 @@ proc setSelectedRanges*(textView: TextView, ranges: openArray[TextRange]) =
   textView.xInsertionPoint = nextRanges[0].maxIndex
   textView.updateTypingAttributesForSelection()
   textView.showInsertionPoint()
-  textView.needsDisplay = true
+  textView.invalidateTextSelectionDrawing()
   textView.dispatchSelectionChanged(previousRanges)
 
 proc `selectedRanges=`*(textView: TextView, ranges: seq[TextRange]) =
@@ -1272,13 +1290,13 @@ proc setFindIndicators*(
         color: color,
         visible: true,
       )
-  textView.needsDisplay = true
+  textView.setNeedsDisplayInRenderSlot(TextUnderlayRenderSlot)
 
 proc clearFindIndicators*(textView: TextView) =
   if textView.xFindIndicators.len == 0:
     return
   textView.xFindIndicators.setLen(0)
-  textView.needsDisplay = true
+  textView.setNeedsDisplayInRenderSlot(TextUnderlayRenderSlot)
 
 proc findTextRanges*(
     textView: TextView, needle: string, caseSensitive = true
@@ -2035,7 +2053,7 @@ proc setCursor*(textView: TextView, index: int, extending = false) =
   textView.xSelectedRanges = @[initTextRange(start, stop - start)]
   textView.updateTypingAttributesForSelection()
   textView.showInsertionPoint()
-  textView.needsDisplay = true
+  textView.invalidateTextSelectionDrawing()
   textView.dispatchSelectionChanged(previousRanges)
 
 proc selectAllText*(textView: TextView) =
@@ -2045,7 +2063,7 @@ proc selectAllText*(textView: TextView) =
   textView.xSelectedRanges = @[initTextRange(0, textView.xTextStorage.len)]
   textView.updateTypingAttributesForSelection()
   textView.showInsertionPoint()
-  textView.needsDisplay = true
+  textView.invalidateTextSelectionDrawing()
   textView.dispatchSelectionChanged(previousRanges)
 
 proc replaceSelectedText*(textView: TextView, insertion: string) =
@@ -2569,7 +2587,97 @@ proc layoutStabilitySnapshot*(
   for fragment in snapshot.lineFragments:
     result.lineFragments.add fragment.roundLineFragmentToScale(scale)
 
-proc drawTextViewContents*(textView: TextView, context: DrawContext) =
+proc nonzeroRevision(value: Hash): uint64 =
+  result = uint64(cast[uint](value))
+  if result == 0:
+    result = 1
+
+proc glyphLineRevision(layout: GlyphArrangement, glyphRange: Slice[int]): uint64 =
+  var value: Hash
+  value = value !& hash(glyphRange.b - glyphRange.a + 1)
+  if layout.arrangedGlyphs.len > 0:
+    for glyphIndex in glyphRange:
+      let glyph = layout.arrangedGlyphs[glyphIndex]
+      value = value !& hash(glyph.fontId)
+      value = value !& hash(uint32(glyph.glyphId))
+      value = value !& hash(glyph.isWhitespace)
+      value = value !& hash(repr(glyph.pos))
+      value = value !& hash(repr(glyph.imageOffset))
+      value = value !& hash(glyph.rect.x)
+      value = value !& hash(glyph.rect.y)
+      value = value !& hash(glyph.rect.w)
+      value = value !& hash(glyph.rect.h)
+  else:
+    for glyphIndex in glyphRange:
+      value = value !& hash(layout.runes[glyphIndex])
+      value = value !& hash(repr(layout.positions[glyphIndex]))
+      value = value !& hash(layout.selectionRects[glyphIndex].x)
+      value = value !& hash(layout.selectionRects[glyphIndex].y)
+      value = value !& hash(layout.selectionRects[glyphIndex].w)
+      value = value !& hash(layout.selectionRects[glyphIndex].h)
+  for spanIndex, span in layout.spans:
+    let
+      first = max(span.a, glyphRange.a)
+      last = min(span.b, glyphRange.b)
+    if first <= last:
+      let font = layout.fonts[spanIndex]
+      value = value !& hash(font.fontId)
+      value = value !& hash(font.size)
+      value = value !& hash(font.lineHeight)
+      value = value !& hash(font.descentAdj)
+      value = value !& hash(font.underline)
+      value = value !& hash(font.strikethrough)
+      if spanIndex < layout.spanColors.len:
+        value = value !& hash(repr(layout.spanColors[spanIndex]))
+  nonzeroRevision(!$value)
+
+proc glyphLineArrangement(
+    layout: GlyphArrangement, glyphRange: Slice[int]
+): GlyphArrangement =
+  let count = glyphRange.b - glyphRange.a + 1
+  if count <= 0:
+    return
+  result.contentHash = cast[Hash](layout.glyphLineRevision(glyphRange))
+  result.lines = @[0 .. count - 1]
+  result.maxSize = layout.maxSize
+  result.minSize = layout.minSize
+  result.bounding = layout.bounding
+  if layout.arrangedGlyphs.len > 0:
+    result.arrangedGlyphs = layout.arrangedGlyphs[glyphRange.a .. glyphRange.b]
+  else:
+    result.runes = layout.runes[glyphRange.a .. glyphRange.b]
+    result.positions = layout.positions[glyphRange.a .. glyphRange.b]
+    result.selectionRects = layout.selectionRects[glyphRange.a .. glyphRange.b]
+  for spanIndex, span in layout.spans:
+    let
+      first = max(span.a, glyphRange.a)
+      last = min(span.b, glyphRange.b)
+    if first <= last:
+      result.spans.add first - glyphRange.a .. last - glyphRange.a
+      result.fonts.add layout.fonts[spanIndex]
+      if spanIndex < layout.spanColors.len:
+        result.spanColors.add layout.spanColors[spanIndex]
+
+proc drawTextViewUnderlay*(textView: TextView, context: DrawContext) =
+  let revision = textView.renderSlotRevision(TextUnderlayRenderSlot)
+  if not context.beginRenderSlot(TextUnderlayRenderSlot, revision):
+    return
+  textView.updateTextContainer()
+  for indicator in textView.xFindIndicators:
+    if indicator.visible:
+      let rects =
+        if indicator.rects.len > 0:
+          indicator.rects
+        else:
+          textView.xLayoutManager.selectionRects(indicator.range)
+      for rect in rects:
+        discard context.addRectangle(rect, indicator.color)
+  for selected in textView.selectedRanges():
+    if selected.length > 0:
+      for rect in textView.xLayoutManager.selectionRects(selected):
+        discard context.addRectangle(rect, textView.selectionColor())
+
+proc drawTextViewText*(textView: TextView, context: DrawContext) =
   textView.updateTextContainer()
   let
     textRect = textView.bounds.inset(textView.xTextContainer.insets)
@@ -2585,27 +2693,36 @@ proc drawTextViewContents*(textView: TextView, context: DrawContext) =
           textView.alignment(),
           textView.xTextContainer.wraps,
         )
-  for indicator in textView.xFindIndicators:
-    if indicator.visible:
-      let rects =
-        if indicator.rects.len > 0:
-          indicator.rects
-        else:
-          textView.xLayoutManager.selectionRects(indicator.range)
-      for rect in rects:
-        discard context.addRectangle(rect, indicator.color)
-  for selected in textView.selectedRanges():
-    if selected.length > 0:
-      for rect in textView.xLayoutManager.selectionRects(selected):
-        discard context.addRectangle(rect, textView.selectionColor())
+    lineRanges = layout.lineGlyphRanges()
+  if lineRanges.len == 0:
+    let slot = textLineRenderSlotId(0)
+    discard context.beginRenderSlot(slot, 0x9e3779b97f4a7c15'u64)
+  else:
+    for lineIndex, glyphRange in lineRanges:
+      let
+        slot = textLineRenderSlotId(lineIndex)
+        revision = layout.glyphLineRevision(glyphRange)
+      if context.beginRenderSlot(slot, revision):
+        discard context.addText(textRect, layout.glyphLineArrangement(glyphRange))
+
+proc drawTextViewOverlay*(textView: TextView, context: DrawContext) =
+  let revision = textView.renderSlotRevision(TextOverlayRenderSlot)
+  if not context.beginRenderSlot(TextOverlayRenderSlot, revision, rspAfterSubviews):
+    return
+  textView.updateTextContainer()
   let selected = textView.textViewSelectedRange()
-  discard context.addText(textRect, layout)
   if textView.editable and selected.length == 0 and textView.isFocused and
       textView.xInsertionPointVisible:
     context.addRectangle(
       textView.xLayoutManager.caretRect(textView.textViewInsertionPoint()),
       textView.insertionPointColor(),
     )
+
+proc drawTextViewContents*(textView: TextView, context: DrawContext) =
+  ## Draws all text stages for callers outside normal view-scene traversal.
+  textView.drawTextViewUnderlay(context)
+  textView.drawTextViewText(context)
+  textView.drawTextViewOverlay(context)
 
 proc hasSelectedText(textView: TextView): bool =
   for range in textView.selectedRanges():
@@ -2680,8 +2797,14 @@ protocol DefaultTextViewCommandDispatch of ResponderCommandDispatchProtocol:
     textView.performTextInputCommand(args.selector, args.sender)
 
 protocol DefaultTextViewDrawing of ViewDrawingProtocol:
+  method drawUnderlay(textView: TextView, context: DrawContext) =
+    textView.drawTextViewUnderlay(context)
+
   method draw(textView: TextView, context: DrawContext) =
-    textView.drawTextViewContents(context)
+    textView.drawTextViewText(context)
+
+  method drawOverlay(textView: TextView, context: DrawContext) =
+    textView.drawTextViewOverlay(context)
 
 protocol DefaultTextViewEvents of ResponderEventProtocol:
   method mouseDown(textView: TextView, event: MouseEvent): bool =

--- a/src/merenda/nimkit/text/textviews.nim
+++ b/src/merenda/nimkit/text/textviews.nim
@@ -2644,9 +2644,11 @@ proc glyphLineArrangement(
   result.bounding = layout.bounding
   if layout.arrangedGlyphs.len > 0:
     result.arrangedGlyphs = layout.arrangedGlyphs[glyphRange.a .. glyphRange.b]
-  else:
+  if layout.runes.len > glyphRange.b:
     result.runes = layout.runes[glyphRange.a .. glyphRange.b]
+  if layout.positions.len > glyphRange.b:
     result.positions = layout.positions[glyphRange.a .. glyphRange.b]
+  if layout.selectionRects.len > glyphRange.b:
     result.selectionRects = layout.selectionRects[glyphRange.a .. glyphRange.b]
   for spanIndex, span in layout.spans:
     let

--- a/src/merenda/nimkit/view/viewbase.nim
+++ b/src/merenda/nimkit/view/viewbase.nim
@@ -1,3 +1,5 @@
+import std/tables
+
 import ../responder/responders
 import ../themes
 import ../foundation/backrefs
@@ -160,6 +162,7 @@ type
     xNeedsDisplay*: bool
     xNeedsLocalDisplay*: bool
     xDisplayRevision*: uint64
+    xRenderSlotRevisions*: Table[RenderSlotId, uint64]
     xInvalidRects*: seq[Rect]
     xBackgroundColor*: Color
     xUsesThemedRootBackground*: bool
@@ -233,16 +236,47 @@ proc windowBacklink*(view: View): Responder {.inline.} =
 var activeLayoutTransaction* {.threadvar.}: ptr LayoutTransactionState
 var layoutGenerationCounter {.threadvar.}: Natural
 
+proc advanceRevision(value: var uint64) =
+  inc value
+  if value == 0:
+    value = 1
+
+proc renderSlotRevision*(view: View, slot: RenderSlotId): uint64 =
+  ## Returns a view-local revision, creating the slot on first use.
+  if view.isNil:
+    return
+  if slot notin view.xRenderSlotRevisions:
+    view.xRenderSlotRevisions[slot] = 1
+  view.xRenderSlotRevisions[slot]
+
 proc markLocalNeedsDisplay*(view: View, wholeView = true, propagateAncestors = false) =
   if view.isNil:
     return
-  inc view.xDisplayRevision
-  if view.xDisplayRevision == 0:
-    view.xDisplayRevision = 1
+  view.xDisplayRevision.advanceRevision()
+  for revision in view.xRenderSlotRevisions.mvalues:
+    revision.advanceRevision()
   view.xNeedsDisplay = true
   view.xNeedsLocalDisplay = true
   if wholeView:
     view.xInvalidRects.setLen(0)
+  if propagateAncestors:
+    var ancestor = view.superviewBacklink()
+    while not ancestor.isNil:
+      ancestor.xNeedsDisplay = true
+      ancestor = ancestor.superviewBacklink()
+
+proc markRenderSlotNeedsDisplay*(
+    view: View, slot: RenderSlotId, propagateAncestors = false
+) =
+  ## Invalidates one registered drawing slot while retaining the other slots.
+  if view.isNil:
+    return
+  view.xDisplayRevision.advanceRevision()
+  discard view.renderSlotRevision(slot)
+  view.xRenderSlotRevisions[slot].advanceRevision()
+  view.xNeedsDisplay = true
+  view.xNeedsLocalDisplay = true
+  view.xInvalidRects.setLen(0)
   if propagateAncestors:
     var ancestor = view.superviewBacklink()
     while not ancestor.isNil:

--- a/src/merenda/nimkit/view/viewprotos.nim
+++ b/src/merenda/nimkit/view/viewprotos.nim
@@ -67,12 +67,16 @@ protocol ViewProtocol {.setterStyle: nim.} from View:
   method `bounds=`(self: View, bounds: Rect) =
     if self.xBounds == bounds:
       return
+    let previousBounds = self.xBounds
     discard
       recordPropertyAnimation(DynamicAgent(self), `bounds=`(), self.xBounds, bounds)
     self.xBounds = rect(bounds.origin, bounds.size)
     emit self.layoutInputChanged(lirBounds)
     emit self.geometryDidChange()
-    self.needsDisplay = true
+    if previousBounds.size == bounds.size:
+      self.markRenderStructureChanged()
+    else:
+      self.needsDisplay = true
 
   method needsDisplay(self: View): bool =
     self.xNeedsDisplay
@@ -418,6 +422,15 @@ proc propagateNeedsDisplayInRect(view: View, rect: Rect) =
   let parent = view.superviewBacklink()
   if not parent.isNil:
     parent.propagateNeedsDisplayInRect(view.rectToView(clipped, parent))
+
+proc setNeedsDisplayInRenderSlot*(view: View, slot: RenderSlotId) =
+  ## Invalidates one stable drawing slot without rebuilding sibling slots.
+  if view.isNil:
+    return
+  view.markRenderSlotNeedsDisplay(slot)
+  let parent = view.superviewBacklink()
+  if not parent.isNil:
+    parent.propagateNeedsDisplayInRect(view.rectToView(view.bounds(), parent))
 
 protocol ViewLifecycleProtocol:
   proc viewWillMoveToSuperview*(view: View, superview: View) {.signal.}

--- a/src/merenda/nimkit/view/views.nim
+++ b/src/merenda/nimkit/view/views.nim
@@ -1,3 +1,5 @@
+import std/tables
+
 import sigils/core
 
 import ../app/animations
@@ -18,7 +20,8 @@ export responders
 export viewbase except
   AutoresizingState, LayoutInputKind, LayoutTerm, LayoutEquation, LayoutInput,
   LayoutInputCache, LayoutTransactionState, activeLayoutTransaction,
-  markLocalNeedsDisplay, nextLayoutGeneration, noteLayoutInvalidation
+  markLocalNeedsDisplay, markRenderSlotNeedsDisplay, nextLayoutGeneration,
+  noteLayoutInvalidation
 export viewconstraints except generatedLayoutInputs, applyConstraintsForSubtree
 export viewgeometry except
   resetAutoresizingState, refreshAutoresizingReference,
@@ -412,6 +415,7 @@ proc initViewFields*(view: View, frame: Rect = AutoRect) =
   view.xNeedsDisplay = true
   view.xNeedsLocalDisplay = true
   view.xDisplayRevision = 1
+  view.xRenderSlotRevisions = initTable[RenderSlotId, uint64]()
   view.xNeedsLayout = true
   view.xAutoresizingMaskConstraints = not frame.hasAutoMetric
   view.xHuggingPriority[laHorizontal] = LayoutPriorityLow

--- a/tests/kosmo/filetreeinteractions.nim
+++ b/tests/kosmo/filetreeinteractions.nim
@@ -27,7 +27,41 @@ proc rendersFill(view: View, fillValue: Fill): bool =
     if node.kind == nkRectangle and node.fill == fillValue:
       return true
 
+proc rendersTextWithColor(view: View, text: string, textColor: Color): bool =
+  let renders = buildRenders(view)
+  if DefaultDrawLevel notin renders:
+    return
+  for node in renders[DefaultDrawLevel].nodes:
+    if node.kind == nkText and node.renderedText() == text:
+      for spanColor in node.textLayout.spanColors:
+        if spanColor.kind == flColor and spanColor.color == textColor.rgba:
+          return true
+
 suite "Kosmo file tree interactions":
+  test "Git status refresh redraws retained file rows":
+    let
+      root = createTempDir("merenda-kosmo-tree-git-redraw-", "")
+      ignoredPath = root / "ignored.log"
+      ignoredColor = color(0.50, 0.52, 0.56, 0.72)
+    writeFile(ignoredPath, "ignored")
+    let tree = newKosmoFileTree(root, frame = rect(0, 0, 300, 120))
+    defer:
+      removeFile(ignoredPath)
+      removeDir(root)
+
+    discard buildRenders(tree)
+    check not tree.rendersTextWithColor("ignored.log", ignoredColor)
+
+    tree.applyGitStatus(
+      GitStatusSnapshot(
+        rootPath: absolutePath(root),
+        isRepository: true,
+        entries: @[GitStatusEntry(path: ignoredPath, state: gfsIgnored)],
+      )
+    )
+
+    check tree.rendersTextWithColor("ignored.log", ignoredColor)
+
   test "hover input redraws the highlighted row":
     let
       root = createTempDir("merenda-kosmo-tree-hover-", "")

--- a/tests/nimkit/markdownviews.nim
+++ b/tests/nimkit/markdownviews.nim
@@ -1,5 +1,5 @@
 ## Markdown view behavior shared by the NimKit test runner.
-import std/[monotimes, os, strformat, strutils, times, unicode, unittest]
+import std/[algorithm, monotimes, os, strformat, strutils, times, unicode, unittest]
 
 import figdraw
 
@@ -678,6 +678,10 @@ echo "fenced"
         panelFrames.add rect(
           node.screenBox.x, node.screenBox.y, node.screenBox.w, node.screenBox.h
         )
+    panelFrames.sort(
+      proc(left, right: Rect): int =
+        cmp(left.minY, right.minY)
+    )
     require panelFrames.len == 3
 
     let storage = view.textStorage()

--- a/tests/nimkit/renderfragments.nim
+++ b/tests/nimkit/renderfragments.nim
@@ -1,4 +1,4 @@
-import std/[hashes, tables, unittest]
+import std/[hashes, tables, unicode, unittest]
 
 import figdraw
 import pkg/pixie except draw
@@ -14,6 +14,9 @@ type
     drawColor: Color
     drawLevelValue: ZLevel
     invalidatesDuringDraw: bool
+
+  SurfaceSceneView = ref object of View
+    drawColor: Color
 
   VisibleRectSceneView = ref object of View
     drawCount: int
@@ -77,6 +80,12 @@ protocol CountedSceneDrawing of ViewDrawingProtocol:
     if view.invalidatesDuringDraw:
       view.invalidatesDuringDraw = false
       view.needsDisplay = true
+
+protocol SurfaceSceneDrawing of ViewDrawingProtocol:
+  method draw(view: SurfaceSceneView, context: DrawContext) =
+    discard context.addRenderRectangle(
+      context.renderRectFor(rect(1, 2, 9, 7)), fill(view.drawColor)
+    )
 
 protocol VisibleRectSceneDrawing of ViewDrawingProtocol:
   method draw(view: VisibleRectSceneView, context: DrawContext) =
@@ -245,6 +254,11 @@ proc newCountedSceneView(frame: Rect, drawColor: Color): CountedSceneView =
   result = CountedSceneView(drawColor: drawColor)
   result.initViewFields(frame)
   discard result.withProtocol(CountedSceneDrawing)
+
+proc newSurfaceSceneView(frame: Rect, drawColor: Color): SurfaceSceneView =
+  result = SurfaceSceneView(drawColor: drawColor)
+  result.initViewFields(frame)
+  discard result.withProtocol(SurfaceSceneDrawing)
 
 proc newVisibleRectSceneView(frame: Rect): VisibleRectSceneView =
   result = VisibleRectSceneView()
@@ -437,6 +451,28 @@ suite "NimKit render fragments":
     discard root.buildRenderScene()
     check not scene.containsView(removedId)
     check scene.viewEntryCount() == 3
+
+  test "first implicit slot node stays before subviews":
+    let
+      surfaceColor = color(0.74, 0.12, 0.18)
+      childColor = color(0.16, 0.68, 0.28)
+      root = newSurfaceSceneView(rect(0, 0, 120, 80), surfaceColor)
+      child = newSurfaceSceneView(rect(8, 9, 40, 24), childColor)
+    root.addSubview(child)
+
+    let nodes = root.buildRenderScene().materialize()[DefaultDrawLevel].nodes
+    var
+      surfaceIndex = -1
+      childIndex = -1
+    for index, node in nodes:
+      if node.kind == nkRectangle and node.fill == fill(surfaceColor):
+        surfaceIndex = index
+      elif node.kind == nkRectangle and node.fill == fill(childColor):
+        childIndex = index
+
+    check surfaceIndex >= 0
+    check childIndex >= 0
+    check surfaceIndex < childIndex
 
   test "leaf invalidation preserves ancestor and sibling contributions":
     let
@@ -640,6 +676,15 @@ suite "NimKit render fragments":
     check scene.viewRenderSlotChangeGeneration(textView.renderViewId(), thirdLine) ==
       thirdLineGeneration
     check retainedScenes.capturedRenderSlotCount(dirtyUpdate) == 3
+
+    var renderedLines: seq[string]
+    for node in scene.materialize()[DefaultDrawLevel].nodes:
+      if node.kind == nkText:
+        var renderedLine: string
+        for rune in node.textLayout.runes:
+          renderedLine.add rune
+        renderedLines.add renderedLine
+    check renderedLines == @["alpha\n", "Beta\n", "gamma"]
 
     let
       secondGeneration = scene.frameGeneration()

--- a/tests/nimkit/renderfragments.nim
+++ b/tests/nimkit/renderfragments.nim
@@ -30,6 +30,14 @@ type
     image: ImageResource
     style: TextStyle
 
+  SlottedSceneView = ref object of View
+    underlayRevision: uint64
+    contentRevision: uint64
+    overlayRevision: uint64
+    underlayDrawCount: int
+    contentDrawCount: int
+    overlayDrawCount: int
+
   RenderOperationContext = ref object of BackendContext
     operations: seq[string]
     entries: Table[Hash, figdraw.Rect]
@@ -41,6 +49,11 @@ type
     node: string
 
 var sceneDrawCount: int
+
+const
+  TestUnderlaySlot = initRenderSlotId(0x54455354'u32, 1)
+  TestContentSlot = initRenderSlotId(0x54455354'u32, 2)
+  TestOverlaySlot = initRenderSlotId(0x54455354'u32, 3)
 
 protocol SceneDrawing of ViewDrawingProtocol:
   method draw(view: SceneDrawView, context: DrawContext) =
@@ -122,6 +135,22 @@ protocol ResourceSceneDrawing of ViewDrawingProtocol:
   method draw(view: ResourceSceneView, context: DrawContext) =
     discard context.addImage(rect(2, 3, 10, 8), view.image)
     discard context.addText(rect(2, 14, 50, 18), "cached", view.style)
+
+protocol SlottedSceneDrawing of ViewDrawingProtocol:
+  method drawUnderlay(view: SlottedSceneView, context: DrawContext) =
+    if context.beginRenderSlot(TestUnderlaySlot, view.underlayRevision):
+      inc view.underlayDrawCount
+      context.addRectangle(rect(1, 1, 20, 10), color(0.8, 0.1, 0.1))
+
+  method draw(view: SlottedSceneView, context: DrawContext) =
+    if context.beginRenderSlot(TestContentSlot, view.contentRevision):
+      inc view.contentDrawCount
+      context.addRectangle(rect(1, 12, 20, 10), color(0.1, 0.8, 0.1))
+
+  method drawOverlay(view: SlottedSceneView, context: DrawContext) =
+    if context.beginRenderSlot(TestOverlaySlot, view.overlayRevision, rspAfterSubviews):
+      inc view.overlayDrawCount
+      context.addRectangle(rect(1, 23, 20, 10), color(0.1, 0.1, 0.8))
 
 method drawRoundedRectSdf*(
     context: RenderOperationContext,
@@ -238,6 +267,11 @@ proc newResourceSceneView(
   result = ResourceSceneView(image: image, style: style)
   result.initViewFields(frame)
   discard result.withProtocol(ResourceSceneDrawing)
+
+proc newSlottedSceneView(frame: Rect): SlottedSceneView =
+  result = SlottedSceneView(underlayRevision: 1, contentRevision: 1, overlayRevision: 1)
+  result.initViewFields(frame)
+  discard result.withProtocol(SlottedSceneDrawing)
 
 proc renderedOperations(renders: var Renders): seq[string] =
   let context = RenderOperationContext(
@@ -485,7 +519,7 @@ suite "NimKit render fragments":
     check scene.viewCaptureGeneration(parent.renderViewId()) == 2
     check scene.viewCaptureGeneration(child.renderViewId()) == 2
 
-  test "scroll placement preserves drawing that does not read the visible rect":
+  test "bounds-origin scrolling preserves drawing that does not read the visible rect":
     let
       root = newView(frame = rect(0, 0, 180, 120))
       viewport = newCountedSceneView(rect(0, 0, 100, 80), color(0.2, 0.3, 0.4))
@@ -502,7 +536,7 @@ suite "NimKit render fragments":
     var initial = retainedScenes.newRenderSceneUpdate(scene, 0, 0)
     retainedScenes.apply(replica, initial)
 
-    viewport.setBoundsOriginFromLayout(initPoint(0, 24))
+    viewport.bounds = rect(0, 24, 100, 80)
     discard root.buildRenderScene()
     var update =
       retainedScenes.newRenderSceneUpdate(scene, sceneIdentity, initialGeneration)
@@ -515,6 +549,158 @@ suite "NimKit render fragments":
     check retainedScenes.capturedViewCount(update) == 0
     retainedScenes.apply(replica, update)
     check replica.materialize().canonicalNodes() == scene.materialize().canonicalNodes()
+
+  test "named view slots update independently around child content":
+    let
+      root = newView(frame = rect(0, 0, 180, 120))
+      slotted = newSlottedSceneView(rect(4, 5, 80, 70))
+      child = newSceneDrawView(rect(25, 20, 30, 20))
+    slotted.addSubview(child)
+    root.addSubview(slotted)
+
+    let scene = root.buildRenderScene()
+    let
+      sceneIdentity = retainedScenes.sceneIdentity(scene)
+      initialGeneration = scene.frameGeneration()
+      underlayId =
+        scene.viewRenderSlotFragmentId(slotted.renderViewId(), TestUnderlaySlot)
+      contentId =
+        scene.viewRenderSlotFragmentId(slotted.renderViewId(), TestContentSlot)
+      overlayId =
+        scene.viewRenderSlotFragmentId(slotted.renderViewId(), TestOverlaySlot)
+      underlayGeneration =
+        scene.viewRenderSlotChangeGeneration(slotted.renderViewId(), TestUnderlaySlot)
+      overlayGeneration =
+        scene.viewRenderSlotChangeGeneration(slotted.renderViewId(), TestOverlaySlot)
+      replica = retainedScenes.newRenderSceneReplica()
+    var initial = retainedScenes.newRenderSceneUpdate(scene, 0, 0)
+    retainedScenes.apply(replica, initial)
+
+    check slotted.underlayDrawCount == 1
+    check slotted.contentDrawCount == 1
+    check slotted.overlayDrawCount == 1
+
+    slotted.contentRevision = 2
+    slotted.setNeedsDisplayInRenderSlot(TestContentSlot)
+    discard root.buildRenderScene()
+    var update =
+      retainedScenes.newRenderSceneUpdate(scene, sceneIdentity, initialGeneration)
+
+    check slotted.underlayDrawCount == 1
+    check slotted.contentDrawCount == 2
+    check slotted.overlayDrawCount == 1
+    check scene.viewRenderSlotFragmentId(slotted.renderViewId(), TestUnderlaySlot) ==
+      underlayId
+    check scene.viewRenderSlotFragmentId(slotted.renderViewId(), TestContentSlot) ==
+      contentId
+    check scene.viewRenderSlotFragmentId(slotted.renderViewId(), TestOverlaySlot) ==
+      overlayId
+    check scene.viewRenderSlotChangeGeneration(slotted.renderViewId(), TestUnderlaySlot) ==
+      underlayGeneration
+    check scene.viewRenderSlotChangeGeneration(slotted.renderViewId(), TestContentSlot) ==
+      scene.frameGeneration()
+    check scene.viewRenderSlotChangeGeneration(slotted.renderViewId(), TestOverlaySlot) ==
+      overlayGeneration
+    check retainedScenes.capturedViewCount(update) == 1
+    check retainedScenes.capturedRenderSlotCount(update) == 1
+
+    retainedScenes.apply(replica, update)
+    check replica.materialize().canonicalNodes() == scene.materialize().canonicalNodes()
+    check scene.materialize().canonicalNodes() == root.buildRenders().canonicalNodes()
+
+  test "dirty text updates retain unaffected visual-line fragments":
+    let
+      root = newView(frame = rect(0, 0, 260, 140))
+      textView = newTextView("alpha\nbeta\ngamma", frame = rect(0, 0, 240, 120))
+    root.addSubview(textView)
+
+    let scene = root.buildRenderScene()
+    let
+      sceneIdentity = retainedScenes.sceneIdentity(scene)
+      firstGeneration = scene.frameGeneration()
+      firstLine = textLineRenderSlotId(0)
+      secondLine = textLineRenderSlotId(1)
+      thirdLine = textLineRenderSlotId(2)
+      firstLineGeneration =
+        scene.viewRenderSlotChangeGeneration(textView.renderViewId(), firstLine)
+      secondLineGeneration =
+        scene.viewRenderSlotChangeGeneration(textView.renderViewId(), secondLine)
+      thirdLineGeneration =
+        scene.viewRenderSlotChangeGeneration(textView.renderViewId(), thirdLine)
+
+    textView.stringValue = "alpha\nBeta\ngamma"
+    discard root.buildRenderScene()
+    var dirtyUpdate =
+      retainedScenes.newRenderSceneUpdate(scene, sceneIdentity, firstGeneration)
+
+    check scene.viewRenderSlotChangeGeneration(textView.renderViewId(), firstLine) ==
+      firstLineGeneration
+    check scene.viewRenderSlotChangeGeneration(textView.renderViewId(), secondLine) >
+      secondLineGeneration
+    check scene.viewRenderSlotChangeGeneration(textView.renderViewId(), thirdLine) ==
+      thirdLineGeneration
+    check retainedScenes.capturedRenderSlotCount(dirtyUpdate) == 3
+
+    let
+      secondGeneration = scene.frameGeneration()
+      firstLineAfterEdit =
+        scene.viewRenderSlotChangeGeneration(textView.renderViewId(), firstLine)
+      secondLineAfterEdit =
+        scene.viewRenderSlotChangeGeneration(textView.renderViewId(), secondLine)
+      thirdLineAfterEdit =
+        scene.viewRenderSlotChangeGeneration(textView.renderViewId(), thirdLine)
+    textView.selectedRange = initTextRange(1, 2)
+    discard root.buildRenderScene()
+    var selectionUpdate =
+      retainedScenes.newRenderSceneUpdate(scene, sceneIdentity, secondGeneration)
+
+    check scene.viewRenderSlotChangeGeneration(textView.renderViewId(), firstLine) ==
+      firstLineAfterEdit
+    check scene.viewRenderSlotChangeGeneration(textView.renderViewId(), secondLine) ==
+      secondLineAfterEdit
+    check scene.viewRenderSlotChangeGeneration(textView.renderViewId(), thirdLine) ==
+      thirdLineAfterEdit
+    check retainedScenes.capturedRenderSlotCount(selectionUpdate) == 2
+
+  test "mono text rendering retains unchanged rows and isolates cursor updates":
+    let
+      root = newView(frame = rect(0, 0, 240, 120))
+      monoView = newMonoTextViewer("alpha\nbeta\ngamma", frame = rect(0, 0, 240, 120))
+    root.addSubview(monoView)
+
+    let scene = root.buildRenderScene()
+    let
+      sceneIdentity = retainedScenes.sceneIdentity(scene)
+      firstGeneration = scene.frameGeneration()
+      row0 = monoTextRowRenderSlotId(0)
+      row1 = monoTextRowRenderSlotId(1)
+      row2 = monoTextRowRenderSlotId(2)
+      row0Generation =
+        scene.viewRenderSlotChangeGeneration(monoView.renderViewId(), row0)
+      row1Generation =
+        scene.viewRenderSlotChangeGeneration(monoView.renderViewId(), row1)
+      row2Generation =
+        scene.viewRenderSlotChangeGeneration(monoView.renderViewId(), row2)
+
+    monoView.replaceCells(1, 0, [initMonoTextCell("B")])
+    discard root.buildRenderScene()
+    var rowUpdate =
+      retainedScenes.newRenderSceneUpdate(scene, sceneIdentity, firstGeneration)
+
+    check scene.viewRenderSlotChangeGeneration(monoView.renderViewId(), row0) ==
+      row0Generation
+    check scene.viewRenderSlotChangeGeneration(monoView.renderViewId(), row1) >
+      row1Generation
+    check scene.viewRenderSlotChangeGeneration(monoView.renderViewId(), row2) ==
+      row2Generation
+    check retainedScenes.capturedRenderSlotCount(rowUpdate) == 3
+
+    let secondGeneration = scene.frameGeneration()
+    monoView.setCursorPosition(2, 2)
+    discard root.buildRenderScene()
+    var cursorUpdate =
+      retainedScenes.newRenderSceneUpdate(scene, sceneIdentity, secondGeneration)
+    check retainedScenes.capturedRenderSlotCount(cursorUpdate) == 1
 
   test "visible-rect drawing recaptures when scrolling changes its clip":
     let


### PR DESCRIPTION
## Summary
- generalize retained scrolling transforms through `View.bounds=` and ClipView
- add ordered stable render slots with underlay/content/overlay phases
- retain Markdown/editor glyph lines and mono-text rows independently
- document the completed Kosmo Fig fragment follow-ups

## Testing
- `atlas-run tests`