### PR TITLE
Keep Markdown table overflow local

### DIFF
--- a/src/merenda/nimkit/text/markdownviews.nim
+++ b/src/merenda/nimkit/text/markdownviews.nim
@@ -110,6 +110,15 @@ type
     image: ImageResource
     displaySize: Size
 
+  MarkdownCodeBlockPresentation = object
+    range: TextRange
+    storage: TextStorage
+
+  MarkdownCodeBlockScrollPresentation = object
+    range: TextRange
+    scrollView: ScrollView
+    textView: TextView
+
   MarkdownTablePresentation = object
     range: TextRange
     storage: TextStorage
@@ -124,11 +133,13 @@ type
     codeBlockRanges: seq[TextRange]
     codeBlockStyle: MarkdownBlockStyle
     markdownImages: seq[MarkdownImagePresentation]
+    markdownCodeBlocks: seq[MarkdownCodeBlockScrollPresentation]
     markdownTables: seq[MarkdownTableScrollPresentation]
 
   MarkdownDocument = object
     storage: TextStorage
     codeBlockRanges: seq[TextRange]
+    codeBlocks: seq[MarkdownCodeBlockPresentation]
     images: seq[MarkdownImagePresentation]
     imageUrls: seq[string]
     tables: seq[MarkdownTablePresentation]
@@ -138,7 +149,7 @@ type
     text: string
     runeLength: int
     runs: seq[TextAttributeRun]
-    codeBlockRanges: seq[TextRange]
+    codeBlocks: seq[MarkdownCodeBlockPresentation]
     images: seq[MarkdownImagePresentation]
     imageUrls: seq[string]
     style: MarkdownStyle
@@ -441,10 +452,12 @@ proc add(builder: var MarkdownBuilder, rendered: sink MarkdownBuilder) =
         (int(builder.runs[^1].range.length) + int(shifted.range.length)).Natural
     else:
       builder.runs.add shifted
-  for range in rendered.codeBlockRanges:
-    builder.codeBlockRanges.add initTextRange(
-      offset + int(range.location), int(range.length)
+  for presentation in rendered.codeBlocks:
+    var shifted = presentation
+    shifted.range = initTextRange(
+      offset + int(presentation.range.location), int(presentation.range.length)
     )
+    builder.codeBlocks.add shifted
   for presentation in rendered.images:
     var shifted = presentation
     shifted.range = initTextRange(
@@ -612,8 +625,8 @@ proc renderList(
 )
 
 func endsWithCodeBlock(builder: MarkdownBuilder): bool =
-  builder.codeBlockRanges.len > 0 and
-    builder.codeBlockRanges[^1].maxIndex == builder.runeLength
+  builder.codeBlocks.len > 0 and
+    builder.codeBlocks[^1].range.maxIndex == builder.runeLength
 
 proc renderListItem(
     builder: var MarkdownBuilder,
@@ -1095,11 +1108,13 @@ proc renderBlockquote(
     if rune == Rune('\n'):
       atLineStart = true
 
-  for range in quoted.codeBlockRanges:
+  for presentation in quoted.codeBlocks:
+    var mapped = presentation
     let
-      start = sourceToDestination[int(range.location)]
-      stop = sourceToDestination[range.maxIndex]
-    builder.codeBlockRanges.add initTextRange(start, stop - start)
+      start = sourceToDestination[int(presentation.range.location)]
+      stop = sourceToDestination[presentation.range.maxIndex]
+    mapped.range = initTextRange(start, stop - start)
+    builder.codeBlocks.add mapped
   for presentation in quoted.images:
     var mapped = presentation
     let
@@ -1164,19 +1179,30 @@ proc renderBlock(
     builder.renderInlineChildren(token, headingAttributes)
   elif token of markdownParser.CodeBlock:
     let code = markdownParser.CodeBlock(token)
-    let blockStart = builder.runeLength
-    var codeAttributes = builder.style.codeAttributes(attributes)
-    codeAttributes.backgroundColor = builder.style.codeBlockStyle.backgroundColor
+    var renderedCode = MarkdownBuilder(
+      style: builder.style,
+      imageLoader: builder.imageLoader,
+      imageContentTypeLoader: builder.imageContentTypeLoader,
+      syntaxHighlighter: builder.syntaxHighlighter,
+      tableColumnLimit: builder.tableColumnLimit,
+    )
+    var codeAttributes = renderedCode.style.codeAttributes(attributes)
+    codeAttributes.backgroundColor = renderedCode.style.codeBlockStyle.backgroundColor
+    codeAttributes.paragraphStyle.lineBreakMode = tlbmClipping
     if code.info.len > 0:
-      var infoAttributes = builder.style.mutedCodeAttributes(attributes)
-      infoAttributes.backgroundColor = builder.style.codeBlockStyle.backgroundColor
-      builder.add("[" & code.info & "]\n", infoAttributes)
-    builder.addHighlightedCode(
+      var infoAttributes = renderedCode.style.mutedCodeAttributes(attributes)
+      infoAttributes.backgroundColor = renderedCode.style.codeBlockStyle.backgroundColor
+      infoAttributes.paragraphStyle.lineBreakMode = tlbmClipping
+      renderedCode.add("[" & code.info & "]\n", infoAttributes)
+    renderedCode.addHighlightedCode(
       code.doc.strip(chars = {'\n'}), code.info, codeAttributes
     )
-    let blockLength = builder.runeLength - blockStart
-    if blockLength > 0:
-      builder.codeBlockRanges.add initTextRange(blockStart, blockLength)
+    if renderedCode.runeLength > 0:
+      let blockRange = initTextRange(0, renderedCode.runeLength)
+      renderedCode.codeBlocks.add MarkdownCodeBlockPresentation(
+        range: blockRange, storage: newTextStorage(renderedCode.text, renderedCode.runs)
+      )
+      builder.add(move renderedCode)
   elif token of markdownParser.ThematicBreak:
     var ruleAttributes = attributes
     ruleAttributes.foregroundColor = builder.style.ruleColor
@@ -1200,14 +1226,16 @@ proc renderBlock(
     builder.add(token.doc, attributes)
 
 proc toMarkdownDocument(builder: sink MarkdownBuilder): MarkdownDocument =
-  MarkdownDocument(
+  result = MarkdownDocument(
     storage: newTextStorage(builder.text, builder.runs),
-    codeBlockRanges: builder.codeBlockRanges,
+    codeBlocks: builder.codeBlocks,
     images: builder.images,
     imageUrls: builder.imageUrls,
     tables: builder.tables,
     hasTables: builder.hasTables,
   )
+  for presentation in result.codeBlocks:
+    result.codeBlockRanges.add presentation.range
 
 proc parseMarkdownRoot(
     source: string, config: MarkdownParserConfig
@@ -1256,7 +1284,7 @@ proc markdownTextStorage*(
   source.markdownDocument(style, config, syntaxHighlighter = syntaxHighlighter).storage
 
 proc codeBlockRect(
-    textView: MarkdownTextView, range: TextRange, padding: EdgeInsets
+    textView: MarkdownTextView, range: TextRange, style: MarkdownBlockStyle
 ): Rect =
   for lineRect in textView.selectionRects(range):
     if result.isEmpty:
@@ -1264,8 +1292,21 @@ proc codeBlockRect(
     else:
       result = result.union(lineRect)
   if not result.isEmpty:
+    let
+      padding = style.padding
+      outlineInset = max(style.outlineWidth, 0.0'f32) / 2.0'f32
     result =
       result.inset(insets(-padding.top, -padding.left, -padding.bottom, -padding.right))
+    result = rect(
+      result.origin,
+      initSize(
+        min(
+          result.size.width,
+          max(textView.bounds().maxX - outlineInset - result.origin.x, 0.0'f32),
+        ),
+        result.size.height,
+      ),
+    )
 
 proc imageRect(
     textView: MarkdownTextView, presentation: MarkdownImagePresentation
@@ -1295,6 +1336,56 @@ proc textRangeRect(textView: TextView, range: TextRange): Rect =
       result = selectionRect
     else:
       result = result.union(selectionRect)
+
+proc layoutMarkdownCodeBlock(
+    textView: MarkdownTextView,
+    presentation: MarkdownCodeBlockScrollPresentation,
+    viewportRight: float32,
+    rightPadding: float32,
+) =
+  let selectionRects = textView.selectionRects(presentation.range)
+  if selectionRects.len == 0:
+    return
+  let
+    codeRect = textView.textRangeRect(presentation.range)
+    codeOrigin = selectionRects[0].origin
+    scrollView = presentation.scrollView
+    codeTextView = presentation.textView
+    parentCodeHeight = max(codeRect.maxY - codeOrigin.y, codeRect.size.height)
+    viewportWidth = max(viewportRight - codeOrigin.x, 0.0'f32)
+    initialDocumentWidth = max(codeRect.size.width, viewportWidth)
+  codeTextView.setFrameFromLayout(
+    rect(0.0'f32, 0.0'f32, initialDocumentWidth, parentCodeHeight)
+  )
+  let codeContentRect =
+    codeTextView.textRangeRect(initTextRange(0, codeTextView.textStorage().len))
+  let
+    codeWidth = max(codeContentRect.maxX, codeContentRect.size.width)
+    paddedCodeWidth = codeWidth + max(rightPadding, 0.0'f32)
+    codeHeight =
+      max(parentCodeHeight, max(codeContentRect.maxY, codeContentRect.size.height))
+    overflowing = paddedCodeWidth > viewportWidth
+    documentWidth = max(paddedCodeWidth, viewportWidth)
+    scrollerHeight =
+      if overflowing:
+        scrollView.scrollerThickness()
+      else:
+        0.0'f32
+  scrollView.setFrameFromLayout(
+    rect(codeOrigin.x, codeOrigin.y, viewportWidth, codeHeight + scrollerHeight)
+  )
+  codeTextView.setFrameFromLayout(rect(0.0'f32, 0.0'f32, documentWidth, codeHeight))
+  scrollView.tile()
+  scrollView.setHiddenFromLayout(not overflowing)
+
+proc layoutMarkdownCodeBlocks(textView: MarkdownTextView) =
+  let
+    style = textView.codeBlockStyle
+    viewportRight = textView.bounds().maxX - max(style.outlineWidth, 0.0'f32)
+  if viewportRight <= 0.0'f32:
+    return
+  for presentation in textView.markdownCodeBlocks:
+    textView.layoutMarkdownCodeBlock(presentation, viewportRight, style.padding.right)
 
 proc layoutMarkdownTables(textView: MarkdownTextView) =
   let tableViewportRight = textView.bounds().maxX
@@ -1339,6 +1430,45 @@ proc clearMarkdownTables(textView: MarkdownTextView) =
     presentation.scrollView.removeFromSuperview()
   textView.markdownTables.setLen(0)
 
+proc clearMarkdownCodeBlocks(textView: MarkdownTextView) =
+  for presentation in textView.markdownCodeBlocks:
+    presentation.scrollView.removeFromSuperview()
+  textView.markdownCodeBlocks.setLen(0)
+
+proc installMarkdownCodeBlocks(
+    textView: MarkdownTextView,
+    codeBlocks: openArray[MarkdownCodeBlockPresentation],
+    backgroundColor: Color,
+) =
+  textView.clearMarkdownCodeBlocks()
+  for codeBlock in codeBlocks:
+    let
+      codeTextView = newTextView()
+      scrollView = newScrollView(documentView = codeTextView)
+    codeTextView.propagatesIntrinsicContentSizeChanges = false
+    codeTextView.richText = true
+    codeTextView.editable = false
+    codeTextView.selectable = true
+    codeTextView.backgroundColor = backgroundColor
+    codeTextView.textContainer = initTextContainer(
+      wraps = false, widthTracksTextView = true, heightTracksTextView = true
+    )
+    codeTextView.textStorage = codeBlock.storage
+    codeTextView.accessibilityLabel = "Markdown code block"
+    scrollView.hasHorizontalScroller = true
+    scrollView.hasVerticalScroller = false
+    scrollView.autohidePolicy = sapWhenNeeded
+    scrollView.borderType = svbNoBorder
+    scrollView.drawsBackground = false
+    scrollView.clipView().backgroundColor = backgroundColor
+    scrollView.clipView().drawsBackground = true
+    scrollView.setHiddenFromLayout(true)
+    textView.addSubview(scrollView)
+    textView.markdownCodeBlocks.add MarkdownCodeBlockScrollPresentation(
+      range: codeBlock.range, scrollView: scrollView, textView: codeTextView
+    )
+  textView.setNeedsLayout()
+
 proc installMarkdownTables(
     textView: MarkdownTextView,
     tables: openArray[MarkdownTablePresentation],
@@ -1382,6 +1512,7 @@ proc markdownTextLayoutDidComplete(
 
 protocol MarkdownTextViewLayout of ViewLayoutProtocol:
   method layoutSubviews(textView: MarkdownTextView) =
+    textView.layoutMarkdownCodeBlocks()
     textView.layoutMarkdownTables()
 
 protocol MarkdownTextViewDrawing of ViewDrawingProtocol:
@@ -1390,7 +1521,7 @@ protocol MarkdownTextViewDrawing of ViewDrawingProtocol:
     if style.backgroundColor.a > 0.0'f32 or
         (style.outlineColor.a > 0.0'f32 and style.outlineWidth > 0.0'f32):
       for range in textView.codeBlockRanges:
-        let blockRect = textView.codeBlockRect(range, style.padding)
+        let blockRect = textView.codeBlockRect(range, style)
         if not blockRect.isEmpty:
           discard context.addRenderRectangle(
             context.renderRectFor(blockRect),
@@ -1441,6 +1572,9 @@ proc applyMarkdownDocument(view: MarkdownView, document: sink MarkdownDocument) 
   view.xHasMarkdownTables = document.hasTables
   view.minimumWrappedDocumentWidth = 0.0'f32
   view.textStorage = document.storage
+  textView.installMarkdownCodeBlocks(
+    document.codeBlocks, view.xMarkdownStyle.codeBlockStyle.backgroundColor
+  )
   textView.installMarkdownTables(document.tables, view.xMarkdownStyle.backgroundColor)
   view.pruneMarkdownImageCache(document.imageUrls)
   textView.needsDisplay = true

--- a/src/merenda/nimkit/text/markdownviews.nim
+++ b/src/merenda/nimkit/text/markdownviews.nim
@@ -1297,8 +1297,8 @@ proc textRangeRect(textView: TextView, range: TextRange): Rect =
       result = result.union(selectionRect)
 
 proc layoutMarkdownTables(textView: MarkdownTextView) =
-  let contentRect = textView.textContainer().layoutRect()
-  if contentRect.size.width <= 0.0'f32:
+  let tableViewportRight = textView.bounds().maxX
+  if tableViewportRight <= 0.0'f32:
     return
   for presentation in textView.markdownTables:
     let selectionRects = textView.selectionRects(presentation.range)
@@ -1310,22 +1310,28 @@ proc layoutMarkdownTables(textView: MarkdownTextView) =
     let
       scrollView = presentation.scrollView
       tableTextView = presentation.textView
-      tableHeight = max(tableRect.maxY - tableOrigin.y, tableRect.size.height)
-      viewportWidth = max(contentRect.maxX - tableOrigin.x, 0.0'f32)
-      frameHeight = tableHeight + scrollView.scrollerThickness()
-      initialDocumentWidth = max(tableRect.size.width, viewportWidth + 1.0'f32)
-    scrollView.setFrameFromLayout(
-      rect(tableOrigin.x, tableOrigin.y, viewportWidth, frameHeight)
-    )
+      parentTableHeight = max(tableRect.maxY - tableOrigin.y, tableRect.size.height)
+      viewportWidth = max(tableViewportRight - tableOrigin.x, 0.0'f32)
+      initialDocumentWidth = max(tableRect.size.width, viewportWidth)
     tableTextView.setFrameFromLayout(
-      rect(0.0'f32, 0.0'f32, initialDocumentWidth, tableHeight)
+      rect(0.0'f32, 0.0'f32, initialDocumentWidth, parentTableHeight)
     )
     let tableContentRect =
       tableTextView.textRangeRect(initTextRange(0, tableTextView.textStorage().len))
-    if tableContentRect.size.width > initialDocumentWidth:
-      tableTextView.setFrameFromLayout(
-        rect(0.0'f32, 0.0'f32, tableContentRect.size.width, tableHeight)
-      )
+    let
+      tableWidth = max(tableContentRect.maxX, tableContentRect.size.width)
+      tableHeight =
+        max(parentTableHeight, max(tableContentRect.maxY, tableContentRect.size.height))
+      documentWidth = max(tableWidth, viewportWidth)
+      scrollerHeight =
+        if tableWidth > viewportWidth:
+          scrollView.scrollerThickness()
+        else:
+          0.0'f32
+    scrollView.setFrameFromLayout(
+      rect(tableOrigin.x, tableOrigin.y, viewportWidth, tableHeight + scrollerHeight)
+    )
+    tableTextView.setFrameFromLayout(rect(0.0'f32, 0.0'f32, documentWidth, tableHeight))
     scrollView.tile()
 
 proc clearMarkdownTables(textView: MarkdownTextView) =

--- a/src/merenda/nimkit/text/markdownviews.nim
+++ b/src/merenda/nimkit/text/markdownviews.nim
@@ -29,6 +29,7 @@ import ../foundation/types
 import ../foundation/urlassets
 import ../foundation/urls
 import ../themes
+from ../view/viewgeometry import setFrameFromLayout
 import ../view/views
 import ./markdownhtmlimages
 import ./markdownparsing
@@ -109,18 +110,29 @@ type
     image: ImageResource
     displaySize: Size
 
+  MarkdownTablePresentation = object
+    range: TextRange
+    storage: TextStorage
+    overflowing: bool
+
+  MarkdownTableScrollPresentation = object
+    range: TextRange
+    scrollView: ScrollView
+    textView: TextView
+
   MarkdownTextView = ref object of TextView
     codeBlockRanges: seq[TextRange]
     codeBlockStyle: MarkdownBlockStyle
     markdownImages: seq[MarkdownImagePresentation]
+    markdownTables: seq[MarkdownTableScrollPresentation]
 
   MarkdownDocument = object
     storage: TextStorage
     codeBlockRanges: seq[TextRange]
     images: seq[MarkdownImagePresentation]
     imageUrls: seq[string]
+    tables: seq[MarkdownTablePresentation]
     hasTables: bool
-    tableColumnWidth: int
 
   MarkdownBuilder = object
     text: string
@@ -134,7 +146,7 @@ type
     imageContentTypeLoader: MarkdownImageContentTypeLoader
     syntaxHighlighter: SyntaxHighlighter
     tableColumnLimit: int
-    tableColumnWidth: int
+    tables: seq[MarkdownTablePresentation]
     hasTables: bool
 
   MarkdownTableAlignment = enum
@@ -415,7 +427,6 @@ proc addBlockBreak(builder: var MarkdownBuilder, attributes: TextAttributes) =
 proc add(builder: var MarkdownBuilder, rendered: sink MarkdownBuilder) =
   let offset = builder.runeLength
   builder.hasTables = builder.hasTables or rendered.hasTables
-  builder.tableColumnWidth = max(builder.tableColumnWidth, rendered.tableColumnWidth)
   builder.imageUrls.add(rendered.imageUrls)
   builder.text.add rendered.text
   builder.runeLength += rendered.runeLength
@@ -440,6 +451,12 @@ proc add(builder: var MarkdownBuilder, rendered: sink MarkdownBuilder) =
       offset + int(presentation.range.location), int(presentation.range.length)
     )
     builder.images.add shifted
+  for presentation in rendered.tables:
+    var shifted = presentation
+    shifted.range = initTextRange(
+      offset + int(presentation.range.location), int(presentation.range.length)
+    )
+    builder.tables.add shifted
 
 proc renderInline(
   builder: var MarkdownBuilder, token: markdownParser.Token, attributes: TextAttributes
@@ -945,7 +962,7 @@ proc renderTable(
   var tableColumnWidth = MarkdownTableSeparatorWidth * (columnCount - 1)
   for width in widths:
     tableColumnWidth += width
-  builder.tableColumnWidth = max(builder.tableColumnWidth, tableColumnWidth)
+  let tableStart = builder.runeLength
   var separatorAttributes = tableAttributes
   separatorAttributes.foregroundColor = builder.style.ruleColor
 
@@ -997,6 +1014,14 @@ proc renderTable(
         if columnIndex > 0:
           builder.add("─┼─", separatorAttributes)
         builder.add("─".repeat(width), separatorAttributes)
+  let overflowing = tableColumnWidth > builder.tableColumnLimit
+  let tableRange = initTextRange(tableStart, builder.runeLength - tableStart)
+  var presentation =
+    MarkdownTablePresentation(range: tableRange, overflowing: overflowing)
+  if overflowing:
+    presentation.storage =
+      newTextStorage(builder.text, builder.runs).sliceTextStorage(tableRange)
+  builder.tables.add move presentation
   builder.hasTables = true
 
 proc renderContainerChild(
@@ -1082,8 +1107,14 @@ proc renderBlockquote(
       stop = sourceToDestination[presentation.range.maxIndex]
     mapped.range = initTextRange(start, stop - start)
     builder.images.add mapped
+  for presentation in quoted.tables:
+    var mapped = presentation
+    let
+      start = sourceToDestination[int(presentation.range.location)]
+      stop = sourceToDestination[presentation.range.maxIndex]
+    mapped.range = initTextRange(start, stop - start)
+    builder.tables.add mapped
   builder.hasTables = builder.hasTables or quoted.hasTables
-  builder.tableColumnWidth = max(builder.tableColumnWidth, quoted.tableColumnWidth)
 
 proc addHighlightedCode(
     builder: var MarkdownBuilder, source, language: string, attributes: TextAttributes
@@ -1174,8 +1205,8 @@ proc toMarkdownDocument(builder: sink MarkdownBuilder): MarkdownDocument =
     codeBlockRanges: builder.codeBlockRanges,
     images: builder.images,
     imageUrls: builder.imageUrls,
+    tables: builder.tables,
     hasTables: builder.hasTables,
-    tableColumnWidth: builder.tableColumnWidth,
   )
 
 proc parseMarkdownRoot(
@@ -1258,6 +1289,95 @@ proc imageRect(
     return
   rect(anchor.origin.x, anchor.origin.y, drawSize.width, drawSize.height)
 
+proc textRangeRect(textView: TextView, range: TextRange): Rect =
+  for selectionRect in textView.selectionRects(range):
+    if result.isEmpty:
+      result = selectionRect
+    else:
+      result = result.union(selectionRect)
+
+proc layoutMarkdownTables(textView: MarkdownTextView) =
+  let contentRect = textView.textContainer().layoutRect()
+  if contentRect.size.width <= 0.0'f32:
+    return
+  for presentation in textView.markdownTables:
+    let selectionRects = textView.selectionRects(presentation.range)
+    if selectionRects.len == 0:
+      continue
+    let
+      tableRect = textView.textRangeRect(presentation.range)
+      tableOrigin = selectionRects[0].origin
+    let
+      scrollView = presentation.scrollView
+      tableTextView = presentation.textView
+      tableHeight = max(tableRect.maxY - tableOrigin.y, tableRect.size.height)
+      viewportWidth = max(contentRect.maxX - tableOrigin.x, 0.0'f32)
+      frameHeight = tableHeight + scrollView.scrollerThickness()
+      initialDocumentWidth = max(tableRect.size.width, viewportWidth + 1.0'f32)
+    scrollView.setFrameFromLayout(
+      rect(tableOrigin.x, tableOrigin.y, viewportWidth, frameHeight)
+    )
+    tableTextView.setFrameFromLayout(
+      rect(0.0'f32, 0.0'f32, initialDocumentWidth, tableHeight)
+    )
+    let tableContentRect =
+      tableTextView.textRangeRect(initTextRange(0, tableTextView.textStorage().len))
+    if tableContentRect.size.width > initialDocumentWidth:
+      tableTextView.setFrameFromLayout(
+        rect(0.0'f32, 0.0'f32, tableContentRect.size.width, tableHeight)
+      )
+    scrollView.tile()
+
+proc clearMarkdownTables(textView: MarkdownTextView) =
+  for presentation in textView.markdownTables:
+    presentation.scrollView.removeFromSuperview()
+  textView.markdownTables.setLen(0)
+
+proc installMarkdownTables(
+    textView: MarkdownTextView,
+    tables: openArray[MarkdownTablePresentation],
+    backgroundColor: Color,
+) =
+  textView.clearMarkdownTables()
+  for table in tables:
+    if not table.overflowing:
+      continue
+    let
+      tableTextView = newTextView()
+      scrollView = newScrollView(documentView = tableTextView)
+    tableTextView.propagatesIntrinsicContentSizeChanges = false
+    tableTextView.richText = true
+    tableTextView.editable = false
+    tableTextView.selectable = true
+    tableTextView.backgroundColor = backgroundColor
+    tableTextView.textContainer = initTextContainer(
+      wraps = false, widthTracksTextView = true, heightTracksTextView = true
+    )
+    tableTextView.textStorage = table.storage
+    tableTextView.accessibilityLabel = "Markdown table"
+    scrollView.hasHorizontalScroller = true
+    scrollView.hasVerticalScroller = false
+    scrollView.autohidePolicy = sapWhenNeeded
+    scrollView.borderType = svbNoBorder
+    scrollView.drawsBackground = false
+    scrollView.clipView().backgroundColor = backgroundColor
+    scrollView.clipView().drawsBackground = true
+    textView.addSubview(scrollView)
+    textView.markdownTables.add MarkdownTableScrollPresentation(
+      range: table.range, scrollView: scrollView, textView: tableTextView
+    )
+  textView.setNeedsLayout()
+
+proc markdownTextLayoutDidComplete(
+    textView: MarkdownTextView, snapshot: TextLayoutSnapshot
+) {.slot.} =
+  discard snapshot
+  textView.setNeedsLayout()
+
+protocol MarkdownTextViewLayout of ViewLayoutProtocol:
+  method layoutSubviews(textView: MarkdownTextView) =
+    textView.layoutMarkdownTables()
+
 protocol MarkdownTextViewDrawing of ViewDrawingProtocol:
   method draw(textView: MarkdownTextView, context: DrawContext) =
     let style = textView.codeBlockStyle
@@ -1280,7 +1400,6 @@ protocol MarkdownTextViewDrawing of ViewDrawingProtocol:
     TextView(textView).drawTextViewContents(context)
 
 func markdownImageCacheKey(view: MarkdownView, url: string): string
-proc markdownTableOverflowWidth(view: MarkdownView, tableColumnWidth: int): float32
 
 proc pruneMarkdownImageCache(view: MarkdownView, imageUrls: openArray[string]) =
   var activeKeys = initTable[string, bool]()
@@ -1314,9 +1433,9 @@ proc applyMarkdownDocument(view: MarkdownView, document: sink MarkdownDocument) 
   textView.codeBlockStyle = view.xMarkdownStyle.codeBlockStyle
   textView.markdownImages = document.images
   view.xHasMarkdownTables = document.hasTables
-  view.minimumWrappedDocumentWidth =
-    view.markdownTableOverflowWidth(document.tableColumnWidth)
+  view.minimumWrappedDocumentWidth = 0.0'f32
   view.textStorage = document.storage
+  textView.installMarkdownTables(document.tables, view.xMarkdownStyle.backgroundColor)
   view.pruneMarkdownImageCache(document.imageUrls)
   textView.needsDisplay = true
 
@@ -1360,19 +1479,6 @@ proc markdownTableColumnLimit(view: MarkdownView): int =
       (measuredLimit div MarkdownTableColumnQuantum) * MarkdownTableColumnQuantum
   clamp(
     quantizedLimit, MarkdownTableMinimumColumnLimit, MarkdownTableMaximumColumnLimit
-  )
-
-proc markdownTableOverflowWidth(view: MarkdownView, tableColumnWidth: int): float32 =
-  if view.isNil or tableColumnWidth <= view.xMarkdownTableColumnLimit:
-    return
-  let
-    viewportWidth = view.bounds().size.width
-    contentWidth =
-      float32(tableColumnWidth) * view.markdownTableCharacterWidth() /
-      MarkdownTableViewportFraction
-  max(
-    viewportWidth + 1.0'f32,
-    contentWidth + view.xMarkdownStyle.documentInsets.horizontal,
   )
 
 proc scheduleMarkdownTableResize(view: MarkdownView) =
@@ -1905,6 +2011,7 @@ proc initMarkdownViewFields*(
   ## HTTP(S) images use `urlAssetLoader`, or a lazy shared loader when it is nil.
   let textView = MarkdownTextView()
   textView.initTextViewFields()
+  discard textView.withProtocol(MarkdownTextViewLayout)
   discard textView.withProtocol(MarkdownTextViewDrawing)
   initTextEditorFields(
     view, frame = frame, richText = true, wraps = true, textView = textView
@@ -1935,6 +2042,9 @@ proc initMarkdownViewFields*(
     view.xMarkdownRoot.markdownDocument(style, syntaxHighlighter = syntaxHighlighter)
   )
   view.textView().layoutManager().usesBackgroundLayout = true
+  textView.layoutManager().connect(
+    layoutDidComplete, textView, markdownTextLayoutDidComplete
+  )
   view.scheduleMarkdownParse()
 
 proc newMarkdownView*(

--- a/src/merenda/nimkit/text/texteditors.nim
+++ b/src/merenda/nimkit/text/texteditors.nim
@@ -294,7 +294,7 @@ proc textDocumentSize(
         defaultFontSize()
     documentWidth =
       if editor.xWraps:
-        max(max(viewportWidth, editor.xMinimumWrappedDocumentWidth), textWidth)
+        max(viewportWidth, editor.xMinimumWrappedDocumentWidth)
       else:
         max(max(textWidth, viewportWidth), editor.xMinimumDocumentSize.width)
   initSize(

--- a/tests/nimkit/markdownviews.nim
+++ b/tests/nimkit/markdownviews.nim
@@ -32,6 +32,11 @@ proc attributesFor(storage: TextStorage, needle: string): TextAttributes =
   doAssert index >= 0, "rendered Markdown should contain: " & needle
   storage.attributesAt(index)
 
+proc tableScrollViews(view: MarkdownView): seq[ScrollView] =
+  for subview in view.textView().subviews():
+    if subview of ScrollView:
+      result.add ScrollView(subview)
+
 proc unavailableMarkdownImage(url: string): ImageResource =
   discard url
 
@@ -802,7 +807,7 @@ Press <kbd>Enter</kbd>.
     check storage.attributesFor("Metric").fontSize == style.bodyFontSize * 0.9'f32
     check storage.attributesFor("CPU p95").fontSize == style.bodyFontSize * 0.9'f32
 
-  test "wide GFM tables use horizontal overflow while Markdown still wraps":
+  test "wide GFM tables scroll independently while the Markdown document fits":
     let
       source =
         "A deliberately long paragraph that should continue to use wrapped text " &
@@ -814,15 +819,31 @@ Press <kbd>Enter</kbd>.
     require view.waitForMarkdownParsing()
     discard buildRenders(view)
     require view.waitForMarkdownLayout()
+    view.layoutSubtreeIfNeeded()
 
     check view.wraps
-    check view.scrollView().hasHorizontalScroller
-    check view.scrollView().maximumContentOffset().x > 0.0'f32
     let
+      tableScrollViews = view.tableScrollViews()
       rendered = view.textStorage().stringValue()
       paragraphStop = rendered.runeIndexOf("\n\n")
       tableStart = paragraphStop + 2
       tableLineLength = rendered.runeSubStr(tableStart).runeIndexOf("\n")
+
+    check not view.scrollView().hasHorizontalScroller
+    check view.scrollView().maximumContentOffset().x == 0.0'f32
+    check view.textView().frame().size.width <=
+      view.scrollView().viewportSize().width + 0.001'f32
+    require tableScrollViews.len == 1
+    let tableScrollView = tableScrollViews[0]
+    check tableScrollView.hasHorizontalScroller
+    check tableScrollView.maximumContentOffset().x > 0.0'f32
+    check tableScrollView.frame().maxX <=
+      view.scrollView().viewportSize().width + 0.001'f32
+
+    tableScrollView.contentOffset =
+      initPoint(tableScrollView.maximumContentOffset().x, 0.0'f32)
+    check tableScrollView.contentOffset().x > 0.0'f32
+    check view.scrollView().contentOffset().x == 0.0'f32
 
     require paragraphStop > 0
     require tableLineLength > 0
@@ -838,6 +859,13 @@ Press <kbd>Enter</kbd>.
     check tableRects.len == 1
     check tableRects[0].maxX > viewportWidth
 
+    view.markdown = "The replacement document has no table."
+    require view.waitForMarkdownParsing()
+    require view.waitForMarkdownLayout()
+    view.layoutSubtreeIfNeeded()
+    check view.tableScrollViews().len == 0
+    check view.scrollView().maximumContentOffset().x == 0.0'f32
+
   test "compact GFM tables stay within the Markdown viewport":
     let view = newMarkdownView(
       "| Metric | Value |\n| - | - |\n| CPU | 42% |", frame = rect(0, 0, 420, 200)
@@ -846,6 +874,32 @@ Press <kbd>Enter</kbd>.
     discard buildRenders(view)
     require view.waitForMarkdownLayout()
 
+    check view.scrollView().maximumContentOffset().x == 0.0'f32
+    check view.tableScrollViews().len == 0
+
+  test "each overflowing GFM table gets its own horizontal scroll view":
+    let
+      wideTable =
+        "| A | B | C | D | E | F | G | H |\n" & "| - | - | - | - | - | - | - | - |\n" &
+        "| CPU p95 | CPU p95 | CPU p95 | CPU p95 | CPU p95 | CPU p95 | " &
+        "CPU p95 | CPU p95 |"
+      view = newMarkdownView(
+        wideTable & "\n\nBetween the tables.\n\n" & wideTable,
+        frame = rect(0, 0, 300, 320),
+      )
+    require view.waitForMarkdownParsing()
+    discard buildRenders(view)
+    require view.waitForMarkdownLayout()
+    view.layoutSubtreeIfNeeded()
+
+    let tableScrollViews = view.tableScrollViews()
+    require tableScrollViews.len == 2
+    for tableScrollView in tableScrollViews:
+      check tableScrollView.maximumContentOffset().x > 0.0'f32
+    tableScrollViews[0].contentOffset =
+      initPoint(tableScrollViews[0].maximumContentOffset().x, 0.0'f32)
+    check tableScrollViews[0].contentOffset().x > 0.0'f32
+    check tableScrollViews[1].contentOffset().x == 0.0'f32
     check view.scrollView().maximumContentOffset().x == 0.0'f32
 
   test "GFM tables reflow once the Markdown viewport settles":

--- a/tests/nimkit/markdownviews.nim
+++ b/tests/nimkit/markdownviews.nim
@@ -37,6 +37,17 @@ proc tableScrollViews(view: MarkdownView): seq[ScrollView] =
     if subview of ScrollView:
       result.add ScrollView(subview)
 
+proc codeBlockScrollViews(view: MarkdownView, includeHidden = false): seq[ScrollView] =
+  for subview in view.textView().subviews():
+    if subview of ScrollView:
+      let
+        scrollView = ScrollView(subview)
+        documentView = scrollView.documentView()
+      if documentView of TextView and
+          documentView.accessibilityLabel() == "Markdown code block" and
+          (includeHidden or not scrollView.hidden):
+        result.add scrollView
+
 proc textRangeRect(textView: TextView, range: TextRange): Rect =
   for selectionRect in textView.selectionRects(range):
     if result.isEmpty:
@@ -711,6 +722,77 @@ echo "fenced"
       if index < labels.high:
         let nextLabelFrame = renderedTextFrame(labels[index + 1])
         check nextLabelFrame.minY >= panelFrames[index].maxY
+
+  test "wide fenced and indented code blocks scroll within the Markdown document":
+    let
+      longLine = "let payload = \"" & "abcdefghij".repeat(18) & "\""
+      style = initMarkdownStyle()
+      source =
+        "A prose paragraph that should wrap to the Markdown viewport while code " &
+        "blocks below retain their source lines. ".repeat(3) & "\n\n```nim\n" & longLine &
+        "\n```\n\nBetween blocks.\n\n    " & longLine
+      view = newMarkdownView(source, frame = rect(0, 0, 320, 320), style = style)
+    require view.waitForMarkdownParsing()
+    discard buildRenders(view)
+    require view.waitForMarkdownLayout()
+    view.layoutSubtreeIfNeeded()
+
+    let
+      codeScrollViews = view.codeBlockScrollViews()
+      rendered = view.textStorage().stringValue()
+      codeStart = rendered.runeIndexOf(longLine)
+      paragraphStop = rendered.runeIndexOf("\n\n")
+    require codeScrollViews.len == 2
+    require codeStart >= 0
+    require paragraphStop > 0
+    for codeScrollView in codeScrollViews:
+      check codeScrollView.hasHorizontalScroller
+      check codeScrollView.maximumContentOffset().x > 0.0'f32
+      let expectedRightEdge =
+        view.textView().bounds().maxX - style.codeBlockStyle.outlineWidth
+      check abs(codeScrollView.frame().maxX - expectedRightEdge) <= 0.001'f32
+      let
+        codeTextView = TextView(codeScrollView.documentView())
+        localCodeRect =
+          codeTextView.textRangeRect(initTextRange(0, codeTextView.textStorage().len))
+      check localCodeRect.maxY <= codeScrollView.viewportSize().height + 0.001'f32
+    check view.scrollView().maximumContentOffset().x == 0.0'f32
+    let
+      sourceCodeAttributes = view.textStorage().attributesFor("payload")
+      localCodeAttributes = TextView(codeScrollViews[0].documentView())
+        .textStorage()
+        .attributesFor("payload")
+    check localCodeAttributes == sourceCodeAttributes
+
+    let
+      paragraphRects = view.textView().selectionRects(initTextRange(0, paragraphStop))
+      codeRects =
+        view.textView().selectionRects(initTextRange(codeStart, longLine.runeLen))
+      viewportWidth = view.scrollView().viewportSize().width
+    check paragraphRects.len > 1
+    for rect in paragraphRects:
+      check rect.maxX <= viewportWidth + 0.001'f32
+    check codeRects.len == 1
+    check codeRects[0].maxX > viewportWidth
+
+    codeScrollViews[0].contentOffset =
+      initPoint(codeScrollViews[0].maximumContentOffset().x, 0.0'f32)
+    check codeScrollViews[0].contentOffset().x > 0.0'f32
+    check codeScrollViews[1].contentOffset().x == 0.0'f32
+    check view.scrollView().contentOffset().x == 0.0'f32
+
+    var fittingWidth = 0.0'f32
+    for codeScrollView in codeScrollViews:
+      fittingWidth = max(fittingWidth, codeScrollView.documentSize().width)
+    view.frame = rect(0, 0, fittingWidth + 100.0'f32, 320)
+    view.layoutSubtreeIfNeeded()
+
+    check view.codeBlockScrollViews().len == 0
+    let hiddenCodeScrollViews = view.codeBlockScrollViews(includeHidden = true)
+    require hiddenCodeScrollViews.len == 2
+    for codeScrollView in hiddenCodeScrollViews:
+      check codeScrollView.horizontalScroller().hidden
+      check codeScrollView.maximumContentOffset().x <= 0.001'f32
 
   test "raw inline and block HTML remain inert and visibly muted":
     let

--- a/tests/nimkit/markdownviews.nim
+++ b/tests/nimkit/markdownviews.nim
@@ -37,6 +37,13 @@ proc tableScrollViews(view: MarkdownView): seq[ScrollView] =
     if subview of ScrollView:
       result.add ScrollView(subview)
 
+proc textRangeRect(textView: TextView, range: TextRange): Rect =
+  for selectionRect in textView.selectionRects(range):
+    if result.isEmpty:
+      result = selectionRect
+    else:
+      result = result.union(selectionRect)
+
 proc unavailableMarkdownImage(url: string): ImageResource =
   discard url
 
@@ -837,8 +844,7 @@ Press <kbd>Enter</kbd>.
     let tableScrollView = tableScrollViews[0]
     check tableScrollView.hasHorizontalScroller
     check tableScrollView.maximumContentOffset().x > 0.0'f32
-    check tableScrollView.frame().maxX <=
-      view.scrollView().viewportSize().width + 0.001'f32
+    check abs(tableScrollView.frame().maxX - view.textView().bounds().maxX) <= 0.001'f32
 
     tableScrollView.contentOffset =
       initPoint(tableScrollView.maximumContentOffset().x, 0.0'f32)
@@ -852,12 +858,21 @@ Press <kbd>Enter</kbd>.
       tableRects =
         view.textView().selectionRects(initTextRange(tableStart, tableLineLength))
       viewportWidth = view.scrollView().viewportSize().width
+      tableRange = initTextRange(tableStart, rendered.runeLen - tableStart)
+      mainTableRect = view.textView().textRangeRect(tableRange)
+      tableTextView = TextView(tableScrollView.documentView())
+      localTableRect =
+        tableTextView.textRangeRect(initTextRange(0, tableTextView.textStorage().len))
 
     check paragraphRects.len > 1
     for rect in paragraphRects:
       check rect.maxX <= viewportWidth + 0.001'f32
     check tableRects.len == 1
     check tableRects[0].maxX > viewportWidth
+    check tableScrollView.frame().origin.y <= mainTableRect.minY + 0.001'f32
+    check tableScrollView.frame().origin.y + tableScrollView.viewportSize().height >=
+      mainTableRect.maxY - 0.001'f32
+    check localTableRect.maxY <= tableScrollView.viewportSize().height + 0.001'f32
 
     view.markdown = "The replacement document has no table."
     require view.waitForMarkdownParsing()
@@ -876,6 +891,46 @@ Press <kbd>Enter</kbd>.
 
     check view.scrollView().maximumContentOffset().x == 0.0'f32
     check view.tableScrollViews().len == 0
+
+  test "table scroller hides once the resized panel contains the table":
+    var
+      headers: seq[string]
+      dividers: seq[string]
+      values: seq[string]
+    for index in 0 ..< 20:
+      headers.add "Column " & $index
+      dividers.add "---"
+      values.add "CPU p95"
+    let
+      source =
+        "| " & headers.join(" | ") & " |\n| " & dividers.join(" | ") & " |\n| " &
+        values.join(" | ") & " |"
+      view = newMarkdownView(source, frame = rect(0, 0, 300, 200))
+    require view.waitForMarkdownParsing()
+    discard buildRenders(view)
+    require view.waitForMarkdownLayout()
+    view.layoutSubtreeIfNeeded()
+
+    let narrowScrollViews = view.tableScrollViews()
+    require narrowScrollViews.len == 1
+    require narrowScrollViews[0].maximumContentOffset().x > 0.0'f32
+    let fittingWidth = narrowScrollViews[0].documentSize().width + 100.0'f32
+
+    view.frame = rect(0, 0, fittingWidth, 200)
+    require view.waitForMarkdownRendering()
+    discard buildRenders(view)
+    require view.waitForMarkdownLayout()
+    view.layoutSubtreeIfNeeded()
+
+    let fittingScrollViews = view.tableScrollViews()
+    require fittingScrollViews.len == 1
+    let fittingScrollView = fittingScrollViews[0]
+    check fittingScrollView.maximumContentOffset().x <= 0.001'f32
+    check fittingScrollView.horizontalScroller().hidden
+    check abs(
+      fittingScrollView.frame().size.height -
+        fittingScrollView.documentView().frame().size.height
+    ) <= 0.001'f32
 
   test "each overflowing GFM table gets its own horizontal scroll view":
     let


### PR DESCRIPTION
## Summary

- keep wrapped Markdown documents constrained to the panel width
- place each overflowing GFM table in its own horizontal scroll view
- place each overflowing fenced or indented Markdown code block in its own horizontal scroll view
- preserve compact table/code rendering, smaller table fonts, wrapped prose, and code-block panel edges/styles
- clean up embedded table and code-block scrollers when the document changes

This follows #43: paragraph wrapping remained fixed, but wide tables and code blocks could still expand the overall document and make the whole Markdown pane scroll horizontally.

## Tests

- `atlas-run tests nimkit`
- `atlas-run tests`
- `atlas-run tests --compile-only examples/all_compile.nim`