### PR TITLE
Add Kosmo binary installer

### DIFF
--- a/.github/workflows/release-kosmo.yml
+++ b/.github/workflows/release-kosmo.yml
@@ -1,6 +1,9 @@
 name: release-kosmo
 
 on:
+  push:
+    branches:
+      - ci/update-release-binaries
   release:
     types:
       - published
@@ -26,7 +29,7 @@ permissions:
 
 env:
   NIM_VERSION: 2.2.10
-  KOSMO_RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version || '0.0.0' }}
+  KOSMO_RELEASE_VERSION: ${{ github.event.release.tag_name || (github.event_name == 'push' && github.ref == 'refs/heads/ci/update-release-binaries' && 'v0.17.0') || inputs.version || '0.0.0' }}
 
 jobs:
   build-linux:
@@ -122,7 +125,9 @@ jobs:
     timeout-minutes: 60
     env:
       MACOSX_DEPLOYMENT_TARGET: 13.0
-      NOTARIZE_MACOS: ${{ github.event_name == 'release' || inputs.notarize_macos == true }}
+      # Developer ID signing is temporarily opt-in while the signing path is
+      # being repaired. Published releases use the ad-hoc validation path.
+      NOTARIZE_MACOS: ${{ github.event_name == 'workflow_dispatch' && inputs.notarize_macos == true }}
     steps:
       - uses: actions/checkout@v5
 
@@ -424,7 +429,12 @@ jobs:
           if-no-files-found: error
 
   publish-release-assets:
-    if: github.event_name == 'release'
+    # Temporary exception: pushes to the release-repair branch replace the
+    # assets on v0.17.0 without requiring another GitHub release.
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'push' &&
+      github.ref == 'refs/heads/ci/update-release-binaries')
     needs:
       - build-linux
       - build-macos
@@ -451,7 +461,7 @@ jobs:
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || (github.event_name == 'push' && github.ref == 'refs/heads/ci/update-release-binaries' && 'v0.17.0') }}
         run: |
           gh release upload "$RELEASE_TAG" \
             dist/kosmo-linux-amd64.tar.gz \

--- a/.github/workflows/release-kosmo.yml
+++ b/.github/workflows/release-kosmo.yml
@@ -461,6 +461,7 @@ jobs:
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ github.event.release.tag_name || (github.event_name == 'push' && github.ref == 'refs/heads/ci/update-release-binaries' && 'v0.17.0') }}
         run: |
           gh release upload "$RELEASE_TAG" \

--- a/README.md
+++ b/README.md
@@ -53,7 +53,28 @@ Note: You'll want to install the most recent [Atlas](https://github.com/nim-lang
 
 ## Kosmo Install
 
-To run Kosmo you need to install the "kosmo" feature's deps with Atlas:
+Install the latest standalone Kosmo release with:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/elcritch/merenda/HEAD/install.sh | bash
+```
+
+On Linux and Windows (from Git Bash), this installs the command in
+`~/.local/bin`. On macOS it installs `Kosmo.app` in `~/Applications` and adds a
+`~/.local/bin/kosmo` command link. Add `~/.local/bin` to `PATH` if necessary.
+The installer verifies the archive against the release's `SHA256SUMS.txt`.
+
+Set `KOSMO_INSTALL_DIR` to override the application or binary directory. On
+macOS, set `KOSMO_BIN_DIR` separately to move the command link. To install a
+specific release rather than the latest one, provide its tag, for example:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/elcritch/merenda/HEAD/install.sh | \
+  KOSMO_VERSION=v0.17.0 bash
+```
+
+To build Kosmo from source, install the "kosmo" feature's dependencies with
+Atlas:
 
 ```sh
 atlas install -tuk --features:kosmo

--- a/docs/releasing-kosmo.md
+++ b/docs/releasing-kosmo.md
@@ -11,13 +11,29 @@ Each platform archive also includes the notices for Kosmo's bundled IBM Plex
 Sans and JetBrains Mono Nerd Font Mono resources. On macOS the notices live in
 the app's `Contents/Resources` directory.
 
+The root `install.sh` downloads the archive for the current operating system and
+architecture, verifies it against `SHA256SUMS.txt`, and installs it without root
+access. Its defaults are `~/.local/bin` on Linux and Windows, and
+`~/Applications/Kosmo.app` plus a `~/.local/bin/kosmo` command link on macOS.
+`KOSMO_INSTALL_DIR`, `KOSMO_BIN_DIR` (macOS), and `KOSMO_DOC_DIR` (Linux and
+Windows) override those destinations. `KOSMO_VERSION` selects a release tag;
+when unset, the installer downloads the latest release.
+
 Publishing a GitHub release runs all three builds and uploads the resulting archives to
 that release. The release tag should use the `vX.Y.Z` form; the version without the `v`
 is embedded in the executable and the macOS bundle.
 
-The workflow can also be run manually. Manual runs upload Actions artifacts but do not
-modify a GitHub release. By default, a manual macOS build is ad-hoc signed for CI
-validation only. Select `notarize_macos` to test the complete release-signing path.
+The workflow can also be run manually. Manual runs upload Actions artifacts without
+modifying a GitHub release. As a temporary release-repair exception, every push to
+`ci/update-release-binaries` embeds version `0.17.0` and replaces the assets on the
+existing `v0.17.0` release. Remove that branch/tag exception after release testing.
+Published and manual macOS builds are currently ad-hoc signed for CI validation only.
+Select `notarize_macos` on a manual run to test the disabled Developer ID signing and
+notarization path while it is being repaired.
+Because an ad-hoc-signed app can be rejected when a browser marks it as
+quarantined, direct browser downloads are not a substitute for notarized
+distribution. Use the checksum-verifying `install.sh` path for these temporary
+releases.
 
 ## macOS signing requirements
 
@@ -29,9 +45,10 @@ do not receive an automatic waiver; Apple limits fee waivers to qualifying nonpr
 organizations, accredited educational institutions, and government entities.
 
 Kosmo does not need an App Store listing, installer certificate, provisioning profile,
-or paid-app agreement. It currently uses no restricted entitlements. Its release app is
-signed with the hardened runtime and a secure timestamp, submitted with `notarytool`,
-and stapled before the final ZIP is created.
+or paid-app agreement. It currently uses no restricted entitlements. The workflow has
+an opt-in path that signs with the hardened runtime and a secure timestamp, submits the
+app with `notarytool`, and staples it before creating the final ZIP. Published releases
+temporarily skip that path and use an ad-hoc signature instead.
 
 Apple references:
 
@@ -55,7 +72,8 @@ Configure these GitHub Actions repository secrets:
 - `APPLE_TEAM_ID`: ten-character Developer Program team ID
 - `APPLE_APP_SPECIFIC_PASSWORD`: app-specific password for `notarytool`
 
-The workflow imports the certificate into an ephemeral keychain, derives the signing
-identity from the imported Developer ID certificate, and deletes the keychain at the end
-of the job. Published releases fail before building the app if any required credential
-is absent; they never fall back to an ad-hoc signature.
+When `notarize_macos` is selected on a manual run, the workflow imports the certificate
+into an ephemeral keychain, derives the signing identity from the imported Developer ID
+certificate, and deletes the keychain at the end of the job. That opt-in run fails before
+building the app if any required credential is absent. Normal published releases do not
+read these secrets while Developer ID signing is disabled.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+
+set -eu
+
+KOSMO_GITHUB_REPO="${KOSMO_GITHUB_REPO:-elcritch/merenda}"
+KOSMO_VERSION="${KOSMO_VERSION:-}"
+KOSMO_RELEASE_BASE_URL="${KOSMO_RELEASE_BASE_URL:-}"
+KOSMO_TMP_ROOT="${KOSMO_TMP_ROOT:-${TMPDIR:-/tmp}}"
+KOSMO_STAGED_PATH=""
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "install.sh: missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+cleanup() {
+  if [ -n "$KOSMO_STAGED_PATH" ] && [ -e "$KOSMO_STAGED_PATH" ]; then
+    rm -rf "$KOSMO_STAGED_PATH"
+  fi
+  if [ -n "${KOSMO_TMP_DIR:-}" ] && [ -d "$KOSMO_TMP_DIR" ]; then
+    rm -rf "$KOSMO_TMP_DIR"
+  fi
+}
+
+detect_release_archive() {
+  local os
+  local arch
+
+  os="$(uname -s 2>/dev/null || true)"
+  arch="$(uname -m 2>/dev/null || true)"
+
+  case "$os" in
+    Linux)
+      case "$arch" in
+        x86_64 | amd64) echo "linux:kosmo-linux-amd64.tar.gz" ;;
+        *) return 1 ;;
+      esac
+      ;;
+    Darwin)
+      case "$arch" in
+        arm64 | aarch64) echo "macos:kosmo-macos-arm64.zip" ;;
+        *) return 1 ;;
+      esac
+      ;;
+    MINGW* | MSYS* | CYGWIN*)
+      case "$arch" in
+        x86_64 | amd64) echo "windows:kosmo-windows-amd64.zip" ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+calculate_sha256() {
+  if has_cmd sha256sum; then
+    sha256sum "$1" | awk '{ print $1 }'
+  elif has_cmd shasum; then
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  else
+    echo "install.sh: sha256sum or shasum is required to verify the download" >&2
+    exit 1
+  fi
+}
+
+install_command() {
+  local source_bin="$1"
+  local target_name="$2"
+  local installed_bin="$KOSMO_INSTALL_DIR/$target_name"
+
+  if [ -d "$installed_bin" ] && [ ! -L "$installed_bin" ]; then
+    echo "install.sh: cannot replace directory: $installed_bin" >&2
+    exit 1
+  fi
+
+  mkdir -p "$KOSMO_INSTALL_DIR"
+  KOSMO_STAGED_PATH="$KOSMO_INSTALL_DIR/.$target_name.install.$$"
+  cp "$source_bin" "$KOSMO_STAGED_PATH"
+  chmod +x "$KOSMO_STAGED_PATH"
+  mv -f "$KOSMO_STAGED_PATH" "$installed_bin"
+  KOSMO_STAGED_PATH=""
+
+  echo "install.sh: installed Kosmo to $installed_bin" >&2
+  case ":$PATH:" in
+    *":$KOSMO_INSTALL_DIR:"*) ;;
+    *) echo "install.sh: add $KOSMO_INSTALL_DIR to PATH to run kosmo directly" >&2 ;;
+  esac
+}
+
+install_notices() {
+  local extract_dir="$1"
+
+  if [ ! -f "$extract_dir/FONT-LICENSES.md" ]; then
+    return
+  fi
+
+  mkdir -p "$KOSMO_DOC_DIR"
+  cp "$extract_dir/FONT-LICENSES.md" "$KOSMO_DOC_DIR/FONT-LICENSES.md"
+  if [ -d "$extract_dir/font-licenses" ]; then
+    rm -rf "$KOSMO_DOC_DIR/font-licenses"
+    cp -R "$extract_dir/font-licenses" "$KOSMO_DOC_DIR/font-licenses"
+  fi
+  echo "install.sh: installed bundled-font notices to $KOSMO_DOC_DIR" >&2
+}
+
+install_macos_app() {
+  local source_app="$1"
+  local installed_app="$KOSMO_INSTALL_DIR/Kosmo.app"
+  local installed_command="$KOSMO_BIN_DIR/kosmo"
+
+  if [ -d "$installed_command" ] && [ ! -L "$installed_command" ]; then
+    echo "install.sh: cannot replace directory: $installed_command" >&2
+    exit 1
+  fi
+
+  mkdir -p "$KOSMO_INSTALL_DIR" "$KOSMO_BIN_DIR"
+  KOSMO_STAGED_PATH="$KOSMO_INSTALL_DIR/.Kosmo.app.install.$$"
+  ditto "$source_app" "$KOSMO_STAGED_PATH"
+  rm -rf "$installed_app"
+  mv "$KOSMO_STAGED_PATH" "$installed_app"
+  KOSMO_STAGED_PATH=""
+
+  rm -f "$installed_command"
+  ln -s "$installed_app/Contents/MacOS/kosmo" "$installed_command"
+
+  echo "install.sh: installed Kosmo.app to $installed_app" >&2
+  echo "install.sh: installed Kosmo command link to $installed_command" >&2
+  case ":$PATH:" in
+    *":$KOSMO_BIN_DIR:"*) ;;
+    *) echo "install.sh: add $KOSMO_BIN_DIR to PATH to run kosmo directly" >&2 ;;
+  esac
+}
+
+need_cmd uname
+need_cmd curl
+need_cmd mktemp
+need_cmd mkdir
+need_cmd awk
+need_cmd cp
+need_cmd chmod
+need_cmd mv
+need_cmd rm
+need_cmd tr
+
+platform_archive="$(detect_release_archive)" || {
+  echo "install.sh: no Kosmo release is available for $(uname -s)/$(uname -m)" >&2
+  exit 1
+}
+platform="${platform_archive%%:*}"
+archive="${platform_archive#*:}"
+
+case "$platform" in
+  macos)
+    KOSMO_INSTALL_DIR="${KOSMO_INSTALL_DIR:-$HOME/Applications}"
+    KOSMO_BIN_DIR="${KOSMO_BIN_DIR:-$HOME/.local/bin}"
+    need_cmd ditto
+    need_cmd ln
+    ;;
+  *)
+    KOSMO_INSTALL_DIR="${KOSMO_INSTALL_DIR:-$HOME/.local/bin}"
+    KOSMO_DOC_DIR="${KOSMO_DOC_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/doc/kosmo}"
+    ;;
+esac
+
+if [ -z "$KOSMO_RELEASE_BASE_URL" ]; then
+  if [ -n "$KOSMO_VERSION" ]; then
+    KOSMO_RELEASE_BASE_URL="https://github.com/$KOSMO_GITHUB_REPO/releases/download/$KOSMO_VERSION"
+  else
+    KOSMO_RELEASE_BASE_URL="https://github.com/$KOSMO_GITHUB_REPO/releases/latest/download"
+  fi
+fi
+
+KOSMO_TMP_DIR="$(mktemp -d "$KOSMO_TMP_ROOT/kosmo-install.XXXXXX")"
+trap cleanup EXIT INT TERM
+
+archive_path="$KOSMO_TMP_DIR/$archive"
+checksums_path="$KOSMO_TMP_DIR/SHA256SUMS.txt"
+extract_dir="$KOSMO_TMP_DIR/release"
+
+echo "install.sh: downloading $archive" >&2
+curl -fL --retry 3 --retry-delay 2 \
+  "$KOSMO_RELEASE_BASE_URL/$archive" \
+  -o "$archive_path"
+curl -fL --retry 3 --retry-delay 2 \
+  "$KOSMO_RELEASE_BASE_URL/SHA256SUMS.txt" \
+  -o "$checksums_path"
+
+expected_checksum="$(
+  tr -d '\r' < "$checksums_path" |
+    awk -v archive="$archive" '$2 == archive || $2 == "*" archive { print $1; exit }'
+)"
+if [ -z "$expected_checksum" ]; then
+  echo "install.sh: SHA256SUMS.txt has no entry for $archive" >&2
+  exit 1
+fi
+actual_checksum="$(calculate_sha256 "$archive_path")"
+if [ "$actual_checksum" != "$expected_checksum" ]; then
+  echo "install.sh: checksum verification failed for $archive" >&2
+  exit 1
+fi
+echo "install.sh: verified SHA-256 checksum" >&2
+
+mkdir -p "$extract_dir"
+case "$platform" in
+  linux)
+    need_cmd tar
+    tar -xzf "$archive_path" -C "$extract_dir"
+    if [ ! -f "$extract_dir/kosmo" ]; then
+      echo "install.sh: release archive did not contain kosmo" >&2
+      exit 1
+    fi
+    install_command "$extract_dir/kosmo" kosmo
+    install_notices "$extract_dir"
+    ;;
+  macos)
+    ditto -x -k "$archive_path" "$extract_dir"
+    if [ ! -f "$extract_dir/Kosmo.app/Contents/MacOS/kosmo" ]; then
+      echo "install.sh: release archive did not contain Kosmo.app" >&2
+      exit 1
+    fi
+    install_macos_app "$extract_dir/Kosmo.app"
+    ;;
+  windows)
+    need_cmd unzip
+    unzip -q "$archive_path" -d "$extract_dir"
+    if [ ! -f "$extract_dir/kosmo.exe" ]; then
+      echo "install.sh: release archive did not contain kosmo.exe" >&2
+      exit 1
+    fi
+    install_command "$extract_dir/kosmo.exe" kosmo.exe
+    install_notices "$extract_dir"
+    ;;
+esac


### PR DESCRIPTION
## Summary

- add an Atlas-style installer for Kosmo GitHub release binaries
- verify downloaded archives using the published SHA-256 checksums
- use platform-native user installation locations
- temporarily disable automatic macOS Developer ID signing/notarization
- rebuild and replace v0.17.0 assets on pushes to this repair branch

## Validation

- `bash -n install.sh`
- release workflow YAML parse
- mocked macOS, Linux, and Windows installer smoke tests
- checksum mismatch rejection test
- `git diff --check`