### PR TITLE
Restore GrabNim and pin macOS 15 CI

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: deps/
-        key: atlas-env-v3-${{ runner.os }}-${{ runner.arch }}-nim${{ matrix.nimversion }}-${{ hashFiles('merenda.nimble', 'nim.cfg', 'config.nims') }}
+        key: ${{ runner.os }}-nim${{ matrix.nimversion }}-${{ hashFiles('merenda.nimble', 'nim.cfg') }}
 
     - name: Install Atlas
       run: |
@@ -43,34 +43,19 @@ jobs:
           ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
         atlas -v
 
-    - name: Install bootstrap amd64 Nim
-      if: runner.os == 'macOS'
+    - name: Install GrabNim
       run: |
-        atlas --deps="$RUNNER_TEMP/atlas-bootstrap" \
-          --github-path env "${{ matrix.nimversion }}"
+        grabnimInstaller="$(mktemp)"
+        curl --retry 3 --retry-all-errors --retry-delay 2 -fsSL \
+          https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh \
+          -o "$grabnimInstaller"
+        sh "$grabnimInstaller"
+        rm -f "$grabnimInstaller"
+        echo "$HOME/.local/share/grabnim/current/bin" >> "$GITHUB_PATH"
+        echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
 
-    - name: Rebuild Atlas for ARM64
-      if: runner.os == 'macOS'
-      run: |
-        git clone --depth 1 --branch 0.15.2 https://github.com/nim-lang/atlas.git \
-          "$RUNNER_TEMP/atlas-source"
-        cd "$RUNNER_TEMP/atlas-source"
-        nim -v
-        nim installSat
-        atlas_arm64_args="-target arm64-apple-macos11 -arch arm64 -DARCH=arm64"
-        nim c -d:release --cpu:arm64 \
-          --passC:"$atlas_arm64_args" --passL:"$atlas_arm64_args" \
-          --out:"$RUNNER_TEMP/atlas-arm64" src/atlas.nim
-        nim c -d:release --cpu:arm64 \
-          --passC:"$atlas_arm64_args" --passL:"$atlas_arm64_args" \
-          --out:"$RUNNER_TEMP/atlas-run-arm64" src/atlasrun.nim
-        install -m 755 "$RUNNER_TEMP/atlas-arm64" "$HOME/.local/bin/atlas"
-        install -m 755 "$RUNNER_TEMP/atlas-run-arm64" "$HOME/.local/bin/atlas-run"
-        file "$HOME/.local/bin/atlas"
-        atlas -v
-
-    - name: Install Nim binaries
-      run: atlas --github-path env "${{ matrix.nimversion }}"
+    - name: Install Nim
+      run: grabnim "${{ matrix.nimversion }}"
 
     - name: Verify Nim
       run: nim -v
@@ -144,7 +129,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: deps/
-        key: atlas-env-v3-${{ runner.os }}-${{ runner.arch }}-nim${{ matrix.nimversion }}-${{ hashFiles('merenda.nimble', 'nim.cfg', 'config.nims') }}
+        key: ${{ runner.os }}-nim${{ matrix.nimversion }}-${{ hashFiles('merenda.nimble', 'nim.cfg') }}
 
     - name: Install Atlas
       run: |
@@ -154,34 +139,19 @@ jobs:
           ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
         atlas -v
 
-    - name: Install bootstrap amd64 Nim
-      if: runner.os == 'macOS'
+    - name: Install GrabNim
       run: |
-        atlas --deps="$RUNNER_TEMP/atlas-bootstrap" \
-          --github-path env "${{ matrix.nimversion }}"
+        grabnimInstaller="$(mktemp)"
+        curl --retry 3 --retry-all-errors --retry-delay 2 -fsSL \
+          https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh \
+          -o "$grabnimInstaller"
+        sh "$grabnimInstaller"
+        rm -f "$grabnimInstaller"
+        echo "$HOME/.local/share/grabnim/current/bin" >> "$GITHUB_PATH"
+        echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
 
-    - name: Rebuild Atlas for ARM64
-      if: runner.os == 'macOS'
-      run: |
-        git clone --depth 1 --branch 0.15.2 https://github.com/nim-lang/atlas.git \
-          "$RUNNER_TEMP/atlas-source"
-        cd "$RUNNER_TEMP/atlas-source"
-        nim -v
-        nim installSat
-        atlas_arm64_args="-target arm64-apple-macos11 -arch arm64 -DARCH=arm64"
-        nim c -d:release --cpu:arm64 \
-          --passC:"$atlas_arm64_args" --passL:"$atlas_arm64_args" \
-          --out:"$RUNNER_TEMP/atlas-arm64" src/atlas.nim
-        nim c -d:release --cpu:arm64 \
-          --passC:"$atlas_arm64_args" --passL:"$atlas_arm64_args" \
-          --out:"$RUNNER_TEMP/atlas-run-arm64" src/atlasrun.nim
-        install -m 755 "$RUNNER_TEMP/atlas-arm64" "$HOME/.local/bin/atlas"
-        install -m 755 "$RUNNER_TEMP/atlas-run-arm64" "$HOME/.local/bin/atlas-run"
-        file "$HOME/.local/bin/atlas"
-        atlas -v
-
-    - name: Install Nim binaries
-      run: atlas --github-path env "${{ matrix.nimversion }}"
+    - name: Install Nim
+      run: grabnim "${{ matrix.nimversion }}"
 
     - name: Verify Nim
       run: nim -v

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -116,7 +116,7 @@ jobs:
         nimversion:
           - '2.2.10'
         os:
-          - macos-latest
+          - macos-15
           - ubuntu-latest
           # - windows-2022
     steps:

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: deps/
-        key: atlas-env-v2-${{ runner.os }}-${{ runner.arch }}-nim${{ matrix.nimversion }}-${{ hashFiles('merenda.nimble', 'nim.cfg', 'config.nims') }}
+        key: atlas-env-v3-${{ runner.os }}-${{ runner.arch }}-nim${{ matrix.nimversion }}-${{ hashFiles('merenda.nimble', 'nim.cfg', 'config.nims') }}
 
     - name: Install Atlas
       run: |
@@ -43,16 +43,34 @@ jobs:
           ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
         atlas -v
 
-    - name: Set up Nim
+    - name: Install bootstrap amd64 Nim
+      if: runner.os == 'macOS'
       run: |
-        if [[ "$RUNNER_OS" == "macOS" && "$RUNNER_ARCH" == "ARM64" ]]; then
-          # Atlas 0.15.2's universal binary reports amd64 from its arm64 slice.
-          atlas --source \
-            --git-ref="v${{ matrix.nimversion }}" \
-            --github-path env "${{ matrix.nimversion }}-arm64"
-        else
-          atlas --github-path env "${{ matrix.nimversion }}"
-        fi
+        atlas --deps="$RUNNER_TEMP/atlas-bootstrap" \
+          --github-path env "${{ matrix.nimversion }}"
+
+    - name: Rebuild Atlas for ARM64
+      if: runner.os == 'macOS'
+      run: |
+        git clone --depth 1 --branch 0.15.2 https://github.com/nim-lang/atlas.git \
+          "$RUNNER_TEMP/atlas-source"
+        cd "$RUNNER_TEMP/atlas-source"
+        nim -v
+        nim installSat
+        atlas_arm64_args="-target arm64-apple-macos11 -arch arm64 -DARCH=arm64"
+        nim c -d:release --cpu:arm64 \
+          --passC:"$atlas_arm64_args" --passL:"$atlas_arm64_args" \
+          --out:"$RUNNER_TEMP/atlas-arm64" src/atlas.nim
+        nim c -d:release --cpu:arm64 \
+          --passC:"$atlas_arm64_args" --passL:"$atlas_arm64_args" \
+          --out:"$RUNNER_TEMP/atlas-run-arm64" src/atlasrun.nim
+        install -m 755 "$RUNNER_TEMP/atlas-arm64" "$HOME/.local/bin/atlas"
+        install -m 755 "$RUNNER_TEMP/atlas-run-arm64" "$HOME/.local/bin/atlas-run"
+        file "$HOME/.local/bin/atlas"
+        atlas -v
+
+    - name: Install Nim binaries
+      run: atlas --github-path env "${{ matrix.nimversion }}"
 
     - name: Verify Nim
       run: nim -v
@@ -126,7 +144,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: deps/
-        key: atlas-env-v2-${{ runner.os }}-${{ runner.arch }}-nim${{ matrix.nimversion }}-${{ hashFiles('merenda.nimble', 'nim.cfg', 'config.nims') }}
+        key: atlas-env-v3-${{ runner.os }}-${{ runner.arch }}-nim${{ matrix.nimversion }}-${{ hashFiles('merenda.nimble', 'nim.cfg', 'config.nims') }}
 
     - name: Install Atlas
       run: |
@@ -136,16 +154,34 @@ jobs:
           ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
         atlas -v
 
-    - name: Set up Nim
+    - name: Install bootstrap amd64 Nim
+      if: runner.os == 'macOS'
       run: |
-        if [[ "$RUNNER_OS" == "macOS" && "$RUNNER_ARCH" == "ARM64" ]]; then
-          # Atlas 0.15.2's universal binary reports amd64 from its arm64 slice.
-          atlas --source \
-            --git-ref="v${{ matrix.nimversion }}" \
-            --github-path env "${{ matrix.nimversion }}-arm64"
-        else
-          atlas --github-path env "${{ matrix.nimversion }}"
-        fi
+        atlas --deps="$RUNNER_TEMP/atlas-bootstrap" \
+          --github-path env "${{ matrix.nimversion }}"
+
+    - name: Rebuild Atlas for ARM64
+      if: runner.os == 'macOS'
+      run: |
+        git clone --depth 1 --branch 0.15.2 https://github.com/nim-lang/atlas.git \
+          "$RUNNER_TEMP/atlas-source"
+        cd "$RUNNER_TEMP/atlas-source"
+        nim -v
+        nim installSat
+        atlas_arm64_args="-target arm64-apple-macos11 -arch arm64 -DARCH=arm64"
+        nim c -d:release --cpu:arm64 \
+          --passC:"$atlas_arm64_args" --passL:"$atlas_arm64_args" \
+          --out:"$RUNNER_TEMP/atlas-arm64" src/atlas.nim
+        nim c -d:release --cpu:arm64 \
+          --passC:"$atlas_arm64_args" --passL:"$atlas_arm64_args" \
+          --out:"$RUNNER_TEMP/atlas-run-arm64" src/atlasrun.nim
+        install -m 755 "$RUNNER_TEMP/atlas-arm64" "$HOME/.local/bin/atlas"
+        install -m 755 "$RUNNER_TEMP/atlas-run-arm64" "$HOME/.local/bin/atlas-run"
+        file "$HOME/.local/bin/atlas"
+        atlas -v
+
+    - name: Install Nim binaries
+      run: atlas --github-path env "${{ matrix.nimversion }}"
 
     - name: Verify Nim
       run: nim -v

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -35,14 +35,6 @@ jobs:
         path: deps/
         key: ${{ runner.os }}-nim${{ matrix.nimversion }}-${{ hashFiles('merenda.nimble', 'nim.cfg') }}
 
-    - name: Install Atlas
-      run: |
-        mkdir -p "$HOME/.local/bin"
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | \
-          ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
-        atlas -v
-
     - name: Install GrabNim
       run: |
         grabnimInstaller="$(mktemp)"
@@ -56,6 +48,14 @@ jobs:
 
     - name: Install Nim
       run: grabnim "${{ matrix.nimversion }}"
+
+    - name: Install latest Atlas
+      run: |
+        mkdir -p "$HOME/.local/bin"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | \
+          ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
+        atlas -v
 
     - name: Verify Nim
       run: nim -v
@@ -131,14 +131,6 @@ jobs:
         path: deps/
         key: ${{ runner.os }}-nim${{ matrix.nimversion }}-${{ hashFiles('merenda.nimble', 'nim.cfg') }}
 
-    - name: Install Atlas
-      run: |
-        mkdir -p "$HOME/.local/bin"
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | \
-          ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
-        atlas -v
-
     - name: Install GrabNim
       run: |
         grabnimInstaller="$(mktemp)"
@@ -152,6 +144,14 @@ jobs:
 
     - name: Install Nim
       run: grabnim "${{ matrix.nimversion }}"
+
+    - name: Install latest Atlas
+      run: |
+        mkdir -p "$HOME/.local/bin"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | \
+          ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
+        atlas -v
 
     - name: Verify Nim
       run: nim -v

--- a/.github/workflows/release-kosmo.yml
+++ b/.github/workflows/release-kosmo.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: deps/
-          key: kosmo-release-${{ runner.os }}-${{ runner.arch }}-atlas-env-v2-nim${{ env.NIM_VERSION }}-${{ hashFiles('merenda.nimble', 'nim.cfg', 'config.nims') }}
+          key: kosmo-release-${{ runner.os }}-${{ runner.arch }}-atlas-env-v3-nim${{ env.NIM_VERSION }}-${{ hashFiles('merenda.nimble', 'nim.cfg', 'config.nims') }}
 
       - name: Install Atlas
         run: |
@@ -127,16 +127,32 @@ jobs:
             ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
           atlas -v
 
-      - name: Set up Nim
+      - name: Install bootstrap amd64 Nim
         run: |
-          if [[ "$RUNNER_ARCH" == "ARM64" ]]; then
-            # Atlas 0.15.2's universal binary reports amd64 from its arm64 slice.
-            atlas --source \
-              --git-ref="v$NIM_VERSION" \
-              --github-path env "$NIM_VERSION-arm64"
-          else
-            atlas --github-path env "$NIM_VERSION"
-          fi
+          atlas --deps="$RUNNER_TEMP/atlas-bootstrap" \
+            --github-path env "$NIM_VERSION"
+
+      - name: Rebuild Atlas for ARM64
+        run: |
+          git clone --depth 1 --branch 0.15.2 https://github.com/nim-lang/atlas.git \
+            "$RUNNER_TEMP/atlas-source"
+          cd "$RUNNER_TEMP/atlas-source"
+          nim -v
+          nim installSat
+          atlas_arm64_args="-target arm64-apple-macos11 -arch arm64 -DARCH=arm64"
+          nim c -d:release --cpu:arm64 \
+            --passC:"$atlas_arm64_args" --passL:"$atlas_arm64_args" \
+            --out:"$RUNNER_TEMP/atlas-arm64" src/atlas.nim
+          nim c -d:release --cpu:arm64 \
+            --passC:"$atlas_arm64_args" --passL:"$atlas_arm64_args" \
+            --out:"$RUNNER_TEMP/atlas-run-arm64" src/atlasrun.nim
+          install -m 755 "$RUNNER_TEMP/atlas-arm64" "$HOME/.local/bin/atlas"
+          install -m 755 "$RUNNER_TEMP/atlas-run-arm64" "$HOME/.local/bin/atlas-run"
+          file "$HOME/.local/bin/atlas"
+          atlas -v
+
+      - name: Install Nim binaries
+        run: atlas --github-path env "$NIM_VERSION"
 
       - name: Verify Nim
         run: nim -v

--- a/.github/workflows/release-kosmo.yml
+++ b/.github/workflows/release-kosmo.yml
@@ -55,14 +55,6 @@ jobs:
           path: deps/
           key: kosmo-release-${{ runner.os }}-${{ runner.arch }}-nim${{ env.NIM_VERSION }}-${{ hashFiles('merenda.nimble') }}
 
-      - name: Install Atlas
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | \
-            ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
-          atlas -v
-
       - name: Install GrabNim
         run: |
           grabnimInstaller="$(mktemp)"
@@ -76,6 +68,14 @@ jobs:
 
       - name: Install Nim
         run: grabnim "$NIM_VERSION"
+
+      - name: Install latest Atlas
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | \
+            ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
+          atlas -v
 
       - name: Verify Nim
         run: nim -v
@@ -130,14 +130,6 @@ jobs:
           path: deps/
           key: kosmo-release-${{ runner.os }}-${{ runner.arch }}-nim${{ env.NIM_VERSION }}-${{ hashFiles('merenda.nimble') }}
 
-      - name: Install Atlas
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | \
-            ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
-          atlas -v
-
       - name: Install GrabNim
         run: |
           grabnimInstaller="$(mktemp)"
@@ -151,6 +143,14 @@ jobs:
 
       - name: Install Nim
         run: grabnim "$NIM_VERSION"
+
+      - name: Install latest Atlas
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | \
+            ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
+          atlas -v
 
       - name: Verify Nim
         run: nim -v

--- a/.github/workflows/release-kosmo.yml
+++ b/.github/workflows/release-kosmo.yml
@@ -63,8 +63,19 @@ jobs:
             ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
           atlas -v
 
-      - name: Set up Nim
-        run: atlas --github-path env "$NIM_VERSION"
+      - name: Install GrabNim
+        run: |
+          grabnimInstaller="$(mktemp)"
+          curl --retry 3 --retry-all-errors --retry-delay 2 -fsSL \
+            https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh \
+            -o "$grabnimInstaller"
+          sh "$grabnimInstaller"
+          rm -f "$grabnimInstaller"
+          echo "$HOME/.local/share/grabnim/current/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
+
+      - name: Install Nim
+        run: grabnim "$NIM_VERSION"
 
       - name: Verify Nim
         run: nim -v
@@ -117,7 +128,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: deps/
-          key: kosmo-release-${{ runner.os }}-${{ runner.arch }}-atlas-env-v3-nim${{ env.NIM_VERSION }}-${{ hashFiles('merenda.nimble', 'nim.cfg', 'config.nims') }}
+          key: kosmo-release-${{ runner.os }}-${{ runner.arch }}-nim${{ env.NIM_VERSION }}-${{ hashFiles('merenda.nimble') }}
 
       - name: Install Atlas
         run: |
@@ -127,32 +138,19 @@ jobs:
             ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
           atlas -v
 
-      - name: Install bootstrap amd64 Nim
+      - name: Install GrabNim
         run: |
-          atlas --deps="$RUNNER_TEMP/atlas-bootstrap" \
-            --github-path env "$NIM_VERSION"
+          grabnimInstaller="$(mktemp)"
+          curl --retry 3 --retry-all-errors --retry-delay 2 -fsSL \
+            https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh \
+            -o "$grabnimInstaller"
+          sh "$grabnimInstaller"
+          rm -f "$grabnimInstaller"
+          echo "$HOME/.local/share/grabnim/current/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
 
-      - name: Rebuild Atlas for ARM64
-        run: |
-          git clone --depth 1 --branch 0.15.2 https://github.com/nim-lang/atlas.git \
-            "$RUNNER_TEMP/atlas-source"
-          cd "$RUNNER_TEMP/atlas-source"
-          nim -v
-          nim installSat
-          atlas_arm64_args="-target arm64-apple-macos11 -arch arm64 -DARCH=arm64"
-          nim c -d:release --cpu:arm64 \
-            --passC:"$atlas_arm64_args" --passL:"$atlas_arm64_args" \
-            --out:"$RUNNER_TEMP/atlas-arm64" src/atlas.nim
-          nim c -d:release --cpu:arm64 \
-            --passC:"$atlas_arm64_args" --passL:"$atlas_arm64_args" \
-            --out:"$RUNNER_TEMP/atlas-run-arm64" src/atlasrun.nim
-          install -m 755 "$RUNNER_TEMP/atlas-arm64" "$HOME/.local/bin/atlas"
-          install -m 755 "$RUNNER_TEMP/atlas-run-arm64" "$HOME/.local/bin/atlas-run"
-          file "$HOME/.local/bin/atlas"
-          atlas -v
-
-      - name: Install Nim binaries
-        run: atlas --github-path env "$NIM_VERSION"
+      - name: Install Nim
+        run: grabnim "$NIM_VERSION"
 
       - name: Verify Nim
         run: nim -v


### PR DESCRIPTION
## Summary

- restore GrabNim for Nim installation in build-full CI
- restore GrabNim for Linux and macOS Kosmo release builds
- keep Atlas for dependency installation and atlas-run
- pin build-full macOS jobs to macos-15

## Validation

- atlas-run tests --only-errors (4/4 passed)
- workflow YAML parsing
- git diff --check