### PR TITLE
Fix Markdown text-selection rendering crash

### DIFF
--- a/src/merenda/nimkit/text/markdownviews.nim
+++ b/src/merenda/nimkit/text/markdownviews.nim
@@ -46,6 +46,7 @@ export syntaxhighlighting
 export texttypes
 
 const
+  MarkdownUnderlayRenderSlot = initRenderSlotId(0x4d41524b'u32, 1)
   MarkdownImageBlockSpacing = 12.0'f32
     ## Fixed separation around image attachment lines, independent of image size.
   MarkdownTableDefaultColumnLimit = 100
@@ -1517,30 +1518,32 @@ protocol MarkdownTextViewLayout of ViewLayoutProtocol:
 
 protocol MarkdownTextViewDrawing of ViewDrawingProtocol:
   method drawUnderlay(textView: MarkdownTextView, context: DrawContext) =
-    let style = textView.codeBlockStyle
-    if style.backgroundColor.a > 0.0'f32 or
-        (style.outlineColor.a > 0.0'f32 and style.outlineWidth > 0.0'f32):
-      var blockRects: seq[Rect]
-      for range in textView.codeBlockRanges:
-        let blockRect = textView.codeBlockRect(range, style)
-        if not blockRect.isEmpty:
-          blockRects.add blockRect
-      blockRects.sort(
-        proc(left, right: Rect): int =
-          cmp(left.minY, right.minY)
-      )
-      for blockRect in blockRects:
-        discard context.addRenderRectangle(
-          context.renderRectFor(blockRect),
-          fill(style.backgroundColor),
-          style.outlineColor,
-          max(style.outlineWidth, 0.0'f32),
-          max(style.cornerRadius, 0.0'f32),
+    let revision = textView.renderSlotRevision(MarkdownUnderlayRenderSlot)
+    if context.beginRenderSlot(MarkdownUnderlayRenderSlot, revision):
+      let style = textView.codeBlockStyle
+      if style.backgroundColor.a > 0.0'f32 or
+          (style.outlineColor.a > 0.0'f32 and style.outlineWidth > 0.0'f32):
+        var blockRects: seq[Rect]
+        for range in textView.codeBlockRanges:
+          let blockRect = textView.codeBlockRect(range, style)
+          if not blockRect.isEmpty:
+            blockRects.add blockRect
+        blockRects.sort(
+          proc(left, right: Rect): int =
+            cmp(left.minY, right.minY)
         )
-    for presentation in textView.markdownImages:
-      let rect = textView.imageRect(presentation)
-      if not rect.isEmpty:
-        discard context.addImage(rect, presentation.image)
+        for blockRect in blockRects:
+          discard context.addRenderRectangle(
+            context.renderRectFor(blockRect),
+            fill(style.backgroundColor),
+            style.outlineColor,
+            max(style.outlineWidth, 0.0'f32),
+            max(style.cornerRadius, 0.0'f32),
+          )
+      for presentation in textView.markdownImages:
+        let rect = textView.imageRect(presentation)
+        if not rect.isEmpty:
+          discard context.addImage(rect, presentation.image)
     TextView(textView).drawTextViewUnderlay(context)
 
   method draw(textView: MarkdownTextView, context: DrawContext) =

--- a/tests/nimkit/markdownviews.nim
+++ b/tests/nimkit/markdownviews.nim
@@ -666,6 +666,21 @@ echo "fenced"
         check node.screenBox.h > 20.0'f32
     check panelCount == 2
 
+  test "selecting text retains unchanged Markdown underlays":
+    let
+      root = newView(frame = rect(0, 0, 520, 320))
+      view = newMarkdownView(
+        "Before.\n\n```nim\necho \"selected\"\n```", frame = rect(0, 0, 520, 320)
+      )
+    root.addSubview(view)
+    require view.waitForMarkdownParsing()
+    require view.waitForMarkdownLayout()
+    root.layoutSubtreeIfNeeded()
+    discard root.buildRenderScene()
+
+    view.textView().selectedRange = initTextRange(0, 6)
+    discard root.buildRenderScene()
+
   test "code block panels in ordered lists do not overlap item labels":
     var style = initMarkdownStyle()
     style.codeBlockStyle.padding = insets(7.0'f32, 10.0'f32)


### PR DESCRIPTION
## Summary

- capture Markdown code-block panels and images in a dedicated retained underlay slot
- keep selection-only redraws from emitting into an unchanged cached slot
- add a regression covering a stable Markdown layout followed by text selection

## Root cause

Markdown underlay drawing emitted panel rectangles and images before opening a retained render slot. After layout settled, changing only the text selection left the implicit default slot unchanged, so drawing a panel into that cached slot raised cannot draw an unchanged render slot.

## Testing

- atlas-run tests
- atlas-run tests --compile-only examples/all_compile.nim