### PR TITLE
Fix Kosmo window focus and multi-root file browsing

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-15
+          - os: macos-latest
             nimversion: '2.2.10'
             display: none
             compiler: clang
@@ -120,7 +120,7 @@ jobs:
         nimversion:
           - '2.2.10'
         os:
-          - macos-15
+          - macos-latest
           - ubuntu-latest
           # - windows-2022
     steps:

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -37,30 +37,25 @@ jobs:
         path: deps/
         key: ${{ runner.os }}-nim${{ matrix.nimversion }}-${{ hashFiles('merenda.nimble', 'nim.cfg') }}
 
-    - name: Install GrabNim
-      run: |
-        grabnimInstaller="$(mktemp)"
-        curl --retry 3 --retry-all-errors --retry-delay 2 -fsSL \
-          https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh \
-          -o "$grabnimInstaller"
-        sh "$grabnimInstaller"
-        rm -f "$grabnimInstaller"
-        echo "$HOME/.local/share/grabnim/current/bin" >> "$GITHUB_PATH"
-        echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
-
-    - name: Install Nim
-      run: grabnim "${{ matrix.nimversion }}"
-
-    - name: Install latest Atlas
+    - name: Install latest Atlas and set up Nim
       run: |
         mkdir -p "$HOME/.local/bin"
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | \
           ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
-        atlas -v
+        "$HOME/.local/bin/atlas" env "${{ matrix.nimversion }}" --binary --github-path
 
     - name: Verify Nim
-      run: nim -v
+      run: |
+        atlas -v
+        uname -m
+        nimPath="$(command -v nim)"
+        echo "$nimPath"
+        nim -v
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          file "$nimPath"
+          lipo -archs "$nimPath"
+        fi
 
     - name: Setup software OpenGL/Vulkan (Mesa) + Xvfb (X11)
       if: runner.os == 'Linux' && matrix.display == 'x11'
@@ -136,30 +131,25 @@ jobs:
         path: deps/
         key: ${{ runner.os }}-nim${{ matrix.nimversion }}-${{ hashFiles('merenda.nimble', 'nim.cfg') }}
 
-    - name: Install GrabNim
-      run: |
-        grabnimInstaller="$(mktemp)"
-        curl --retry 3 --retry-all-errors --retry-delay 2 -fsSL \
-          https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh \
-          -o "$grabnimInstaller"
-        sh "$grabnimInstaller"
-        rm -f "$grabnimInstaller"
-        echo "$HOME/.local/share/grabnim/current/bin" >> "$GITHUB_PATH"
-        echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
-
-    - name: Install Nim
-      run: grabnim "${{ matrix.nimversion }}"
-
-    - name: Install latest Atlas
+    - name: Install latest Atlas and set up Nim
       run: |
         mkdir -p "$HOME/.local/bin"
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | \
           ATLAS_INSTALL_DIR="$HOME/.local/bin" bash -
-        atlas -v
+        "$HOME/.local/bin/atlas" env "${{ matrix.nimversion }}" --binary --github-path
 
     - name: Verify Nim
-      run: nim -v
+      run: |
+        atlas -v
+        uname -m
+        nimPath="$(command -v nim)"
+        echo "$nimPath"
+        nim -v
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          file "$nimPath"
+          lipo -archs "$nimPath"
+        fi
 
     - name: Install Deps
       run: |

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -21,9 +21,11 @@ jobs:
           - os: macos-15
             nimversion: '2.2.10'
             display: none
+            compiler: clang
           - os: ubuntu-26.04
             nimversion: '2.2.10'
             display: x11
+            compiler: gcc
           # - os: ubuntu-24.04
           #   display: wayland
     steps:
@@ -98,9 +100,12 @@ jobs:
 
     - name: Build Tests
       run: |
+        compilerOptions=(--debugger:off "--cc:${{ matrix.compiler }}")
+        if [[ "$RUNNER_OS" == "Linux" && "${{ matrix.compiler }}" == "gcc" ]]; then
+          compilerOptions+=(--opt:none)
+        fi
         atlas-run tests --jobs:1 --compiler-output -- \
-            --opt:none \
-            --debugger:off
+            "${compilerOptions[@]}"
 
     - name: Build Integration Tests
       if: runner.os == 'macOS'

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -103,11 +103,6 @@ jobs:
       run: |
         atlas-run tests --jobs:1 --compiler-output -- --opt:none
 
-    - name: Build Integration Tests
-      if: runner.os == 'macOS'
-      run: |
-        atlas-run tests --jobs:2 --only-errors "tests/integration*.nim"
-
   examples:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -94,13 +94,14 @@ jobs:
           -delete
 
     - name: Build Tests
+      if: runner.os == 'macOS'
       run: |
-        compilerOptions=(--debugger:off "--cc:${{ matrix.compiler }}")
-        if [[ "$RUNNER_OS" == "Linux" && "${{ matrix.compiler }}" == "gcc" ]]; then
-          compilerOptions+=(--opt:none)
-        fi
-        atlas-run tests --jobs:1 --compiler-output -- \
-            "${compilerOptions[@]}"
+        atlas-run tests --jobs:1 --compiler-output
+
+    - name: Build Tests
+      if: runner.os == 'Linux'
+      run: |
+        atlas-run tests --jobs:1 --compiler-output -- --opt:none
 
     - name: Build Integration Tests
       if: runner.os == 'macOS'

--- a/.github/workflows/release-kosmo.yml
+++ b/.github/workflows/release-kosmo.yml
@@ -116,7 +116,7 @@ jobs:
           if-no-files-found: error
 
   build-macos:
-    runs-on: macos-15
+    runs-on: macos-latest
     timeout-minutes: 60
     env:
       MACOSX_DEPLOYMENT_TARGET: 13.0

--- a/README.md
+++ b/README.md
@@ -706,6 +706,11 @@ floating control group in the document switches between the rendered preview
 and Moe's syntax editor, selects a light or dark page, and decreases or increases
 the preview font size. Both modes share the same in-memory Moe buffer, so the
 preview includes unsaved edits.
+Each pane retains its three most recently used rendered Markdown previews, including
+their selection and scroll position, so switching among recent unchanged previews
+does not parse and lay them out again. The rendered view is read-only: edit commands
+cannot change the hidden source buffer, and a tab's modified indicator means that its
+Markdown source has unsaved edits.
 
 Kosmo's File > New Terminal command opens a `TerminalView` in the focused
 editor group. Terminal and text tabs share selection, closing, reordering,

--- a/README.md
+++ b/README.md
@@ -621,6 +621,12 @@ Command-Shift-E selects and focuses the file explorer. Command-Shift-F selects
 the find-in-files sidebar and focuses its query field. Command-1 focuses the
 file browser, while Command-2 through Command-8 focus editor panels in their
 current split-tree order, visiting top or left panes before bottom or right panes.
+Panel focus follows the displayed document, including terminals and Markdown
+previews. In Vim-style editor navigation, Control-W followed by h/j/k/l or w
+focuses the neighboring or next pane; leaving the editor cancels an unfinished
+Control-W prefix. Control-W in a focused terminal remains available to the shell.
+Show Files and Find in Files invoked from a detached pane bring its project's
+browser window forward.
 For example:
 
 ```json
@@ -669,6 +675,12 @@ ordered top-level browser roots. If no Kosmo window is available, opening a file
 creates an editor-only window without a file-browser sidebar. Project window
 titles show `Kosmo (first-root)` and add `+ N` inside the parentheses when more
 top-level roots are open.
+
+Quick Open and Find in Files search every browser root, respecting each folder's
+Git ignore rules and returning overlapping files only once. Quick Open labels
+results by root when several folders are open, including folders with the same
+name. Git decorations refresh for every root independently. The first root remains
+the default working directory for new terminals and relative editor paths.
 
 About Kosmo shows the Kosmo icon, the package version from `merenda.nimble`, build
 Git hash, clickable Moe project link, and Kosmo's GNU GPL-3.0 license notice.

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -1,4 +1,4 @@
-version       = "0.16.2"
+version       = "0.16.3"
 author        = "Jaremy Creechley"
 description   = "Nim-native UI toolkit"
 license       = "BSD-3-Clause"

--- a/src/merenda/kosmo/filesearchpanel.nim
+++ b/src/merenda/kosmo/filesearchpanel.nim
@@ -43,6 +43,7 @@ type
     cancelButton*: nimkit.Button
     xRootPath: string
     xSearchOptions: nimkit.FileSearchOptions
+    xRootPaths: seq[string]
     xService: nimkit.FileSearchService
     xActiveSearch: nimkit.FileSearchHandle
 
@@ -383,7 +384,7 @@ proc performSearch*(panel: KosmoFileSearchPanel): bool {.discardable.} =
   try:
     panel.ensureSearchService()
     panel.xActiveSearch = panel.xService.search(
-      nimkit.initFileSearchQuery(panel.xRootPath, pattern, panel.xSearchOptions)
+      nimkit.initFileSearchQuery(panel.xRootPaths, pattern, panel.xSearchOptions)
     )
     result = true
   except CatchableError as error:
@@ -451,21 +452,35 @@ protocol KosmoFileSearchPanelLayout of nimkit.ViewLayoutProtocol:
 proc rootPath*(panel: KosmoFileSearchPanel): string =
   panel.xRootPath
 
-proc `rootPath=`*(panel: KosmoFileSearchPanel, rootPath: string) =
-  let next =
-    if rootPath.len > 0 and dirExists(rootPath):
-      absolutePath(rootPath)
-    else:
-      ""
-  if panel.xRootPath == next:
+proc rootPaths*(panel: KosmoFileSearchPanel): seq[string] =
+  ## Return all folders included in subsequent searches.
+  panel.xRootPaths
+
+proc `rootPaths=`*(panel: KosmoFileSearchPanel, rootPaths: openArray[string]) =
+  ## Replace the search roots and discard results from the previous workspace.
+  var next: seq[string]
+  for root in rootPaths:
+    if root.len > 0 and dirExists(root):
+      let path = normalizedPath(absolutePath(root))
+      if path notin next:
+        next.add path
+  if panel.xRootPaths == next:
     return
   if not panel.xActiveSearch.isNil and not panel.xActiveSearch.isFinished():
     panel.xActiveSearch.cancel()
   panel.xActiveSearch = nil
   panel.updateSearchControls(false)
-  panel.xRootPath = next
-  panel.resultsView.setMatches(next, [])
+  panel.xRootPaths = next
+  panel.xRootPath =
+    if next.len > 0:
+      next[0]
+    else:
+      ""
+  panel.resultsView.setMatches(panel.xRootPath, [])
   panel.statusLabel.text = "Enter a regular expression"
+
+proc `rootPath=`*(panel: KosmoFileSearchPanel, rootPath: string) =
+  panel.rootPaths = [rootPath]
 
 proc activeSearch*(panel: KosmoFileSearchPanel): nimkit.FileSearchHandle =
   panel.xActiveSearch

--- a/src/merenda/kosmo/filetree.nim
+++ b/src/merenda/kosmo/filetree.nim
@@ -20,6 +20,7 @@ type
     xOnOpenFile: FileTreeOpenHandler
     xOpenDisposition: FileTreeOpenDisposition
     xGitStatusService: nimkit.GitStatusService
+    xGitSnapshots: Table[string, nimkit.GitStatusSnapshot]
     xGitFileStates: Table[string, nimkit.GitFileState]
     xGitDescendantStates: Table[string, nimkit.GitFileState]
 
@@ -216,7 +217,7 @@ proc fileTreeRowWasActivated(
     tree.xOnOpenFile(path, tree.xOpenDisposition)
 
 proc rootPath*(tree: KosmoFileTree): string =
-  ## Return the first project root, used by single-root services such as Git.
+  ## Return the first project root, used as the default working directory.
   tree.xRootPath
 
 proc rootPaths*(tree: KosmoFileTree): lent seq[string] =
@@ -233,7 +234,7 @@ proc reloadRoots(tree: KosmoFileTree, expanded: seq[string]) =
 proc `rootPath=`*(tree: KosmoFileTree, path: string) =
   let next =
     if path.len > 0 and dirExists(path):
-      absolutePath(path)
+      normalizedPath(absolutePath(path))
     else:
       ""
   let nextRoots =
@@ -247,8 +248,9 @@ proc `rootPath=`*(tree: KosmoFileTree, path: string) =
   tree.xRootPaths = nextRoots
   tree.xGitFileStates.clear()
   tree.xGitDescendantStates.clear()
+  tree.xGitSnapshots.clear()
   if not tree.xGitStatusService.isNil:
-    tree.xGitStatusService.rootPath = next
+    tree.xGitStatusService.rootPaths = nextRoots
   let expanded =
     if next.len > 0:
       @[next]
@@ -260,16 +262,16 @@ proc addRootPath*(tree: KosmoFileTree, path: string): bool {.discardable.} =
   ## Append a directory to the browser's ordered top-level folders.
   if tree.isNil or path.len == 0 or not dirExists(path):
     return
-  let next = absolutePath(path)
+  let next = normalizedPath(absolutePath(path))
   if next in tree.xRootPaths:
     return
   if tree.xRootPath.len == 0:
     tree.xRootPath = next
     tree.xGitFileStates.clear()
     tree.xGitDescendantStates.clear()
-    if not tree.xGitStatusService.isNil:
-      tree.xGitStatusService.rootPath = next
   tree.xRootPaths.add next
+  if not tree.xGitStatusService.isNil:
+    tree.xGitStatusService.rootPaths = tree.xRootPaths
   var expanded = tree.expandedItemIdentifiers()
   expanded.add next
   tree.reloadRoots(expanded)
@@ -282,25 +284,27 @@ proc refresh*(tree: KosmoFileTree) =
   tree.reloadOutlineData()
 
 proc applyGitStatus*(tree: KosmoFileTree, snapshot: nimkit.GitStatusSnapshot) =
-  ## Replace file and descendant decorations from one completed status snapshot.
-  if tree.isNil or snapshot.rootPath != tree.xRootPath:
+  ## Replace one root's decorations while retaining snapshots for the other roots.
+  if tree.isNil or snapshot.rootPath notin tree.xRootPaths:
     return
+  tree.xGitSnapshots[snapshot.rootPath] = snapshot
   var
     fileStates = initTable[string, nimkit.GitFileState]()
     descendantStates = initTable[string, nimkit.GitFileState]()
-  if snapshot.isRepository:
-    for entry in snapshot.entries:
-      fileStates.includeGitState(entry.path, entry.state)
-      if entry.state != nimkit.gfsIgnored:
-        var parentPath = entry.path.parentDir()
-        while parentPath.len > 0:
-          descendantStates.includeGitState(parentPath, entry.state)
-          if parentPath == tree.xRootPath:
-            break
-          let nextParent = parentPath.parentDir()
-          if nextParent == parentPath:
-            break
-          parentPath = nextParent
+  for root, rootSnapshot in tree.xGitSnapshots:
+    if rootSnapshot.isRepository:
+      for entry in rootSnapshot.entries:
+        fileStates.includeGitState(entry.path, entry.state)
+        if entry.state != nimkit.gfsIgnored:
+          var parentPath = entry.path.parentDir()
+          while parentPath.len > 0:
+            descendantStates.includeGitState(parentPath, entry.state)
+            if parentPath == root:
+              break
+            let nextParent = parentPath.parentDir()
+            if nextParent == parentPath:
+              break
+            parentPath = nextParent
   if tree.xGitFileStates == fileStates and tree.xGitDescendantStates == descendantStates:
     return
   tree.xGitFileStates = fileStates
@@ -324,7 +328,7 @@ proc startGitStatusMonitoring*(
   result = nimkit.newGitStatusService(refreshInterval = refreshInterval)
   result.connect(nimkit.gitStatusDidRefresh, tree, applyRefreshedGitStatus)
   tree.xGitStatusService = result
-  result.rootPath = tree.xRootPath
+  result.rootPaths = tree.xRootPaths
 
 proc refreshGitStatus*(tree: KosmoFileTree): bool {.discardable.} =
   ## Request an immediate status refresh in addition to the periodic schedule.

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -205,6 +205,7 @@ type
     contentView: nimkit.View
     statusLabel: nimkit.Label
     primary: bool
+    activeGroup: KosmoEditorGroup
 
   KosmoDockController = ref object
     frontend: WeakRef[KosmoApplication]
@@ -288,6 +289,10 @@ proc `activeGroup=`(controller: KosmoDockController, group: KosmoEditorGroup) =
   if controller.xActiveGroup == group:
     return
   controller.xActiveGroup = group
+  if not group.isNil:
+    for host in controller.hosts:
+      if host.workspace == group.workspace:
+        host.activeGroup = group
   for candidate in controller.groups:
     candidate.updateActivePaneIndicator(
       candidate == group and not controller.xSidebarFocused
@@ -314,6 +319,7 @@ proc show*(frontend: KosmoApplication)
 proc close*(frontend: KosmoApplication)
 proc activateGroup(controller: KosmoDockController, view: KosmoEditorView)
 proc focusPanel(controller: KosmoDockController, panelNumber: int): bool
+proc focusGroup(controller: KosmoDockController, group: KosmoEditorGroup): bool
 proc preferredPaneResponder(group: KosmoEditorGroup): nimkit.Responder
 proc groupForView(
   controller: KosmoDockController, view: KosmoEditorView
@@ -1100,6 +1106,10 @@ protocol KosmoEditorAppearanceObserver of nimkit.WindowAppearanceEvents:
       handler.editorView[].refresh()
 
 protocol KosmoEditorFocusObserver of nimkit.WindowFocusEvents:
+  proc didResignKeyWindow(handler: KosmoEditorTabsHandler) {.slot.} =
+    if not handler.editorView.isNil:
+      handler.editorView[].pendingPanePrefix = false
+
   proc didChangeFirstResponder(
       handler: KosmoEditorTabsHandler, previous: nimkit.Responder
   ) {.slot.} =
@@ -1109,6 +1119,7 @@ protocol KosmoEditorFocusObserver of nimkit.WindowFocusEvents:
     let
       view = handler.editorView[]
       controller = handler.dockController[]
+    view.pendingPanePrefix = false
     if view.dockGroup.isNil:
       return
     let group = view.dockGroup[]
@@ -2361,6 +2372,15 @@ protocol KosmoEditorPaneLayout of nimkit.ViewLayoutProtocol:
 proc setContentView(pane: KosmoEditorPane, contentView: nimkit.View) =
   if pane.isNil or contentView.isNil or pane.contentView == contentView:
     return
+  let owner = pane.window()
+  var transferFocus = false
+  if owner of nimkit.Window and not pane.contentView.isNil:
+    var responder = nimkit.Window(owner).firstResponder()
+    while not responder.isNil:
+      if responder == nimkit.Responder(pane.contentView):
+        transferFocus = true
+        break
+      responder = responder.nextResponder()
   if pane.contentView == nimkit.View(pane.markdownView) and
       contentView != nimkit.View(pane.markdownView):
     pane.markdownView.markdown = ""
@@ -2372,6 +2392,15 @@ proc setContentView(pane: KosmoEditorPane, contentView: nimkit.View) =
   if contentView != nimkit.View(pane.editorView):
     pane.commandBar.hidden = true
   pane.setNeedsLayout()
+  if transferFocus:
+    var responder = nimkit.Responder(contentView)
+    if not pane.dockGroup.isNil:
+      let group = pane.dockGroup[]
+      let document = group.documentForIdentifier(group.selectedTabIdentifier)
+      if not document.isNil and document.contentView == contentView and
+          not document.preferredFirstResponder.isNil:
+        responder = nimkit.Responder(document.preferredFirstResponder)
+    discard nimkit.Window(owner).makeFirstResponder(responder)
 
 protocol KosmoEditorPaneCommandDispatch of nimkit.ResponderCommandDispatchProtocol:
   method dispatchCommand(pane: KosmoEditorPane, args: nimkit.TryToPerformArgs): bool =
@@ -2572,7 +2601,7 @@ proc focusedEditorGroup(controller: KosmoDockController): KosmoEditorGroup =
   if controller.isNil or controller.frontend.isNil:
     return
   let window = controller.frontend[].application.keyWindow()
-  if window.isNil:
+  if window.isNil or window.isClosed():
     return
   var responder = window.firstResponder()
   while not responder.isNil:
@@ -2582,11 +2611,30 @@ proc focusedEditorGroup(controller: KosmoDockController): KosmoEditorGroup =
     responder = responder.nextResponder()
 
 proc activePaneGroup(controller: KosmoDockController): KosmoEditorGroup =
+  if controller.isNil or controller.frontend.isNil or controller.frontend[].xClosed:
+    return
   result = controller.focusedEditorGroup()
-  if result.isNil:
-    result = controller.activeGroup
-  if result.isNil and controller.groups.len > 0:
-    result = controller.groups[0]
+  if not result.isNil:
+    return
+  let window =
+    if controller.frontend.isNil:
+      nil
+    else:
+      controller.frontend[].application.keyWindow()
+  for host in controller.hosts:
+    if host.window == window and not window.isNil and not window.isClosed():
+      if host.activeGroup in controller.groups:
+        return host.activeGroup
+      for group in controller.groups:
+        if group.window == window:
+          return group
+  let active = controller.activeGroup
+  if not active.isNil and active in controller.groups and not active.window.isNil and
+      not active.window.isClosed():
+    return active
+  for group in controller.groups:
+    if not group.window.isNil and not group.window.isClosed():
+      return group
 
 proc activeEditorView(controller: KosmoDockController): KosmoEditorView =
   let group = controller.activePaneGroup()
@@ -2671,7 +2719,6 @@ proc focusPanel(controller: KosmoDockController, panelNumber: int): bool =
     if controller.frontend.isNil:
       return
     let frontend = controller.frontend[]
-    controller.activatePanelWindow(frontend.window)
     return frontend.showFileExplorer()
 
   let
@@ -2679,24 +2726,7 @@ proc focusPanel(controller: KosmoDockController, panelNumber: int): bool =
     groups = controller.groupsInPanelOrder()
   if groupIndex notin 0 ..< groups.len:
     return
-  let group = groups[groupIndex]
-  if group.window.isNil or group.window.isClosed():
-    return
-
-  controller.activatePanelWindow(group.window)
-  controller.activateGroup(group.editorView)
-  let document = group.documentForIdentifier(group.selectedTabIdentifier)
-  if group.selectedTabIdentifier.len > 0:
-    controller.activatePaneTab(group, group.selectedTabIdentifier, focus = false)
-  else:
-    group.pane.setContentView(group.editorView)
-
-  let responder =
-    if document.isNil or document.preferredFirstResponder.isNil:
-      group.preferredPaneResponder()
-    else:
-      nimkit.Responder(document.preferredFirstResponder)
-  result = group.window.makeFirstResponder(responder)
+  controller.focusGroup(groups[groupIndex])
 
 proc initialBufferIds(editor: KosmoEditor): seq[KosmoBufferId] =
   for tab in editor.tabs():
@@ -3041,18 +3071,21 @@ proc splitNewBufferBelow(
   true
 
 proc preferredPaneResponder(group: KosmoEditorGroup): nimkit.Responder =
-  if group.pane.contentView == nimkit.View(group.pane.markdownView):
+  let document = group.documentForIdentifier(group.selectedTabIdentifier)
+  if not document.isNil and not document.preferredFirstResponder.isNil:
+    nimkit.Responder(document.preferredFirstResponder)
+  elif group.pane.contentView == nimkit.View(group.pane.markdownView):
     nimkit.Responder(group.pane.markdownView)
   else:
     nimkit.Responder(group.editorView)
 
 proc focusGroup(controller: KosmoDockController, group: KosmoEditorGroup): bool =
-  if controller.isNil or group.isNil:
+  if controller.isNil or group.isNil or group.window.isNil or group.window.isClosed():
     return
+  controller.activatePanelWindow(group.window)
   controller.activateGroup(group.editorView)
-  discard group.window.makeFirstResponder(group.preferredPaneResponder())
+  result = group.window.makeFirstResponder(group.preferredPaneResponder())
   group.editorView.refresh()
-  true
 
 proc focusNextGroup(controller: KosmoDockController, source: KosmoEditorGroup): bool =
   var candidates: seq[KosmoEditorGroup]
@@ -3570,16 +3603,20 @@ proc showFileExplorer*(frontend: KosmoApplication): bool {.discardable.} =
   if not frontend.sidebarTabs.selectCompactTabAtIndex(0):
     return
   result = frontend.window.makeFirstResponder(frontend.fileTree)
+  if result:
+    frontend.dockController.activatePanelWindow(frontend.window)
 
 proc showFindInFiles*(frontend: KosmoApplication): bool {.discardable.} =
   ## Select the find sidebar tab and focus its search query.
   if frontend.isNil or not frontend.hasFileBrowser() or frontend.sidebarTabs.isNil or
       frontend.searchPanel.isNil:
     return
-  frontend.searchPanel.rootPath = frontend.fileTree.rootPath
+  frontend.searchPanel.rootPaths = frontend.fileTree.rootPaths
   if not frontend.sidebarTabs.selectCompactTabAtIndex(1):
     return
   result = frontend.searchPanel.focusQuery()
+  if result:
+    frontend.dockController.activatePanelWindow(frontend.window)
 
 proc showQuickOpen*(frontend: KosmoApplication): bool {.discardable.} =
   ## Present the fuzzy project-file picker and open its selected file.
@@ -3588,7 +3625,7 @@ proc showQuickOpen*(frontend: KosmoApplication): bool {.discardable.} =
   let weakFrontend = frontend.unsafeWeakRef()
   result = frontend.quickOpenPanel.present(
     frontend.window,
-    frontend.fileTree.rootPath,
+    frontend.fileTree.rootPaths,
     proc(path: string) =
       if weakFrontend.isNil:
         return
@@ -4367,6 +4404,8 @@ proc chooseFile(frontend: KosmoApplication) =
   if frontend.isNil:
     return
   let panel = nimkit.newOpenPanel()
+  defer:
+    panel.window.close()
   panel.message = "Open a file or add a folder to this window."
   panel.canChooseDirectories = true
   panel.directoryUrl = frontend.fileTree.rootPath
@@ -4381,6 +4420,8 @@ proc chooseFile(manager: KosmoWindowManager) =
     frontend.chooseFile()
     return
   let panel = nimkit.newOpenPanel()
+  defer:
+    panel.window.close()
   panel.message = "Open a file or folder in Kosmo."
   panel.canChooseDirectories = true
   panel.directoryUrl = getCurrentDir()
@@ -4394,6 +4435,8 @@ proc chooseProject(manager: KosmoWindowManager) =
   let
     frontend = manager.activeFrontend()
     panel = nimkit.newOpenPanel()
+  defer:
+    panel.window.close()
   panel.window.title = "Open Project"
   panel.message = "Choose a folder to open in a new Kosmo window."
   panel.prompt = "Open Project"
@@ -4427,21 +4470,23 @@ proc loadKosmoKeyBindings*(
 
 proc openPath*(frontend: KosmoApplication, path: string): bool {.discardable.} =
   ## Open a file here, or add a folder to this window's visible browser.
-  if frontend.isNil or frontend.dockController.isNil:
+  if frontend.isNil or frontend.xClosed or frontend.dockController.isNil:
     return
   if dirExists(path):
     if not frontend.hasFileBrowser():
       if frontend.xWindowManager.isNil:
         return
       return not frontend.xWindowManager[].openProject(path).isNil
-    let root = absolutePath(path)
+    let root = normalizedPath(absolutePath(path))
     result = root in frontend.fileTree.rootPaths or frontend.fileTree.addRootPath(root)
   elif fileExists(path):
-    result = frontend.dockController.activeEditorView().openFile(path)
+    let view = frontend.dockController.activeEditorView()
+    if not view.isNil:
+      result = view.openFile(path)
   if result and dirExists(path):
     frontend.updateProjectWindowTitle()
     if not frontend.searchPanel.isNil:
-      frontend.searchPanel.rootPath = frontend.fileTree.rootPath
+      frontend.searchPanel.rootPaths = frontend.fileTree.rootPaths
 
 proc openDocument*(
     frontend: KosmoApplication, document: KosmoPaneDocument

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -73,6 +73,7 @@ Licensed under the GNU General Public License v3.0 (GPL-3.0).""" %
   KosmoMarkdownControlButtonStyleClass = "kosmo-markdown-control-button"
   KosmoPreviewTabStyleClass* = "kosmo-preview"
   KosmoMarkdownDefaultFontSize* = 14.0'f32
+  KosmoMarkdownPreviewCacheLimit = 3
   KosmoMarkdownMinimumFontSize* = 9.0'f32
   KosmoMarkdownMaximumFontSize* = 28.0'f32
   KosmoInactivePaneStyleClass* = "kosmo-inactive-pane"
@@ -135,6 +136,10 @@ type
   KosmoMarkdownView = ref object of nimkit.MarkdownView
     editorView: WeakRef[KosmoEditorView]
 
+  KosmoMarkdownPreview = object
+    bufferId: KosmoBufferId
+    view: KosmoMarkdownView
+
   KosmoMarkdownControls* = ref object of nimkit.Box
     modeButton*: nimkit.Button
     colorModeButton*: nimkit.Button
@@ -175,6 +180,7 @@ type
     editorView*: KosmoEditorView
     commandBar*: KosmoCommandBar
     markdownView*: KosmoMarkdownView
+    markdownPreviews: seq[KosmoMarkdownPreview]
     markdownControls*: KosmoMarkdownControls
     contentView*: nimkit.View
     activeIndicator: KosmoPaneIndicator
@@ -717,6 +723,38 @@ proc documentForIdentifier(
   if index >= 0:
     result = group.documents[index]
 
+proc markdownViewForBuffer(pane: KosmoEditorPane, id: KosmoBufferId): KosmoMarkdownView
+
+proc removeMarkdownPreview(pane: KosmoEditorPane, id: KosmoBufferId) =
+  if pane.isNil:
+    return
+  for index, preview in pane.markdownPreviews:
+    if preview.bufferId == id:
+      preview.view.markdown = ""
+      pane.markdownPreviews.delete(index)
+      return
+
+proc pruneMarkdownPreviews(pane: KosmoEditorPane, tabs: openArray[KosmoTab]) =
+  if pane.isNil:
+    return
+  var index = pane.markdownPreviews.high
+  while index >= 0:
+    var retained = false
+    for tab in tabs:
+      if tab.id == pane.markdownPreviews[index].bufferId:
+        retained = true
+        break
+    if not retained:
+      pane.removeMarkdownPreview(pane.markdownPreviews[index].bufferId)
+    dec index
+
+proc clearMarkdownPreviews(pane: KosmoEditorPane) =
+  if pane.isNil:
+    return
+  for preview in pane.markdownPreviews:
+    preview.view.markdown = ""
+  pane.markdownPreviews.setLen(0)
+
 func documents*(group: KosmoEditorGroup): lent seq[KosmoPaneDocument] =
   ## Return the non-Moe documents currently owned by this pane group.
   group.documents
@@ -1151,6 +1189,7 @@ proc syncSelectedEditorContent(
   if view.dockGroup.isNil:
     return keckSyntax
   let group = view.dockGroup[]
+  group.pane.pruneMarkdownPreviews(tabs)
   var selectedId: KosmoBufferId
   if not group.selectedTabIdentifier.parseTabIdentifier(selectedId):
     group.pane.syncMarkdownControls(false)
@@ -1169,11 +1208,13 @@ proc syncSelectedEditorContent(
       if source.isNone:
         group.pane.setContentView(view)
         return keckSyntax
-      group.pane.markdownView.imageBasePath = tab.filePath.get.parentDir
-      group.pane.markdownView.markdownStyle =
+      let markdownView = group.pane.markdownViewForBuffer(selectedId)
+      group.pane.markdownView = markdownView
+      markdownView.imageBasePath = tab.filePath.get.parentDir
+      markdownView.markdownStyle =
         group.pane.markdownControls.markdownPresentationStyle()
-      group.pane.markdownView.markdown = source.get
-      group.pane.setContentView(group.pane.markdownView)
+      markdownView.markdown = source.get
+      group.pane.setContentView(markdownView)
       return keckMarkdownPreview
     group.pane.setContentView(view)
     return keckSyntax
@@ -2381,9 +2422,6 @@ proc setContentView(pane: KosmoEditorPane, contentView: nimkit.View) =
         transferFocus = true
         break
       responder = responder.nextResponder()
-  if pane.contentView == nimkit.View(pane.markdownView) and
-      contentView != nimkit.View(pane.markdownView):
-    pane.markdownView.markdown = ""
   if pane.contentView.isNil:
     pane.addSubview(contentView, positioned = nimkit.svpBelow)
   elif not pane.replaceSubview(pane.contentView, contentView):
@@ -2411,6 +2449,25 @@ protocol KosmoEditorPaneCommandDispatch of nimkit.ResponderCommandDispatchProtoc
         group.editorView.tabsDelegate.dockController.isNil:
       return false
     let controller = group.editorView.tabsDelegate.dockController[]
+    if pane.contentView == nimkit.View(pane.markdownView):
+      let firstResponder = group.window.firstResponder()
+      let previewTextView =
+        if firstResponder of nimkit.TextView:
+          nimkit.TextView(firstResponder)
+        else:
+          pane.markdownView.textView()
+      case $args.selector.name
+      of KosmoCopyAction, "copy":
+        discard previewTextView.copyText()
+        return true
+      of KosmoCutAction, KosmoPasteAction, KosmoUndoAction, KosmoRedoAction, "cut",
+          "paste", "undo", "redo":
+        return true
+      of KosmoSelectAllAction, "selectAll":
+        previewTextView.selectAllText()
+        return true
+      else:
+        discard
     let panelNumber = args.selector.focusPanelNumber()
     if panelNumber > 0:
       discard controller.focusPanel(panelNumber)
@@ -2508,16 +2565,48 @@ protocol KosmoMarkdownLinkDelegate of nimkit.TextViewDelegateProtocol:
       return false
     controller.frontend[].openPath(path)
 
+proc newKosmoMarkdownView(editorView: KosmoEditorView): KosmoMarkdownView =
+  result = KosmoMarkdownView()
+  result.initMarkdownViewFields(syntaxHighlighter = nimkit.matterSyntaxHighlighter)
+  result.editorView = editorView.unsafeWeakRef()
+  let keyEquivalentMethod: nimkit.DynamicMethod = proc(
+      self: nimkit.DynamicAgent, invocation: var nimkit.Invocation
+  ) =
+    let event = invocation.argsAs(nimkit.KeyEvent)
+    let markdownView = KosmoMarkdownView(self)
+    if markdownView.handleMarkdownPaneKey(event):
+      invocation.setResult(true)
+    else:
+      invocation.setResult(markdownView.handleMarkdownNavigationKey(event))
+  discard
+    result.replaceMethod(nimkitSelectors.performKeyEquivalent(), keyEquivalentMethod)
+
+proc markdownViewForBuffer(
+    pane: KosmoEditorPane, id: KosmoBufferId
+): KosmoMarkdownView =
+  for index in 0 ..< pane.markdownPreviews.len:
+    if pane.markdownPreviews[index].bufferId == id:
+      let cached = pane.markdownPreviews[index]
+      result = cached.view
+      pane.markdownPreviews.delete(index)
+      pane.markdownPreviews.add cached
+      return
+  if pane.markdownPreviews.len >= KosmoMarkdownPreviewCacheLimit:
+    pane.markdownPreviews[0].view.markdown = ""
+    pane.markdownPreviews.delete(0)
+  if pane.markdownPreviews.len == 0:
+    result = pane.markdownView
+  else:
+    result = newKosmoMarkdownView(pane.editorView)
+    result.textView().delegate = nimkit.DynamicAgent(pane)
+  pane.markdownPreviews.add KosmoMarkdownPreview(bufferId: id, view: result)
+
 proc newKosmoEditorPane(editorView: KosmoEditorView): KosmoEditorPane =
   let
     commandBar = newKosmoCommandBar(editorView)
-    markdownView = KosmoMarkdownView()
+    markdownView = newKosmoMarkdownView(editorView)
     markdownControls = newKosmoMarkdownControls(editorView)
     activeIndicator = newKosmoPaneIndicator()
-  markdownView.initMarkdownViewFields(
-    syntaxHighlighter = nimkit.matterSyntaxHighlighter
-  )
-  markdownView.editorView = editorView.unsafeWeakRef()
   result = KosmoEditorPane(
     documentTabs: editorView.documentTabs,
     editorView: editorView,
@@ -2537,18 +2626,6 @@ proc newKosmoEditorPane(editorView: KosmoEditorView): KosmoEditorPane =
   discard result.withProtocol(KosmoEditorPaneLayout)
   discard result.withProtocol(KosmoEditorPaneCommandDispatch)
   discard result.withProtocol(KosmoMarkdownLinkDelegate)
-  let keyEquivalentMethod: nimkit.DynamicMethod = proc(
-      self: nimkit.DynamicAgent, invocation: var nimkit.Invocation
-  ) =
-    let event = invocation.argsAs(nimkit.KeyEvent)
-    let markdownView = KosmoMarkdownView(self)
-    if markdownView.handleMarkdownPaneKey(event):
-      invocation.setResult(true)
-    else:
-      invocation.setResult(markdownView.handleMarkdownNavigationKey(event))
-  discard result.markdownView.replaceMethod(
-    nimkitSelectors.performKeyEquivalent(), keyEquivalentMethod
-  )
   result.markdownView.textView().delegate = nimkit.DynamicAgent(result)
 
 proc groupForView(
@@ -2678,7 +2755,6 @@ proc activatePaneTab(
   controller.activateGroup(group.editorView)
   var id: KosmoBufferId
   if identifier.parseTabIdentifier(id):
-    group.pane.setContentView(group.editorView)
     group.editorView.saveViewState()
     group.editorView.editor.dismissCompletionPopup()
     group.editorView.editor.dismissCommandLine()
@@ -2813,6 +2889,7 @@ proc removeBuffer(group: KosmoEditorGroup, id: KosmoBufferId) =
   group.editorView.forgetMarkdownMode(id)
   group.editorView.selectedBufferId = none(KosmoBufferId)
   group.editorView.lastTabs.setLen(0)
+  group.pane.removeMarkdownPreview(id)
   let orderIndex = group.tabOrder.find(id.tabIdentifier)
   if orderIndex >= 0:
     group.tabOrder.delete(orderIndex)
@@ -2832,6 +2909,7 @@ proc removeGroup(controller: KosmoDockController, group: KosmoEditorGroup) =
   group.editorView.tabsDelegate.dockController = default(WeakRef[KosmoDockController])
   group.editorView.dockGroup = default(WeakRef[KosmoEditorGroup])
   group.pane.dockGroup = default(WeakRef[KosmoEditorGroup])
+  group.pane.clearMarkdownPreviews()
   let wasActive = controller.activeGroup == group
   discard group.workspace.removePanel(group.panel)
   let index = controller.groups.find(group)
@@ -4542,6 +4620,7 @@ proc close*(frontend: KosmoApplication) =
   if not frontend.dockController.isNil:
     for group in frontend.dockController.groups:
       group.editorView.tabsDelegate.stopObservingWindow()
+      group.pane.clearMarkdownPreviews()
       for document in group.documents:
         discard document.close()
     let hosts = frontend.dockController.hosts

--- a/src/merenda/kosmo/quickopen.nim
+++ b/src/merenda/kosmo/quickopen.nim
@@ -1,6 +1,6 @@
 ## Fuzzy project-file picker used by Kosmo's quick-open command.
 
-import std/[algorithm, math, os, osproc, sets, streams, strutils]
+import std/[algorithm, math, os, osproc, sets, streams, strutils, tables]
 
 import sigils/core
 
@@ -34,6 +34,8 @@ type
     queryField*: nimkit.TextField
     resultsView*: nimkit.PopupListView
     xRootPath: string
+    xRootPaths: seq[string]
+    xFilePaths: Table[string, string]
     xProjectFiles: seq[string]
     xFilteredFiles: seq[string]
     xHighlightedIndex: int
@@ -304,7 +306,7 @@ proc activateIndex(panel: KosmoQuickOpenPanel, index: int) =
   if panel.isNil or index notin 0 ..< panel.xFilteredFiles.len:
     return
   let
-    path = panel.xRootPath / panel.xFilteredFiles[index]
+    path = panel.xFilePaths[panel.xFilteredFiles[index]]
     handler = panel.xOnOpen
   panel.dismiss()
   if not handler.isNil:
@@ -666,6 +668,11 @@ proc newKosmoQuickOpenPanel*(rootPath = ""): KosmoQuickOpenPanel =
 proc rootPath*(panel: KosmoQuickOpenPanel): string =
   if panel.isNil: "" else: panel.xRootPath
 
+proc rootPaths*(panel: KosmoQuickOpenPanel): seq[string] =
+  ## Return the indexed folders in browser order.
+  if not panel.isNil:
+    result = panel.xRootPaths
+
 proc projectFiles*(panel: KosmoQuickOpenPanel): seq[string] =
   if not panel.isNil:
     result = panel.xProjectFiles
@@ -684,14 +691,53 @@ proc highlightedFile*(panel: KosmoQuickOpenPanel): string =
 proc isOpen*(panel: KosmoQuickOpenPanel): bool =
   not panel.isNil and not panel.hidden()
 
-proc reloadProjectFiles*(panel: KosmoQuickOpenPanel, rootPath = "") =
-  ## Refresh the picker index for a project root.
+proc reloadProjectFiles*(panel: KosmoQuickOpenPanel, rootPaths: openArray[string]) =
+  ## Index all roots, preserving distinct names and deduplicating overlapping files.
   if panel.isNil:
     return
-  if rootPath.len > 0:
-    panel.xRootPath = absolutePath(rootPath)
-  panel.xProjectFiles = projectFiles(panel.xRootPath)
+  var roots: seq[string]
+  for root in rootPaths:
+    if root.len > 0 and dirExists(root):
+      let path = normalizedPath(absolutePath(root))
+      if path notin roots:
+        roots.add path
+  panel.xRootPaths = roots
+  panel.xRootPath =
+    if roots.len > 0:
+      roots[0]
+    else:
+      ""
+  panel.xProjectFiles.setLen(0)
+  panel.xFilePaths.clear()
+  var seen = initHashSet[string]()
+  for root in roots:
+    var prefix = root.extractFilename()
+    for other in roots:
+      if other != root and other.extractFilename() == prefix:
+        prefix = root
+        break
+    for relative in projectFiles(root):
+      let path = normalizedPath(root / relative)
+      if path notin seen:
+        seen.incl path
+        let label =
+          if roots.len == 1:
+            relative
+          else:
+            prefix / relative
+        panel.xProjectFiles.add label
+        panel.xFilePaths[label] = path
   panel.filterFiles()
+
+proc reloadProjectFiles*(panel: KosmoQuickOpenPanel, rootPath = "") =
+  ## Refresh a single root, or the current roots when no argument is supplied.
+  if not panel.isNil:
+    if rootPath.len > 0:
+      panel.reloadProjectFiles([rootPath])
+    elif panel.xRootPaths.len > 0:
+      panel.reloadProjectFiles(panel.xRootPaths)
+    else:
+      panel.reloadProjectFiles([panel.xRootPath])
 
 proc startPresentationAnimation(panel: KosmoQuickOpenPanel, window: nimkit.Window) =
   if panel.isNil or window.isNil:
@@ -728,7 +774,7 @@ proc startPresentationAnimation(panel: KosmoQuickOpenPanel, window: nimkit.Windo
 proc present*(
     panel: KosmoQuickOpenPanel,
     window: nimkit.Window,
-    rootPath: string,
+    rootPaths: openArray[string],
     onOpen: KosmoQuickOpenHandler,
 ): bool {.discardable.} =
   ## Show the picker, focus its query, and preserve the previous responder.
@@ -736,10 +782,12 @@ proc present*(
     return
   panel.xOnOpen = onOpen
   if panel.isOpen():
+    if @rootPaths != panel.xRootPaths:
+      panel.reloadProjectFiles(rootPaths)
     return window.makeFirstResponder(panel.queryField)
 
   panel.queryField.text = ""
-  panel.reloadProjectFiles(rootPath)
+  panel.reloadProjectFiles(rootPaths)
   panel.hidden = false
   panel.needsDisplay = true
   let weakPanel = panel.unsafeWeakRef()
@@ -757,3 +805,12 @@ proc present*(
     panel.finishDismiss()
   else:
     panel.startPresentationAnimation(window)
+
+proc present*(
+    panel: KosmoQuickOpenPanel,
+    window: nimkit.Window,
+    rootPath: string,
+    onOpen: KosmoQuickOpenHandler,
+): bool {.discardable.} =
+  ## Show a picker for one folder.
+  panel.present(window, [rootPath], onOpen)

--- a/src/merenda/nimkit/foundation/filesearch.nim
+++ b/src/merenda/nimkit/foundation/filesearch.nim
@@ -40,6 +40,7 @@ type
 
   FileSearchQuery* = object
     rootPath*: string
+    rootPaths*: seq[string] ## When nonempty, search these roots instead of `rootPath`.
     pattern*: string
     options*: FileSearchOptions
 
@@ -159,6 +160,25 @@ func initFileSearchQuery*(
   ## Create a regular-expression search rooted at `rootPath`.
   FileSearchQuery(rootPath: rootPath, pattern: pattern, options: options)
 
+func initFileSearchQuery*(
+    rootPaths: openArray[string], pattern: string, options = initFileSearchOptions()
+): FileSearchQuery =
+  ## Search multiple folders with shared limits and no duplicate file results.
+  FileSearchQuery(rootPaths: @rootPaths, pattern: pattern, options: options)
+
+proc searchRoots(query: FileSearchQuery): seq[string] =
+  let roots =
+    if query.rootPaths.len > 0:
+      query.rootPaths
+    else:
+      @[query.rootPath]
+  for root in roots:
+    if root.len == 0:
+      raise newException(IOError, "file search root cannot be empty")
+    let path = normalizedPath(absolutePath(root))
+    if path notin result:
+      result.add path
+
 func identifier*(handle: FileSearchHandle): uint64 =
   if not handle.isNil:
     result = handle.xIdentifier
@@ -184,9 +204,9 @@ func cancellationRequested(control: SharedPtr[FileSearchControl]): bool =
   control[].cancelled.load(moAcquire)
 
 proc validate(query: FileSearchQuery) =
-  if not dirExists(query.rootPath):
-    raise
-      newException(IOError, "file search root is not a directory: " & query.rootPath)
+  for root in query.searchRoots():
+    if not dirExists(root):
+      raise newException(IOError, "file search root is not a directory: " & root)
   if query.pattern.len == 0:
     raise newException(ValueError, "file search pattern cannot be empty")
   if query.options.maxResults <= 0:
@@ -240,10 +260,9 @@ proc gitSearchFiles(
   try:
     process = startProcess(
       "git",
-      workingDir = rootPath,
       args = [
-        "--no-optional-locks", "ls-files", "--cached", "--others", "--exclude-standard",
-        "-z", "--", ".",
+        "-C", rootPath, "--no-optional-locks", "ls-files", "--cached", "--others",
+        "--exclude-standard", "-z", "--", ".",
       ],
       options = {poUsePath, poStdErrToStdOut},
     )
@@ -336,12 +355,8 @@ proc nextSearchFile(
     for entryPath in directories:
       traversal.pendingDirectories.add entryPath
 
-  if stats.discoveredFileCount == traversal.options.maxFiles:
-    reason = fsfrFileLimitReached
-    return
   path = traversal.pendingFiles[traversal.nextFileIndex]
   inc traversal.nextFileIndex
-  inc stats.discoveredFileCount
   result = true
 
 proc addLineMatches(
@@ -519,19 +534,29 @@ proc performFileSearch(
   result.stats.workerThreadId = getThreadId()
   let pattern = query.searchPattern()
   let mimeTypes = newMimetypes()
-  var
-    traversal = initFileSearchTraversal(query.rootPath, query.options, control)
-    path: string
-  while traversal.nextSearchFile(result.stats, result.reason, path):
-    try:
-      searchMappedFile(
-        batchState, path, pattern, query.options, mimeTypes, control, result
-      )
-    except IOError, OSError:
-      inc result.stats.failedFileCount
+  var seen = initHashSet[string]()
+  for root in query.searchRoots():
+    var
+      traversal = initFileSearchTraversal(root, query.options, control)
+      path: string
+    while traversal.nextSearchFile(result.stats, result.reason, path):
+      if path notin seen:
+        if result.stats.discoveredFileCount == query.options.maxFiles:
+          result.reason = fsfrFileLimitReached
+          return
+        seen.incl path
+        inc result.stats.discoveredFileCount
+        try:
+          searchMappedFile(
+            batchState, path, pattern, query.options, mimeTypes, control, result
+          )
+        except IOError, OSError:
+          inc result.stats.failedFileCount
+        if result.reason != fsfrCompleted:
+          return
+        batchState.publishIfDue()
     if result.reason != fsfrCompleted:
       return
-    batchState.publishIfDue()
 
 proc executeFileSearch(
   worker: AgentProxy[FileSearchWorker],

--- a/src/merenda/nimkit/foundation/gitstatus.nim
+++ b/src/merenda/nimkit/foundation/gitstatus.nim
@@ -43,7 +43,7 @@ type
     xTimerThread: SigilChronosThreadPtr
     xTicker: AgentProxy[GitStatusRefreshTicker]
     xTimer: SigilTimer
-    xRootPath: string
+    xRootPaths: seq[string]
     xLastSnapshot: GitStatusSnapshot
     xNextIdentifier: uint64
     xActiveIdentifier: uint64
@@ -129,10 +129,11 @@ proc parseGitStatusPorcelain*(
 
 proc runGit(rootPath: string, args: openArray[string]): GitCommandResult =
   var process: Process
+  var arguments = @["-C", rootPath, "--no-optional-locks"]
+  arguments.add args
   try:
-    process = startProcess(
-      "git", workingDir = rootPath, args = args, options = {poUsePath, poStdErrToStdOut}
-    )
+    process =
+      startProcess("git", args = arguments, options = {poUsePath, poStdErrToStdOut})
     result.output = process.outputStream().readAll()
     result.exitCode = process.waitForExit()
   finally:
@@ -176,17 +177,20 @@ proc readGitStatus(rootPath: string): GitStatusSnapshot =
     result.errorMessage = getCurrentExceptionMsg()
 
 proc executeGitStatus(
-  worker: AgentProxy[GitStatusWorker], identifier: uint64, rootPath: string
+  worker: AgentProxy[GitStatusWorker], identifier: uint64, rootPaths: seq[string]
 ) {.signal.}
 
 proc gitStatusFinished(
-  worker: GitStatusWorker, identifier: uint64, snapshot: GitStatusSnapshot
+  worker: GitStatusWorker, identifier: uint64, snapshots: seq[GitStatusSnapshot]
 ) {.signal.}
 
 proc executeGitStatus(
-    worker: GitStatusWorker, identifier: uint64, rootPath: string
+    worker: GitStatusWorker, identifier: uint64, rootPaths: seq[string]
 ) {.slot.} =
-  emit worker.gitStatusFinished(identifier, readGitStatus(rootPath))
+  var snapshots: seq[GitStatusSnapshot]
+  for root in rootPaths:
+    snapshots.add readGitStatus(root)
+  emit worker.gitStatusFinished(identifier, snapshots)
 
 proc gitStatusRefreshTicked(ticker: GitStatusRefreshTicker) {.signal.}
 
@@ -200,44 +204,61 @@ proc gitStatusDidRefresh*(
 proc refresh*(service: GitStatusService): bool {.discardable.}
 
 proc completeGitStatus(
-    service: GitStatusService, identifier: uint64, snapshot: GitStatusSnapshot
+    service: GitStatusService, identifier: uint64, snapshots: seq[GitStatusSnapshot]
 ) {.slot.} =
   if service.xClosed or identifier != service.xActiveIdentifier:
     return
   service.xActiveIdentifier = 0
-  if snapshot.rootPath == service.xRootPath:
-    service.xLastSnapshot = snapshot
-    emit service.gitStatusDidRefresh(snapshot)
+  for snapshot in snapshots:
+    if snapshot.rootPath in service.xRootPaths:
+      if snapshot.rootPath == service.xRootPaths[0]:
+        service.xLastSnapshot = snapshot
+      emit service.gitStatusDidRefresh(snapshot)
   let refreshPending = service.xRefreshPending
   service.xRefreshPending = false
   if refreshPending:
     discard service.refresh()
 
 proc requestPeriodicGitStatusRefresh(service: GitStatusService) {.slot.} =
-  discard service.refresh()
+  # A slow scan must finish before the next periodic scan is requested.
+  if service.xActiveIdentifier == 0:
+    discard service.refresh()
 
 proc rootPath*(service: GitStatusService): string =
-  if not service.isNil:
-    result = service.xRootPath
+  ## Return the first monitored root.
+  if not service.isNil and service.xRootPaths.len > 0:
+    result = service.xRootPaths[0]
 
-proc `rootPath=`*(service: GitStatusService, rootPath: string) =
+proc rootPaths*(service: GitStatusService): seq[string] =
+  ## Return the folders refreshed by this service's single worker.
+  if not service.isNil:
+    result = service.xRootPaths
+
+proc `rootPaths=`*(service: GitStatusService, rootPaths: openArray[string]) =
+  ## Replace the monitored roots, coalescing updates with any active refresh.
   if service.isNil or service.xClosed:
     return
-  let next =
-    if rootPath.len > 0:
-      absolutePath(rootPath)
-    else:
-      ""
-  if service.xRootPath == next:
+  var next: seq[string]
+  for root in rootPaths:
+    if root.len > 0:
+      let path = normalizedPath(absolutePath(root))
+      if path notin next:
+        next.add path
+  if service.xRootPaths == next:
     return
-  service.xRootPath = next
-  service.xLastSnapshot = GitStatusSnapshot(rootPath: next)
+  service.xRootPaths = next
+  service.xLastSnapshot = GitStatusSnapshot(rootPath: service.rootPath())
   if service.xActiveIdentifier != 0:
     service.xRefreshPending = next.len > 0
   elif next.len > 0:
     discard service.refresh()
 
+proc `rootPath=`*(service: GitStatusService, rootPath: string) =
+  ## Replace the monitored folders with a single root; empty clears them.
+  service.rootPaths = [rootPath]
+
 proc lastSnapshot*(service: GitStatusService): lent GitStatusSnapshot =
+  ## Return the most recent completed snapshot for the first monitored root.
   service.xLastSnapshot
 
 func isRefreshing*(service: GitStatusService): bool =
@@ -245,14 +266,14 @@ func isRefreshing*(service: GitStatusService): bool =
 
 proc refresh*(service: GitStatusService): bool {.discardable.} =
   ## Request one status refresh, coalescing requests while Git is already running.
-  if service.isNil or service.xClosed or service.xRootPath.len == 0:
+  if service.isNil or service.xClosed or service.xRootPaths.len == 0:
     return
   if service.xActiveIdentifier != 0:
     service.xRefreshPending = true
     return
   inc service.xNextIdentifier
   service.xActiveIdentifier = service.xNextIdentifier
-  emit service.xWorker.executeGitStatus(service.xActiveIdentifier, service.xRootPath)
+  emit service.xWorker.executeGitStatus(service.xActiveIdentifier, service.xRootPaths)
   true
 
 proc newGitStatusService*(

--- a/tests/kosmo/cli.nim
+++ b/tests/kosmo/cli.nim
@@ -58,8 +58,10 @@ suite "Kosmo command line":
       writeFile(
         helperPath,
         """#!/bin/sh
-printf '%s\n' "$PWD" > "$1"
-printf '%s\n' "$2" >> "$1"
+printf '%s\n' "$PWD" > "$1.tmp"
+sleep 0.1
+printf '%s\n' "$2" >> "$1.tmp"
+mv "$1.tmp" "$1"
 """,
       )
       launchKosmoInBackground("/bin/sh", commandLine.arguments, root)

--- a/tests/kosmo/fixtures/markdown-activation.md
+++ b/tests/kosmo/fixtures/markdown-activation.md
@@ -1,0 +1,575 @@
+# Incremental Render Fragments
+
+## Implementation status
+
+Implementation began with [FigDraw PR #72](https://github.com/elcritch/figdraw/pull/72)
+and the initial NimKit scene foundation on `feature/incremental-render-fragments`.
+FigDraw support shipped in 0.36.0, and the initial NimKit scene foundation was
+merged on `feature/incremental-render-fragments`. Per-view contribution caching,
+direct fragment rendering, and the dedicated-renderer update protocol are complete
+on `feature/per-view-render-fragment-cache`. The unchecked FigDraw validator and
+items under Deferred Work are not part of the NimKit implementation.
+
+## Recommendation
+
+Modify FigDraw's fragment model first, then use fragments as NimKit's per-view
+render cache.
+
+- Fragments should be attachable as logical children of existing nodes, including
+  nodes inside other fragments, and as roots of a layer.
+- A fragment attachment must remain present when its contents have zero, one, or
+  many roots.
+- NimKit should cache vector/render-tree fragments at this stage. It should not
+  add a separate rasterized-view or texture cache yet.
+- Enable fragment-native rendering on both direct and dedicated static renderers.
+- Preserve monolithic `Renders` through a flattening/materialization API for
+  compatibility and diagnostics.
+- Do not share a mutable fragment graph between the application and renderer
+  threads.
+- Dynlib integration is outside the scope of this work.
+
+Fragments initially optimize render-tree construction: clean views avoid
+running `draw`, laying out text, and rebuilding Fig nodes. They do not by
+themselves reduce the number of GPU draw operations in a frame.
+
+## FigDraw prerequisites
+
+### Persistent fragment slots
+
+The current `insertChildren` API can insert a fragment beneath a base node or a
+node in another fragment. Keep that capability, but change its representation.
+
+At present, a parent contains one `RenderChild` entry for every current root of
+the inserted fragment. Replacing a fragment with an empty `RenderList` removes
+all of those entries and therefore loses the fragment's insertion position.
+Changing the number of roots also requires finding and rewriting references
+throughout the graph.
+
+Represent an attachment as one persistent fragment edge instead:
+
+```text
+parent children = [node A, fragment F, node B]
+fragment F roots = [] | [root X] | [root X, root Y]
+```
+
+Traversal expands the roots of `F` in place. This preserves identity and sibling
+order across empty and multi-root replacements and avoids graph-wide reference
+rewrites.
+
+- [x] Store one fragment edge per attachment rather than one edge per root.
+- [x] Add equivalent persistent slots to each layer's root sequence.
+- [x] Allow fragment edges beneath base nodes and nodes inside fragments.
+- [x] Detect attachment cycles.
+- [x] Give each mutable fragment exactly one attachment. Reusing content in more
+      than one location should require a distinct fragment instance.
+
+### Explicit attachment APIs
+
+The current names are easy to confuse: `insertChildren` creates a replaceable
+fragment, while `addChildren` physically appends nodes to a `RenderList`. Make
+the distinction explicit in the API.
+
+The intended surface is approximately:
+
+```nim
+proc attachChildFragment*(
+    tree: RenderFragments,
+    parent: RenderNodeCursor,
+    childPos: Natural,
+    contents: sink RenderList,
+): RenderFragmentHandle
+
+proc attachRootFragment*(
+    tree: RenderFragments,
+    level: ZLevel,
+    rootPos: Natural,
+    contents: sink RenderList,
+): RenderFragmentHandle
+
+proc replaceFragment*(
+    tree: RenderFragments,
+    handle: RenderFragmentHandle,
+    contents: sink RenderList,
+): RenderFragmentHandle
+
+proc moveFragment*(
+    tree: RenderFragments,
+    handle: RenderFragmentHandle,
+    destination: RenderFragmentDestination,
+    position: Natural,
+): RenderFragmentHandle
+
+proc removeFragment*(
+    tree: RenderFragments,
+    handle: RenderFragmentHandle,
+)
+```
+
+- [x] Use explicit `attachChildFragment` and `attachRootFragment` naming.
+- [x] Keep physical node/list insertion under separate, clearly named APIs.
+- [x] Support atomic movement/reordering without a transient detached state.
+- [x] Return a refreshed handle from every operation that advances its version.
+
+### Tree-owned, generation-stamped handles
+
+`RenderCursor` currently combines a node location with an implicit fragment
+reference. It does not identify the owning tree or the version of that tree or
+fragment. Separate the concepts:
+
+- `RenderFragmentHandle` identifies a persistent replacement slot.
+- `RenderNodeCursor` identifies a node in a particular fragment/base version.
+
+Both types should be opaque value types. A fragment handle should internally
+carry the equivalent of:
+
+```text
+treeId
+treeEpoch
+layerEpoch
+fragmentId
+fragmentVersion
+```
+
+The `RenderFragments` tree should own a registry of fragment records, and graph
+edges should reference registry IDs rather than externally mutable fragment
+objects.
+
+Generation scopes should remain independent:
+
+- `clear` advances the tree epoch.
+- Replacing a whole layer advances that layer's epoch and detaches its fragments.
+- Replacing one fragment advances only that fragment's version.
+- Removing a fragment marks it detached and invalidates its handle.
+- Renderer target and atlas generations belong to renderer messages, not the UI
+  fragment tree.
+
+Do not use a single global version for ordinary fragment replacements; changing
+one view must not invalidate every other view's handle.
+
+- [x] Reject handles from another tree.
+- [x] Reject stale tree, layer, and fragment generations.
+- [x] Reject detached handles.
+- [x] Reject node cursors from an older fragment version.
+- [x] Return a structured rejection status for expected stale-message handling.
+- [x] Do not rely on `assert` for public validation, because danger builds remove
+      assertions.
+
+### Controlled topology mutation
+
+Raw access to `RenderList.nodes`, `rootIds`, `Renders.layers`, mutable fragment
+layers, or mutable nodes can leave fragment traversal metadata stale.
+
+- [x] Do not return `var RenderList` from a fragment tree.
+- [x] Expose node reads as immutable values or lent read-only references.
+- [x] Add a controlled `updateNode` operation for changing visual properties.
+- [x] Preserve or reject changes to topology fields such as `parent`,
+      `childCount`, and `zlevel` in `updateNode`.
+- [x] Copy an existing `Renders` when wrapping it unless exclusive ownership can
+      genuinely be enforced.
+- [ ] Add debug validation for roots, parents, child ordering, attachment state,
+      and cycles.
+
+A controlled node update lets NimKit retain a stable view shell while changing
+its frame, background, shadow, or clipping properties without detaching cached
+child fragments.
+
+### Monolithic materialization
+
+Add a compatibility operation:
+
+```nim
+proc materialize*(tree: RenderFragments): Renders
+```
+
+It should produce a fresh monolithic tree by traversing logical fragment edges,
+then recompute physical indexes, parents, roots, and child counts. It must
+preserve exact layer, root, sibling, clipping, and transform order.
+
+- [x] Make materialization deterministic.
+- [x] Keep the returned tree independent of subsequent fragment mutations.
+- [x] Use materialization for diagnostics, differential tests, public
+      `buildRenders`, and compatibility rendering.
+
+## NimKit retained render scene
+
+### Scene ownership
+
+Introduce a `RenderScene` owned by a window/content render root. It should own:
+
+- The FigDraw `RenderFragments` tree.
+- A registry of cached view contributions.
+- Frame and resource generations.
+- Retired resource manifests awaiting safe release.
+
+Give each `View` a stable monotonic `RenderViewId`. Store fragment handles in the
+scene's `ViewRenderEntry`, not directly on the view: handles belong to one
+fragment tree, while a view can move between windows or be rendered by a
+diagnostic scene.
+
+- [x] Assign stable view IDs without retaining removed views.
+- [x] Mark entries encountered during each scene reconciliation.
+- [x] Detach and sweep entries not encountered in the completed traversal.
+- [x] Reuse a view ID in a different scene by creating scene-local fragments.
+
+### Composite view contribution
+
+A view cannot be represented safely as one replaceable fragment. Current drawing
+can produce normal children, escaped siblings, and roots on additional layers.
+Use a composite entry:
+
+```text
+view slot
+└── stable placement transform fragment
+    ├── stable shell fragment      background, shadow, clipping
+    │   └── stable content transform fragment
+    │       ├── replaceable self fragment
+    │       ├── child view slot
+    │       └── child view slot
+    └── stable escaped-content transform fragment
+        └── escaped fragment       exterior focus ring or chrome
+
+layer-root transform fragments     popup, focus, tooltip, future overlays
+```
+
+The placement and content fragments each contain one `nkTransform` node updated
+through the controlled node API. Placement tracks the view frame; clipped and
+escaped content transforms track the negative bounds origin. Their fragment IDs,
+the shell, self drawing, escaped drawing, and child slots remain attached when a
+view or ancestor moves or scrolls. The shell remains the background and clipping
+parent. Rebuilding a view's own drawing replaces the self fragment without
+disturbing its child-view slots.
+
+Preserve these existing semantics:
+
+- Normal view content and same-layer descendants are children of the shell and
+  inherit its clipping and placement transform.
+- Exterior focus rings and similar content using `renderViewParent` remain
+  siblings following the view slot, outside the view's own clip.
+- A view whose effective draw level differs from its parent is a layer root.
+- Popup, focus-ring, tooltip, and future accessibility-overlay roots retain
+  depth-first view traversal order within their layers.
+- Dynamic layer appearance and disappearance must not leave stale `OrderedTable`
+  insertion order. Reconcile layer order explicitly each frame.
+
+### DrawContext capture
+
+`DrawContext` currently writes into one monolithic `Renders` and represents its
+normal and escaped parents as `FigIdx`. Refactor the internal drawing target so a
+single view draw can be captured into separate outputs:
+
+- Normal content beneath the view shell.
+- Escaped sibling content beneath the shell's parent.
+- Root content grouped by explicit `ZLevel`.
+
+Temporary internal anchor nodes are an acceptable first implementation if they
+are removed while finalizing each captured `RenderList`. Existing public drawing
+helpers should continue to return usable local `FigIdx` values during the draw.
+
+- [x] Build or reuse the shell during scene reconciliation.
+- [x] Run `view.draw` only when its local contribution is dirty or its render
+      context changed.
+- [x] Replace each affected output fragment atomically after a successful draw.
+- [x] Reconcile child, sibling, root, and layer slots independently of redrawing
+      clean view content.
+
+### Display invalidation
+
+Current descendant invalidation propagates `xNeedsDisplay` through every
+ancestor. That would cause fragment caching to redraw the entire ancestor chain.
+Separate:
+
+- A view's local drawing revision.
+- Aggregate descendant-dirty state.
+- Damage rectangles used to schedule a frame.
+- Structural and inherited render-context revisions.
+
+Replace recursive blanket dirty-flag clearing with revision acknowledgement:
+capture the revision before drawing and mark only that revision as rendered. An
+invalidation raised during layout or drawing must remain pending.
+
+- [x] Make local invalidation advance only the target view's drawing revision.
+- [x] Propagate damage/descendant state without advancing ancestor drawing
+      revisions.
+- [x] Include effective appearance, local placement, draw level, and relevant
+      geometry in the view cache key. Include the visible rectangle only for
+      drawing that reads it.
+- [x] Invalidate/reconcile descendants when an ancestor changes an inherited
+      render context.
+
+The completed implementation captures drawing in bounds coordinates and keeps
+frame placement and bounds-origin scrolling in stable transform fragments.
+`DrawContext.visibleRect` records a dependency when drawing reads it, so
+virtualized drawing is recaptured as its clip moves while ordinary drawing remains
+cached. Explicit-layer output is rooted under an equivalent absolute content
+transform.
+
+## Resource manifests
+
+Each cached view contribution should retain the font and image resources used to
+build it. At the frame boundary, create a fresh merged manifest from all live,
+attached contributions rather than maintaining incremental resource reference
+counts initially.
+
+- [x] Add manifest merge support.
+- [x] Associate fragment/resource versions with the scene frame generation.
+- [x] Exclude manifests belonging only to removed or replaced fragments from the
+      new live merge.
+- [x] Retain replaced manifests until the frame that could reference them has
+      completed or been acknowledged.
+- [x] Replay the current merged live manifest after atlas recovery.
+- [x] Keep atlas generation separate from UI fragment-handle generations.
+
+For direct synchronous rendering, old resources can be released after the frame
+boundary. For threaded rendering, use the existing render-ID acknowledgement and
+resource-lease mechanism.
+
+## Renderer-thread boundary
+
+Do not move a `RenderFragments` graph to the renderer thread while the UI scene
+retains handles into it. That would alias mutable fragment objects and node
+storage across threads.
+
+Implemented behavior:
+
+- Direct static rendering reconciles and renders the mutable application-thread
+  fragment graph synchronously without materializing `Renders`.
+- Public/diagnostic `buildRenders` retains compatibility by materializing lazily
+  and caching the monolithic result until the scene changes.
+- The application scene builds a cumulative update from the last acknowledged
+  scene generation. Every update contains the complete view placement order and
+  node payloads only for contributions changed after that baseline.
+- Updates are move-only and carry copied dirty node sequences plus font/image IDs.
+  Placement-only updates carry value-type cache keys and mutate the renderer's
+  retained transform nodes. They never carry application-thread resource handles
+  or FigDraw fragment handles.
+- The dedicated renderer owns a separate `RenderScene` and moves received node
+  payloads into its own fragment graph before rendering it directly.
+- The bounded two-entry channel coalesces superseded frames. Because the newest
+  update is cumulative from the acknowledged generation, dropping an intermediate
+  update cannot omit one of its fragment replacements.
+- Target, render, scene, and baseline generations are checked before mutating the
+  renderer replica. New scenes, changed layer sets, target replacement, and an
+  explicitly forced recovery are full-update ordering barriers.
+- Render acknowledgement advances the application's cumulative baseline and
+  releases retired fragment resource manifests. Rejection clears that baseline,
+  drops rejected leases, and forces the next update to be full.
+- Atlas recovery uses the transferred live font/image ID set to replay and retain
+  only resources referenced by the accepted scene.
+- No mutable fragment graph crosses the renderer-thread boundary.
+
+The complete threaded update is stamped with the equivalent of:
+
+```text
+targetGeneration
+renderId
+scene identity
+acknowledged base generation
+current scene/resource generation
+```
+
+- [x] Bound and coalesce queued replacements by fragment and generation.
+- [x] Treat clear, layer replacement, target replacement, and full snapshots as
+      ordering barriers.
+- [x] Reject obsolete target, scene, layer, atlas, and fragment generations.
+- [x] Acknowledge the applied frame/update generation before releasing payloads
+      and resources.
+- [x] Send a full current snapshot after target replacement or when a delta chain
+      cannot be applied safely.
+
+## Tests
+
+### FigDraw safety and structure
+
+- [x] Reject a fragment handle used with a foreign tree.
+- [x] Reject handles retained across `clear` and layer replacement.
+- [x] Reject an older handle after a successful replacement.
+- [x] Reject detached and removed fragment handles.
+- [x] Replace a fragment with zero roots and later restore one or many roots at
+      the same position.
+- [x] Cover fragments beneath base nodes and beneath nodes in other fragments.
+- [x] Cover root fragments, multiple layers, physical node insertions, movement,
+      removal, and reordering.
+- [x] Ensure public APIs cannot make traversal metadata stale.
+
+### NimKit equivalence
+
+Build scenes through both the legacy monolithic path and the fragment path, then
+compare a canonical traversal or renderer-operation stream rather than physical
+Fig indexes.
+
+- [x] Nested view updates and sibling ordering.
+- [x] Same-layer versus cross-layer descendants.
+- [x] Clips, transforms, shadows, and inherited visibility.
+- [x] Exterior focus rings and other escaped sibling content.
+- [x] Inline popups, tooltip layers, focus-ring layers, and overlay ordering.
+- [x] Hidden, removed, reinserted, and reordered views.
+- [x] Appearance-generation and ancestor-geometry changes.
+- [x] Scrolling updates placement transforms without recapturing drawing that does
+      not read `visibleRect`, while visibility-dependent drawing is recaptured.
+- [x] Font and image replacement and removed-view resources.
+- [x] Atlas recovery using only the current live manifest.
+
+### Operation counts and threads
+
+- [x] Initial frame draws every participating view once.
+- [x] A clean frame invokes no view `draw` methods.
+- [x] A leaf display invalidation rebuilds only the leaf's own dirty fragments.
+- [x] Structural reconciliation does not redraw unaffected view content.
+- [x] Fragment-backed and monolithic rendering emit equivalent renderer
+      operations.
+- [x] Coalesced thread updates apply the newest valid replacement.
+- [x] Clear and target-replacement barriers discard stale queued updates.
+- [x] Resource leases survive until the corresponding renderer acknowledgement.
+
+## Performance baseline
+
+`tests/benchmark_render_fragments.nim` is a release-mode diagnostic benchmark,
+not a timing-threshold test. It measures flat trees from 100 through 10,000
+views, uses the median of seven samples, and separately exercises clean frames,
+root-dirty frames, leaf-dirty frames, scene materialization, layer replacement,
+and fragment reordering.
+
+On an Apple M3 Pro (12 cores), macOS 15.6, Nim 2.2.10, ARC with threads enabled,
+the following medians were observed. Times are microseconds per operation:
+
+| Views | monolithic cached | monolithic root dirty | monolithic leaf dirty | scene cached | scene root dirty | scene leaf dirty | materialize |
+|------:|------------------:|----------------------:|----------------------:|-------------:|-----------------:|-----------------:|------------:|
+| 100 | 13.87 | 471.83 | 467.30 | 2.97 | 411.43 | 413.58 | 12.35 |
+| 1,000 | 114.31 | 5,002.16 | 4,761.46 | 4.73 | 4,190.01 | 4,207.23 | 109.66 |
+| 5,000 | 725.07 | 29,584.12 | 29,409.19 | 28.18 | 26,306.13 | 25,819.05 | 629.54 |
+| 10,000 | 1,527.02 | 61,390.76 | 61,047.55 | 55.23 | 54,694.61 | 55,140.80 | 1,383.33 |
+
+The completed direct-renderer path keeps the same linear reconciliation cost
+while narrowing `draw` calls and fragment replacement to dirty contributions.
+Scene-update timings no longer include monolithic materialization.
+
+The root- and leaf-dirty timings remain similar for these deliberately empty
+views because both still traverse the view hierarchy and merge live manifests.
+The leaf path runs `draw` only for the leaf, so views with text layout, images,
+SVGs, or other meaningful draw work avoid rebuilding those clean contributions.
+The benchmark shows no new complexity cliff through 10,000 view fragments,
+remains in the same order of magnitude as monolithic rebuilding, and removes the
+71--138 ns/node materialization pass from normal synchronous rendering.
+
+On this run, replacing a 10,000-node compatibility scene took 1.10 ms with one
+layer and 0.84 ms with 32 layers. Materializing 10,000 independent fragment
+slots took 1.24 ms, a 5,000-deep nested fragment chain took 0.80 ms, and replacing
+one leaf remained 0.14--0.20 us across populations of 100 through 10,000.
+
+The benchmark exposed two FigDraw usage cliffs and drove API changes before the
+dependency pin was advanced:
+
+- Materialization had accidentally copied the fragment-entry table once per
+  visited node. It now traverses borrowed internal topology and is linear.
+- Reversing every sibling with individual `moveFragment` calls is quadratic,
+  because each isolated move performs a linear sequence edit. At 5,000 slots a
+  two-way reversal took 1,169.11 ms. The new `reorderChildFragments` and
+  `reorderRootFragments` operations reconcile the complete sibling order in a
+  single linear pass; the same 5,000-slot two-way reversal took 0.94 ms.
+
+NimKit reconciliation should therefore use an isolated move for isolated
+changes and the bulk APIs whenever it already knows a complete sibling order.
+
+`tests/benchmark_markdown_scroll.nim` profiles a more realistic dirty-frame
+workload: the repository's 36,005-byte README in a 760 x 540 `MarkdownView`,
+scrolled bidirectionally over 240 measured frames after 20 warmup frames. It
+measures CPU-side view drawing/reconciliation, bounded-channel handoff,
+renderer-replica application, acknowledgement, and a direct walk of the
+renderer-facing topology; GPU execution is deliberately excluded. The renderer
+stages are serialized in the diagnostic so its CPU total is comparable even
+though production runs them on separate threads. The table reports the median of
+five complete benchmark runs.
+
+On the same Apple M3 Pro, the pre-PR monolithic path and completed fragment-native
+path measured:
+
+| Pipeline | wall median | wall p95 | CPU median | CPU p95 | prepare median | transfer median | apply/ack median | traversal median |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| pre-PR monolithic | 11.545 ms | 12.308 ms | 11.544 ms | 12.306 ms | 11.023 ms | 0.000 ms | 0.001 ms | 0.455 ms |
+| fragment-native | 0.047 ms | 0.051 ms | 0.047 ms | 0.050 ms | 0.024 ms | 0.001 ms | 0.002 ms | 0.014 ms |
+
+The retained transform design reduces median CPU cost by 99.6%, about 246x, in
+this continuously dirty scrolling workload. The Markdown text view was captured
+zero times during the 240 measured frames: scrolling changes its ancestor content
+transform, but does not clone or rebuild the document's text nodes. Of 1,200 view
+placements, 238 (19.8%) carried a changed drawing contribution for the moving
+scrollbar; the clip view, document, scroll-view background, and other drawing were
+reused.
+
+The follow-up profile found that the initial 1.483 ms fragment result was not
+fragment traversal overhead. Reading a `ViewRenderEntry` out of a Nim `Table` by
+value deep-copied its cached `RenderList`, including the clean Markdown glyph
+arrays, in capture checks, reconciliation, and update transfer. Reconciliation now
+mutates table entries in place. The same view walk also copied the immutable
+`Appearance` theme snapshot for every view and retained a whole snapshot merely to
+compare generations; the render walk now borrows appearances synchronously and
+caches only `ThemeGeneration`.
+
+A second view-design pass separated bounds-origin movement from self drawing.
+Stable clipped and escaped content transforms now absorb scrolling through the
+generic `View.bounds=` path as well as `ClipView`, rather than relying on a
+Markdown-specific call site. A focused test verifies that a normal bounds-origin
+update can reach an independent renderer replica with zero view captures, while a
+descendant slot that reads `DrawContext.visibleRect` is still recaptured.
+
+Each view now owns an ordered set of stable render slots. Existing widgets
+automatically draw into a default content slot, while composite widgets can split
+their drawing across `drawUnderlay`, `draw`, and `drawOverlay` phases to implement
+patterns such as `[header] [content] [footer]` around child views. Slot revisions,
+resource manifests, escaped roots, explicit layers, replica updates, and fragment
+identities are all retained independently.
+
+Text views use one slot per visual glyph line, with separate selection/find and
+caret slots. Dirty Markdown and editor updates therefore replace only visually
+changed lines instead of transferring the complete glyph arrangement. Monospaced
+text views similarly retain their surface, viewport dependency, visible rows, and
+cursor independently; terminal cell changes and cursor motion no longer rebuild
+unchanged rows.
+
+FigDraw's `renderRoot(RenderFragments)` iterates `levels`, `roots`, and recursive
+`children` cursors directly. Fragment attachment builds its `RenderEntries`
+tracking metadata eagerly, and the child iterator only rebuilds that metadata if
+it is not ready. The renderer does not call `pairs`, clone a `RenderList`, or call
+`materialize`; that separate API remains limited to compatibility and diagnostic
+paths. The benchmark walked 15,600 retained nodes (65 per frame, including
+placement and content transforms) in 0.014 ms/frame median. FigDraw's child
+iterator currently copies small `RenderChild` metadata sequences returned by its
+lookup table; the long-running sample identifies that as the main remaining
+traversal micro-cost. It does not copy `Fig` nodes or build a render tree, and at
+0.014 ms here it is not a Merenda-side performance cliff. Avoiding that metadata
+copy is a separate FigDraw optimization.
+
+## Follow-up work
+
+- [x] Generalize the Markdown viewer's retained translate-node scrolling
+      optimization and apply it consistently to every scrolling view.
+- [x] Investigate whether monospaced text views, including editors and terminals,
+      can use Fig fragments to make updates cheaper.
+- [x] Audit the view implementations for every current widget and adopt stable
+      fragment slots where appropriate, following patterns such as `[header]
+      [content] [footer]`.
+- [x] Optimize dirty Markdown updates with visual-line render fragments. Scrolling
+      and selection changes retain unchanged glyph lines, and renderer updates
+      transfer only the line, underlay, or caret slots that actually changed.
+
+## Delivery sequence
+
+1. Add failing FigDraw tests for foreign, stale, detached, empty, and raw-mutation
+   cases.
+2. Implement persistent root/child slots, opaque handles, controlled mutation,
+   scoped generations, and `materialize` in FigDraw.
+3. Add NimKit `RenderScene`, stable view IDs, composite view entries, and
+   revision-based invalidation behind a diagnostic/feature switch.
+4. Build monolithic and fragment scenes side by side and establish canonical
+   equivalence and operation-count tests.
+5. Add per-contribution manifests, live-frame merging, and retirement by frame or
+   acknowledgement.
+6. Enable fragment-native rendering for the direct static renderer.
+7. Send cumulative move-only fragment updates to a renderer-owned scene and
+   acknowledge applied generations before releasing resources.
+
+## Deferred work
+
+- Rasterized view/texture caching.
+- Mutable fragment graphs shared across threads.
+- Dynlib fragment integration.

--- a/tests/kosmo/markdownactivation.nim
+++ b/tests/kosmo/markdownactivation.nim
@@ -1,0 +1,184 @@
+import std/[options, os, strutils, tempfiles, unittest]
+
+import merenda/nimkit
+import merenda/kosmo/kosmo
+
+const RepositoryRoot = currentSourcePath().parentDir.parentDir.parentDir
+
+suite "Kosmo Markdown activation":
+  test "returning to an unchanged Markdown tab reuses its rendered preview":
+    let frontend = newKosmoApplication(
+      newApplication("Markdown activation"), monitorsGitStatus = false
+    )
+    defer:
+      frontend.close()
+    frontend.window.setContentView(frontend.contentView)
+    frontend.contentView.frame = rect(0, 0, 1000, 700)
+    frontend.contentView.layoutSubtreeIfNeeded()
+    require frontend.openPath(RepositoryRoot / "TODO-fragments.md")
+    let first = frontend.editorPane.markdownView
+    require first.waitForMarkdownParsing()
+    discard buildRenders(first)
+    first.textView().selectedRange = initTextRange(2, 3)
+    first.scrollView().scrollTo(initPoint(0, 24))
+    let firstScrollOffset = first.scrollView().contentOffset()
+    check firstScrollOffset.y > 0
+    let identifier = frontend.documentTabs.selectedDocumentTabIdentifier
+    require frontend.openPath(RepositoryRoot / "README.md")
+    let second = frontend.editorPane.markdownView
+    let distinctPreviews = second != first
+    require distinctPreviews
+    require second.waitForMarkdownParsing()
+    discard buildRenders(second)
+    for iteration in 0 ..< 3:
+      discard iteration
+      require frontend.documentTabs.selectDocumentTabWithIdentifier(identifier)
+      check not frontend.editorPane.markdownView.isMarkdownParsing()
+      let restoredFirstPreview = frontend.editorPane.markdownView == first
+      check restoredFirstPreview
+      check first.textView().selectedRange == initTextRange(2, 3)
+      check first.scrollView().contentOffset() == firstScrollOffset
+      require frontend.editorPane.markdownView.waitForMarkdownParsing()
+      discard buildRenders(frontend.editorPane.markdownView)
+      for tab in frontend.editorView.editor.tabs():
+        check not tab.modified
+      require frontend.documentTabs.selectDocumentTabAtIndex(1)
+      let restoredSecondPreview = frontend.editorPane.markdownView == second
+      check restoredSecondPreview
+      check not frontend.editorPane.markdownView.isMarkdownParsing()
+      require frontend.editorPane.markdownView.waitForMarkdownParsing()
+    require frontend.documentTabs.selectDocumentTabWithIdentifier(identifier)
+    require frontend.documentTabs.closeDocumentTabAtIndex(0)
+    check first.markdown == ""
+    require first.waitForMarkdownParsing()
+    check second.markdown.len > 0
+
+  test "preview edit commands cannot modify hidden Markdown source":
+    let
+      root = createTempDir("kosmo-markdown-editing-", "")
+      path = root / "preview.md"
+      frontend = newKosmoApplication(
+        newApplication("Markdown editing"), monitorsGitStatus = false
+      )
+      pasteboard = generalPasteboard()
+      previousClipboard = pasteboard.plainText()
+    writeFile(path, "# Preview\n\nUnchanged source\n")
+    defer:
+      discard pasteboard.setPlainText(previousClipboard)
+      frontend.close()
+      removeFile(path)
+      removeDir(root)
+    frontend.window.setContentView(frontend.contentView)
+    require frontend.openPath(path)
+    require frontend.editorPane.markdownView.waitForMarkdownParsing()
+    let
+      id = frontend.editorView.editor.tabs()[0].id
+      original = frontend.editorView.editor.bufferText(id).get
+    require frontend.editorView.editor.handleKey("i")
+    discard pasteboard.setPlainText("unexpected edit")
+    let primary = frontend.shortcutProfile().primaryModifiers()
+    for target in [
+      Responder(frontend.editorPane.markdownView),
+      Responder(frontend.editorPane.markdownView.textView()),
+    ]:
+      require frontend.window.makeFirstResponder(target)
+      discard frontend.window.sendAction(actionSelector(KosmoPasteAction))
+      for key in [keyA, keyC, keyX, keyV, keyZ]:
+        discard frontend.window.dispatchKeyDown(
+          KeyEvent(key: key, keyCode: key.ord, modifiers: primary)
+        )
+      check "Preview" in pasteboard.plainText()
+      discard frontend.window.dispatchKeyDown(
+        KeyEvent(text: "q", key: keyQ, keyCode: keyQ.ord)
+      )
+      for action in ["selectAll", "cut", "paste", "undo", "redo"]:
+        discard frontend.window.sendAction(actionSelector(action))
+      check frontend.editorView.editor.bufferText(id).get == original
+      check not frontend.editorView.editor.tabs()[0].modified
+
+  test "each pane retains its three most recently used previews":
+    let
+      root = createTempDir("kosmo-markdown-lru-", "")
+      frontend =
+        newKosmoApplication(newApplication("Markdown LRU"), monitorsGitStatus = false)
+    var paths: seq[string]
+    for index in 0 ..< 4:
+      let path = root / ("preview-" & $index & ".md")
+      writeFile(path, "# Preview " & $index & "\n")
+      paths.add path
+    defer:
+      frontend.close()
+      for path in paths:
+        removeFile(path)
+      removeDir(root)
+    frontend.window.setContentView(frontend.contentView)
+    var
+      identifiers: seq[string]
+      previews: seq[MarkdownView]
+    for index in 0 ..< 3:
+      require frontend.openPath(paths[index])
+      identifiers.add frontend.documentTabs.selectedDocumentTabIdentifier
+      previews.add frontend.editorPane.markdownView
+      require previews[^1].waitForMarkdownParsing()
+    require frontend.documentTabs.selectDocumentTabWithIdentifier(identifiers[0])
+    let promotedFirst = frontend.editorPane.markdownView == previews[0]
+    check promotedFirst
+    require frontend.openPath(paths[3])
+    identifiers.add frontend.documentTabs.selectedDocumentTabIdentifier
+    previews.add frontend.editorPane.markdownView
+    require previews[^1].waitForMarkdownParsing()
+    check previews[1].markdown == ""
+    check previews[0].markdown.len > 0
+    check previews[2].markdown.len > 0
+    require frontend.documentTabs.selectDocumentTabWithIdentifier(identifiers[0])
+    let restoredPromotedPreview = frontend.editorPane.markdownView == previews[0]
+    check restoredPromotedPreview
+    check not frontend.editorPane.markdownView.isMarkdownParsing()
+    require frontend.documentTabs.selectDocumentTabWithIdentifier(identifiers[2])
+    let restoredRecentPreview = frontend.editorPane.markdownView == previews[2]
+    check restoredRecentPreview
+    check not frontend.editorPane.markdownView.isMarkdownParsing()
+    require frontend.documentTabs.selectDocumentTabWithIdentifier(identifiers[1])
+    let recreatedEvictedPreview = frontend.editorPane.markdownView != previews[1]
+    check recreatedEvictedPreview
+    check frontend.editorPane.markdownView.isMarkdownParsing()
+    require frontend.editorPane.markdownView.waitForMarkdownParsing()
+    check frontend.editorPane.markdownView.markdown.strip() == "# Preview 1"
+
+  test "source edits refresh the cached preview and save normally":
+    let
+      root = createTempDir("kosmo-markdown-save-", "")
+      path = root / "preview.md"
+      frontend =
+        newKosmoApplication(newApplication("Markdown save"), monitorsGitStatus = false)
+    writeFile(path, "# Original\n")
+    defer:
+      frontend.close()
+      removeFile(path)
+      removeDir(root)
+    frontend.window.setContentView(frontend.contentView)
+    frontend.contentView.frame = rect(0, 0, 700, 500)
+    frontend.contentView.layoutSubtreeIfNeeded()
+    require frontend.openPath(path)
+    let preview = frontend.editorPane.markdownView
+    let buttonBounds = frontend.editorPane.markdownControls.modeButton.bounds()
+    let buttonPoint =
+      initPoint(buttonBounds.size.width / 2, buttonBounds.size.height / 2)
+    require frontend.window.clickAt(
+      frontend.editorPane.markdownControls.modeButton.pointToWindow(buttonPoint)
+    )
+    require frontend.editorView.editor.handleKey("i")
+    require frontend.editorView.editor.handleTextInput("Updated ")
+    require frontend.editorView.editor.handleKey("Esc")
+    frontend.editorView.refresh()
+    check frontend.editorView.editor.tabs()[0].modified
+    require frontend.window.clickAt(
+      frontend.editorPane.markdownControls.modeButton.pointToWindow(buttonPoint)
+    )
+    let reusedPreview = frontend.editorPane.markdownView == preview
+    check reusedPreview
+    require preview.waitForMarkdownParsing()
+    check "Updated" in preview.markdown
+    discard frontend.window.sendAction(actionSelector(KosmoSaveAction))
+    check not frontend.editorView.editor.tabs()[0].modified
+    check "Updated" in readFile(path)

--- a/tests/kosmo/markdownactivation.nim
+++ b/tests/kosmo/markdownactivation.nim
@@ -3,19 +3,25 @@ import std/[options, os, strutils, tempfiles, unittest]
 import merenda/nimkit
 import merenda/kosmo/kosmo
 
-const RepositoryRoot = currentSourcePath().parentDir.parentDir.parentDir
+const FixtureDirectory = currentSourcePath().parentDir / "fixtures"
 
 suite "Kosmo Markdown activation":
   test "returning to an unchanged Markdown tab reuses its rendered preview":
-    let frontend = newKosmoApplication(
-      newApplication("Markdown activation"), monitorsGitStatus = false
-    )
+    let
+      root = createTempDir("kosmo-markdown-activation-", "")
+      secondPath = root / "second.md"
+      frontend = newKosmoApplication(
+        newApplication("Markdown activation"), monitorsGitStatus = false
+      )
+    writeFile(secondPath, "# Second preview\n\nA separate cached document.\n")
     defer:
       frontend.close()
+      removeFile(secondPath)
+      removeDir(root)
     frontend.window.setContentView(frontend.contentView)
     frontend.contentView.frame = rect(0, 0, 1000, 700)
     frontend.contentView.layoutSubtreeIfNeeded()
-    require frontend.openPath(RepositoryRoot / "TODO-fragments.md")
+    require frontend.openPath(FixtureDirectory / "markdown-activation.md")
     let first = frontend.editorPane.markdownView
     require first.waitForMarkdownParsing()
     discard buildRenders(first)
@@ -24,7 +30,7 @@ suite "Kosmo Markdown activation":
     let firstScrollOffset = first.scrollView().contentOffset()
     check firstScrollOffset.y > 0
     let identifier = frontend.documentTabs.selectedDocumentTabIdentifier
-    require frontend.openPath(RepositoryRoot / "README.md")
+    require frontend.openPath(secondPath)
     let second = frontend.editorPane.markdownView
     let distinctPreviews = second != first
     require distinctPreviews

--- a/tests/kosmo/panelshortcuts.nim
+++ b/tests/kosmo/panelshortcuts.nim
@@ -18,7 +18,121 @@ proc presentSyntheticWindow(app: Application, frontend: KosmoApplication) =
 proc firstResponderIs(window: Window, expected: Responder): bool =
   window.firstResponder == expected
 
+proc keyWindowIs(app: Application, expected: Window): bool =
+  app.keyWindow() == expected
+
+proc controlKeyEvent(key: Key): KeyEvent =
+  KeyEvent(key: key, keyCode: key.ord, modifiers: {kmControl})
+
 suite "Kosmo synthetic panel shortcuts":
+  test "pane navigation focuses a displayed terminal instead of its detached editor":
+    let
+      app = newApplication("Kosmo Terminal Pane Focus Test")
+      frontend = newKosmoApplication(app, monitorsGitStatus = false)
+      terminal = newKosmoTerminalView()
+    defer:
+      frontend.close()
+    app.presentSyntheticWindow(frontend)
+    require frontend.window.sendAction(actionSelector(KosmoSplitVerticalAction))
+    frontend.contentView.layoutSubtreeIfNeeded()
+    require frontend.openDocument(
+      newKosmoPaneDocument("test-terminal", "Terminal", terminal)
+    )
+    let groups = frontend.editorGroups()
+    require groups.len == 2
+    require frontend.window.dispatchKeyDown(commandNumberEvent(2))
+    require frontend.window.firstResponderIs(groups[0].editorView)
+
+    for direction in [keyL, keyW]:
+      require frontend.window.dispatchKeyDown(controlKeyEvent(keyW))
+      require frontend.window.dispatchKeyDown(controlKeyEvent(direction))
+      check frontend.window.firstResponderIs(terminal)
+      check groups[1].pane.contentView == View(terminal)
+      check terminal.window() == Responder(frontend.window)
+      require frontend.window.dispatchKeyDown(commandNumberEvent(2))
+
+  test "numbered shortcuts repeatedly return from the sidebar to terminal content":
+    let
+      app = newApplication("Kosmo Terminal Number Focus Test")
+      frontend = newKosmoApplication(app, monitorsGitStatus = false)
+      terminal = newKosmoTerminalView()
+    defer:
+      frontend.close()
+    app.presentSyntheticWindow(frontend)
+    require frontend.openDocument(
+      newKosmoPaneDocument("test-terminal", "Terminal", terminal)
+    )
+    for iteration in 0 ..< 5:
+      require app.performMenuKeyEquivalent(commandNumberEvent(1))
+      check frontend.window.firstResponderIs(frontend.fileTree)
+      require app.performMenuKeyEquivalent(commandNumberEvent(2))
+      check frontend.window.firstResponderIs(terminal)
+      check frontend.editorPane.contentView == View(terminal)
+
+  test "leaving an editor cancels its pending pane prefix":
+    let
+      app = newApplication("Kosmo Pane Prefix Focus Test")
+      frontend = newKosmoApplication(app, monitorsGitStatus = false)
+      otherWindow = newWindow("Other window")
+    defer:
+      otherWindow.close()
+      frontend.close()
+    app.presentSyntheticWindow(frontend)
+    require frontend.window.dispatchKeyDown(controlKeyEvent(keyW))
+    require frontend.showFileExplorer()
+    require frontend.window.dispatchKeyDown(commandNumberEvent(2))
+    check not frontend.editorView.performKeyEquivalentInChain(
+      KeyEvent(key: keyH, keyCode: keyH.ord)
+    )
+
+    require frontend.window.dispatchKeyDown(controlKeyEvent(keyW))
+    app.activateWindow(otherWindow)
+    app.activateWindow(frontend.window)
+    check not frontend.editorView.performKeyEquivalentInChain(
+      KeyEvent(key: keyH, keyCode: keyH.ord)
+    )
+
+  test "sidebar commands from a detached pane activate the browser window":
+    let
+      app = newApplication("Kosmo Detached Sidebar Focus Test")
+      frontend = newKosmoApplication(app, monitorsGitStatus = false)
+    defer:
+      frontend.close()
+    app.presentSyntheticWindow(frontend)
+    require frontend.newEditorTab()
+    frontend.contentView.layoutSubtreeIfNeeded()
+    let
+      tabs = frontend.documentTabs
+      tabRect = tabs.documentTabRect(0)
+      start = tabs.pointToWindow(
+        initPoint(
+          tabRect.minX + tabRect.size.width * 0.5'f32,
+          tabRect.minY + tabRect.size.height * 0.5'f32,
+        )
+      )
+      drop = initPoint(
+        frontend.window.frame().size.width + 180.0'f32,
+        frontend.window.frame().size.height + 180.0'f32,
+      )
+    require frontend.window.mouseDownAt(start)
+    require frontend.window.mouseDraggedAt(drop)
+    require frontend.window.mouseUpAt(drop)
+    require frontend.detachedEditorWindows().len == 1
+    let detached = frontend.detachedEditorWindows()[0]
+    detached.contentView().layoutSubtreeIfNeeded()
+
+    app.activateWindow(detached)
+    require detached.sendAction(actionSelector(KosmoShowFileExplorerAction))
+    check app.keyWindowIs(frontend.window)
+    check frontend.window.firstResponderIs(frontend.fileTree)
+
+    app.activateWindow(detached)
+    require detached.sendAction(actionSelector(KosmoFindInFilesAction))
+    check app.keyWindowIs(frontend.window)
+    let searchFocused =
+      frontend.window.fieldEditorClient() == frontend.searchPanel.queryField
+    check searchFocused
+
   test "relative Moe saves use the active project's directory":
     let
       workspace = createTempDir("merenda-kosmo-project-save-", "")

--- a/tests/kosmo/quickopen.nim
+++ b/tests/kosmo/quickopen.nim
@@ -219,6 +219,10 @@ suite "Kosmo quick open":
     )
     check frontend.quickOpenPanel.highlightedFile() == "tests/main_spec.nim"
     check frontend.window.dispatchKeyDown(
+      KeyEvent(key: keyP, keyCode: keyP.ord, modifiers: shortcutModifiers())
+    )
+    check frontend.quickOpenPanel.highlightedFile() == "tests/main_spec.nim"
+    check frontend.window.dispatchKeyDown(
       KeyEvent(key: keyEnter, keyCode: keyEnter.ord, text: "\n")
     )
     check not frontend.quickOpenPanel.isOpen()

--- a/tests/kosmo/tabs.nim
+++ b/tests/kosmo/tabs.nim
@@ -275,7 +275,7 @@ suite "Kosmo":
     )
     check frontend.editorView.markdownMode(markdownId) == kmmSyntax
     check frontend.editorPane.contentView == View(frontend.editorView)
-    check frontend.editorPane.markdownView.markdown == ""
+    check frontend.editorPane.markdownView.markdown.strip() == source.strip()
     check not controls.hidden
     check controls.modeButton.title == "MD"
 
@@ -295,7 +295,7 @@ suite "Kosmo":
 
     check frontend.openPath(textPath)
     check frontend.editorPane.contentView == View(frontend.editorView)
-    check frontend.editorPane.markdownView.markdown == ""
+    check "## Unsaved" in frontend.editorPane.markdownView.markdown
     check controls.hidden
 
   test "Markdown preview opens local links through Kosmo tabs":
@@ -346,7 +346,7 @@ suite "Kosmo":
     check frontend.openPath(markdownPath)
     require frontend.editorPane.markdownView.waitForMarkdownParsing()
 
-    let preview = frontend.editorPane.markdownView
+    var preview = frontend.editorPane.markdownView
     check not preview.clickMarkdownLink("missing")
     check preview.clickMarkdownLink("fragment")
     check preview.clickMarkdownLink("web")
@@ -361,11 +361,13 @@ suite "Kosmo":
     check frontend.editorView.editor.tabs().len == 2
     check frontend.editorView.editor.tabs()[^1].filePath.get ==
       absolutePath(relativeTarget)
+    preview = frontend.editorPane.markdownView
     require preview.waitForMarkdownParsing()
     check frontend.editorPane.contentView == View(preview)
     check preview.markdown.strip() == "# Relative target"
 
     check frontend.openPath(markdownPath)
+    preview = frontend.editorPane.markdownView
     require preview.waitForMarkdownParsing()
     check preview.clickMarkdownLink("absolute")
     check frontend.editorView.editor.tabs().len == 3
@@ -373,6 +375,7 @@ suite "Kosmo":
       absolutePath(absoluteTarget)
 
     check frontend.openPath(markdownPath)
+    preview = frontend.editorPane.markdownView
     require preview.waitForMarkdownParsing()
     check preview.clickMarkdownLink("file URL")
     check frontend.editorView.editor.tabs().len == 4

--- a/tests/kosmo/terminalclipboard.nim
+++ b/tests/kosmo/terminalclipboard.nim
@@ -136,3 +136,47 @@ suite "Kosmo terminal clipboard commands":
       require session.pollUntilText("70 61 73 74 65 03")
       check "70 61 73 74 65 03" in
         session.screen().plainText().splitWhitespace().join(" ")
+
+suite "Kosmo terminal focus input":
+  when defined(posix):
+    test "numbered panel switches restore focus reporting and shell input":
+      let
+        app = newApplication("Kosmo Live Terminal Focus Test")
+        frontend = newKosmoApplication(app, monitorsGitStatus = false)
+        session = spawnCompactTerminalSession(
+          initTerminalSpawnOptions(
+            command =
+              "stty raw -echo; printf ready; " &
+              "dd bs=1 count=8 2>/dev/null | od -An -tx1"
+          )
+        )
+        terminal = newKosmoTerminalView(session)
+      defer:
+        terminal.close()
+        frontend.close()
+        frontend.window.close()
+      app.addWindow(frontend.window)
+      frontend.window.setContentView(frontend.contentView)
+      frontend.contentView.layoutSubtreeIfNeeded()
+      app.activateWindow(frontend.window)
+      require frontend.openDocument(
+        newKosmoPaneDocument("kosmo.test.focus-terminal", "Terminal", terminal)
+      )
+      require session.pollUntilText("ready")
+      session.processOutput("\x1b[?1004h")
+
+      let primary = frontend.shortcutProfile().primaryModifiers()
+      require app.performMenuKeyEquivalent(
+        KeyEvent(key: key1, keyCode: key1.ord, modifiers: primary)
+      )
+      require app.performMenuKeyEquivalent(
+        KeyEvent(key: key2, keyCode: key2.ord, modifiers: primary)
+      )
+      let terminalFocused = frontend.window.firstResponder() == Responder(terminal)
+      check terminalFocused
+      require frontend.window.dispatchTextInput("x")
+      require frontend.window.dispatchKeyDown(
+        KeyEvent(key: keyW, keyCode: keyW.ord, modifiers: {kmControl})
+      )
+      # Focus-out, focus-in, x, and the shell's Control-W arrive exactly once.
+      check session.pollUntilText("1b 5b 4f 1b 5b 49 78 17")

--- a/tests/kosmo/workspaceroots.nim
+++ b/tests/kosmo/workspaceroots.nim
@@ -1,0 +1,212 @@
+import std/[options, os, osproc, strutils, tempfiles, times, unittest]
+
+import merenda/nimkit
+import merenda/kosmo/kosmo
+
+suite "Kosmo workspace roots":
+  test "browser opens stay in their window after a detached pane closes":
+    let
+      root = createTempDir("kosmo-closed-pane-", "")
+      path = root / "file.txt"
+      app = newApplication("Kosmo Closed Pane")
+      frontend = newKosmoApplication(app, root, monitorsGitStatus = false)
+    writeFile(path, "contents")
+    defer:
+      frontend.close()
+      removeDir(root)
+    app.addWindow(frontend.window)
+    frontend.window.setContentView(frontend.contentView)
+    frontend.contentView.layoutSubtreeIfNeeded()
+    app.activateWindow(frontend.window)
+    require frontend.window.makeFirstResponder(frontend.editorView)
+    require frontend.newEditorTab()
+    frontend.contentView.layoutSubtreeIfNeeded()
+    let
+      tabs = frontend.documentTabs
+      bounds = tabs.documentTabRect(0)
+      start = tabs.pointToWindow(initPoint(bounds.minX + 30, bounds.minY + 12))
+      drop = initPoint(
+        frontend.window.frame().size.width + 180,
+        frontend.window.frame().size.height + 180,
+      )
+    require frontend.window.mouseDownAt(start)
+    require frontend.window.mouseDraggedAt(drop)
+    require frontend.window.mouseUpAt(drop)
+    require frontend.detachedEditorWindows().len == 1
+    let detached = frontend.detachedEditorWindows()[0]
+    app.activateWindow(detached)
+    detached.close()
+    require frontend.showFileExplorer()
+    frontend.fileTree.onOpenFile()(path, fodPermanent)
+    let models = frontend.documentTabs.documentTabModels()
+    var fileInMainWindow = false
+    for model in models:
+      if model.title == "file.txt":
+        fileInMainWindow = true
+    check fileInMainWindow
+
+  test "opening a file from a terminal restores the shortcut responder chain":
+    let
+      root = createTempDir("kosmo-open-focus-", "")
+      path = root / "file.txt"
+      app = newApplication("Kosmo Open Focus")
+      frontend = newKosmoApplication(app, root, monitorsGitStatus = false)
+      terminal = newKosmoTerminalView()
+    writeFile(path, "file contents")
+    defer:
+      frontend.close()
+      removeDir(root)
+    app.addWindow(frontend.window)
+    frontend.window.setContentView(frontend.contentView)
+    frontend.contentView.layoutSubtreeIfNeeded()
+    app.activateWindow(frontend.window)
+    require frontend.openDocument(
+      newKosmoPaneDocument("terminal", "Terminal", terminal)
+    )
+    require frontend.openPath(path)
+    let editorFocused =
+      frontend.window.firstResponder() == Responder(frontend.editorView)
+    check editorFocused
+    check frontend.window.dispatchKeyDown(
+      KeyEvent(key: key1, keyCode: key1.ord, modifiers: shortcutModifiers())
+    )
+
+  test "quick open and find in files include every added folder":
+    let
+      workspace = createTempDir("kosmo-multi-root-", "")
+      roots = @[workspace / "first", workspace / "second", workspace / "third"]
+    for root in roots:
+      createDir(root)
+      writeFile(root / "shared.txt", "needle " & root.extractFilename())
+    let
+      app = newApplication("Kosmo Multiple Roots")
+      frontend = newKosmoApplication(app, roots[0], monitorsGitStatus = false)
+    defer:
+      frontend.close()
+      removeDir(workspace)
+    app.addWindow(frontend.window)
+    frontend.window.setContentView(frontend.contentView)
+    frontend.contentView.layoutSubtreeIfNeeded()
+    app.activateWindow(frontend.window)
+    require frontend.window.makeFirstResponder(frontend.editorView)
+    for root in roots[1 .. ^1]:
+      let panel = newOpenPanel()
+      let modal = app.beginModalSession(panel.window)
+      app.endModalSession(modal)
+      panel.window.close()
+      require frontend.openPath(root)
+    check frontend.fileTree.rootPaths == roots
+    require frontend.showQuickOpen()
+    check frontend.quickOpenPanel.projectFiles().len == 3
+    frontend.quickOpenPanel.dismiss()
+    require frontend.showFindInFiles()
+    frontend.searchPanel.queryField.text = "needle"
+    require frontend.searchPanel.performSearch()
+    require frontend.searchPanel.waitForSearch()
+    check frontend.searchPanel.resultsView.matches.len == 3
+    for root in roots:
+      require frontend.showFileExplorer()
+      frontend.contentView.layoutSubtreeIfNeeded()
+      let
+        tree = frontend.fileTree
+        row = tree.rowForItem(root / "shared.txt")
+      require row >= 0
+      let
+        bounds = tree.rowItemRect(row)
+        point = tree.pointToWindow(initPoint(bounds.minX + 90, bounds.minY + 12))
+      require frontend.window.mouseDownAt(point, clickCount = 2)
+      require frontend.window.mouseUpAt(point, clickCount = 2)
+      let tabs = frontend.editorView.editor.tabs()
+      var found = false
+      for tab in tabs:
+        if tab.filePath == some(root / "shared.txt"):
+          found = true
+      check found
+      when defined(posix):
+        require frontend.window.dispatchKeyDown(
+          KeyEvent(
+            key: keyT,
+            keyCode: keyT.ord,
+            modifiers: shortcutModifiers() + {nimkit.kmShift},
+          )
+        )
+        check frontend.editorPane.contentView of KosmoTerminalView
+
+  test "quick open keeps duplicate names distinct and deduplicates overlapping roots":
+    let
+      workspace = createTempDir("kosmo-root-collisions-", "")
+      first = workspace / "one" / "project"
+      second = workspace / "two" / "project"
+    createDir(first / "nested")
+    createDir(second)
+    writeFile(first / "same.txt", "first")
+    writeFile(first / "nested" / "child.txt", "child")
+    writeFile(second / "same.txt", "second")
+    let
+      app = newApplication("Kosmo Root Collisions")
+      frontend = newKosmoApplication(app, first, monitorsGitStatus = false)
+    defer:
+      frontend.close()
+      removeDir(workspace)
+    app.addWindow(frontend.window)
+    frontend.window.setContentView(frontend.contentView)
+    frontend.contentView.layoutSubtreeIfNeeded()
+    app.activateWindow(frontend.window)
+    require frontend.openPath(second)
+    require frontend.openPath(first / "nested")
+    require frontend.showQuickOpen()
+    check frontend.quickOpenPanel.projectFiles().len == 3
+    require frontend.window.dispatchTextInput(second / "same.txt")
+    require frontend.quickOpenPanel.filteredFiles().len == 1
+    require frontend.window.dispatchKeyDown(
+      KeyEvent(key: keyEnter, keyCode: keyEnter.ord)
+    )
+    check not frontend.quickOpenPanel.isOpen()
+    var openedSecond = false
+    for tab in frontend.editorView.editor.tabs():
+      if tab.active and tab.filePath == some(second / "same.txt"):
+        openedSecond = true
+    check openedSecond
+
+  test "Git monitoring includes newly added roots and retains each root's decorations":
+    let
+      workspace = createTempDir("kosmo-roots-git-", "")
+      first = workspace / "first"
+      second = workspace / "second"
+      plain = workspace / "plain"
+      originalDirectory = getCurrentDir()
+    for root in [first, second, plain]:
+      createDir(root)
+      writeFile(root / "changed.txt", "untracked")
+    for root in [first, second]:
+      let initialization = execCmdEx("git -C " & quoteShell(root) & " init -q")
+      require initialization.exitCode == 0
+    let tree = newKosmoFileTree(first)
+    discard tree.startGitStatusMonitoring(refreshInterval = initDuration())
+    defer:
+      tree.stopGitStatusMonitoring()
+      removeDir(workspace)
+    require tree.waitForGitStatus()
+    require tree.addRootPath(second)
+    require tree.addRootPath(plain)
+    require tree.waitForGitStatus()
+    check getCurrentDir() == originalDirectory
+    for root in [first, second]:
+      check tree.outlineItemWithIdentifier(root / "changed.txt").decoration.badge == "U"
+    check tree.outlineItemWithIdentifier(plain / "changed.txt").decoration.badge == ""
+
+    removeFile(second / "changed.txt")
+    require tree.refreshGitStatus()
+    require tree.waitForGitStatus()
+    check tree.outlineItemWithIdentifier(first / "changed.txt").decoration.badge == "U"
+    check tree.outlineItemWithIdentifier(second / "changed.txt").decoration.badge == ""
+    tree.rootPath = plain
+    require tree.waitForGitStatus()
+    tree.applyGitStatus(
+      GitStatusSnapshot(
+        rootPath: first,
+        isRepository: true,
+        entries: @[GitStatusEntry(path: plain / "changed.txt", state: gfsModified)],
+      )
+    )
+    check tree.outlineItemWithIdentifier(plain / "changed.txt").decoration.badge == ""

--- a/tests/nimkit/filesearch.nim
+++ b/tests/nimkit/filesearch.nim
@@ -42,6 +42,37 @@ proc runSearch(
   check service.waitFor(result, timeoutMilliseconds = 10_000)
 
 suite "nimkit memory-mapped file search":
+  test "multiple overlapping roots share result and file limits":
+    let
+      workspace = createTempDir("merenda-search-roots-", "")
+      first = workspace / "first"
+      second = workspace / "second"
+      service = newFileSearchService()
+    createDir(first / "nested")
+    createDir(second)
+    writeFile(first / "nested" / "a.txt", "needle")
+    writeFile(second / "b.txt", "needle")
+    defer:
+      service.close()
+      removeDir(workspace)
+    let roots = @[first, first / "nested", second, second / "."]
+    let all = service.search(initFileSearchQuery(roots, "needle"))
+    require service.waitFor(all)
+    check all.result().matches.len == 2
+    check all.result().stats.discoveredFileCount == 2
+    let limited = service.search(
+      initFileSearchQuery(roots, "needle", initFileSearchOptions(maxResults = 1))
+    )
+    require service.waitFor(limited)
+    check limited.result().matches.len == 1
+    check limited.result().reason == fsfrResultLimitReached
+    let fileLimited = service.search(
+      initFileSearchQuery(roots, "needle", initFileSearchOptions(maxFiles = 1))
+    )
+    require service.waitFor(fileLimited)
+    check fileLimited.result().stats.discoveredFileCount == 1
+    check fileLimited.result().reason == fsfrFileLimitReached
+
   test "searches nested files on a Sigils worker and reports mmap usage":
     let
       root = createTempDir("merenda-file-search-", "")

--- a/tests/tkosmo.nim
+++ b/tests/tkosmo.nim
@@ -9,8 +9,10 @@ import kosmo/editorsearch
 import kosmo/filetreeinteractions
 import kosmo/matterhighlighting
 import kosmo/panelshortcuts
+import kosmo/quickopen
 import kosmo/terminalclipboard
 import kosmo/terminalsearch
+import kosmo/workspaceroots
 
 proc runeIndexOf(source, needle: string): int =
   let byteIndex = source.find(needle)

--- a/tests/tkosmo.nim
+++ b/tests/tkosmo.nim
@@ -8,6 +8,7 @@ import kosmo/config
 import kosmo/editorsearch
 import kosmo/filetreeinteractions
 import kosmo/matterhighlighting
+import kosmo/markdownactivation
 import kosmo/panelshortcuts
 import kosmo/quickopen
 import kosmo/terminalclipboard

--- a/tests/tnimkit.nim
+++ b/tests/tnimkit.nim
@@ -5,6 +5,7 @@ import nimkit/application_icon
 import nimkit/backrefs_arc
 import nimkit/diagnostics
 import nimkit/filesearch
+import nimkit/gitstatus
 import nimkit/font_layout
 import nimkit/images
 import nimkit/markdownviews


### PR DESCRIPTION
## Summary

- Unify Cmd-number and Ctrl-W pane navigation, focus the visible terminal/document responder, and clear pending key prefixes when focus changes.
- Restore keyboard focus when replacing terminal content with a file, remember active panes per window, and prevent file-browser opens from targeting closed detached panes.
- Close completed Open dialogs and consistently propagate every added browser root to Quick Open, Find in Files, and Git monitoring.
- Deduplicate overlapping search roots, disambiguate Quick Open filenames, preserve single-root API behavior, and retain independent Git badges for each root.
- Use git -C without changing the parent process working directory; only start periodic Git scans while idle to avoid continuously queued refreshes.
- Retain the three most recently used Markdown previews per pane. Returning to an unchanged cached tab reuses its rendered content, selection, and scroll position instead of reparsing it.
- Evict least-recently-used previews and clear cached content on tab/pane/frontend close without discarding source buffers or unsaved changes.
- Keep Markdown previews read-only: block editing commands from reaching hidden source buffers and route copy/select-all to rendered text.
- Add regressions for terminal focus, detached windows, three-folder workflows, multiple Git repositories, Markdown tab reuse, LRU eviction, preview commands, and source editing/saving.

## Validation

- atlas-run tests --only-errors: all four test runners passed after the Markdown/LRU changes.
- atlas-run tests kosmo --only-errors: focused Kosmo runner passed.
- atlas-run tests --compile-only src/merenda/kosmo/kosmo.nim --only-errors: standalone Kosmo compiled successfully.
- Git periodic-refresh regression passed three additional independent runs before the Markdown follow-up.
- Formatting completed; git diff --check passed.

## Markdown investigation

The TODO-fragments.md round-trip reproducer confirmed that every return previously started a fresh asynchronous parse. The selection handler itself took about 0–1 ms; the delay was in subsequent preview rebuilding. Tests now verify that cached returns do not start parsing.

The red dot is the unsaved-source indicator, not loading or Git status. Preview command forwarding to hidden editable source has been guarded; genuine unsaved edits are preserved. The exact action that originally dirtied the user's live buffer was not captured.

The three-preview limit bounds retained cache entries per pane, not total application memory in bytes. Evicted previews rebuild on demand. The installed/running Kosmo has not been replaced.

## CI reliability and version 0.16.3

- Fix a detached-launcher test race by publishing the output file atomically after both writes complete.
- Store the full Markdown regression input under tests/kosmo/fixtures/markdown-activation.md and use a small temporary second document. Tests no longer depend on the temporary root TODO-fragments.md or the evolving README.
- Select Clang on macOS and GCC on Linux explicitly. Apply --opt:none only to Linux/GCC; macOS uses normal project optimization. Job counts and cache settings are unchanged.
- Bump merenda.nimble from 0.16.2 to 0.16.3.
- Final local validation passed all four runners with both --cc:clang / normal optimization and --cc:gcc / --opt:none. Hosted CI is being verified for commit 4e93ef11.