### PR TITLE
Share Kosmo workspace indexing and refresh Git from file events

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Atlas:
 atlas install -tuk --features:kosmo
 ```
 
+Kosmo's browser and quick open share a background file inventory. See
+[workspace updates](docs/kosmo-workspace.md) for file/Git watching, process
+lifetime, and the current Linux polling fallback.
+
 ## Nimble
 
 Nimble has a couple of outstanding bugs regarding features. Until they're fixed Atlas is the only way to install the appropriate deps.

--- a/docs/kosmo-workspace.md
+++ b/docs/kosmo-workspace.md
@@ -1,0 +1,46 @@
+# Kosmo workspace updates
+
+Each Kosmo window owns one `WorkspaceFiles` controller. The file browser and
+quick open share its inventory and directory listings. Quick open includes Git's
+tracked and non-ignored untracked files; the browser can additionally display
+ignored files, empty folders, and Git's deleted paths. Ignored subtrees are listed
+on demand rather than recursively indexed.
+
+Scans run on NimKit's shared worker pool. Root changes and filesystem notifications
+invalidate older generations, and overlapping requests coalesce into one follow-up
+scan. A completed snapshot updates both views without resetting browser expansion
+or quick-open selection when the selected file still exists.
+
+## File and Git notifications
+
+With the default `monitorsGitStatus = true`, dmon watches workspace roots and Git
+metadata. Linked worktrees also watch their external Git directory and common
+repository directory. Open buffers outside the browser roots get watch coverage
+without adding their folders to the file inventory.
+
+A 100 ms timer delivers queued notifications on the GUI thread; it does not scan
+the filesystem or periodically invoke Git. Notifications refresh the shared file
+inventory and Git decorations and invalidate Moe's event-driven Git cache. Idle
+ticks collect Moe's asynchronous results and repaint changed Git status without
+requiring keyboard input. Closing a window removes its subscriptions, while
+other windows retain their shared worker and timer threads.
+
+The current dmon 0.5.0 Linux recursive backend has an invalid path concatenation
+when watching newly created directories and can assert in its monitor thread.
+Kosmo therefore uses a logged three-second polling fallback on Linux until that
+dependency is fixed. The same fallback applies if native watch coverage fails or
+dmon's 64-watch limit is reached. FreeBSD uses dmon's own snapshot-based backend.
+
+Embedding tools can disable monitoring and call `workspaceFiles.refresh()`
+explicitly. `reloadProjectFiles` remains a synchronous compatibility API for
+tests and tools; normal quick-open presentation reuses the shared asynchronous
+inventory instead of launching another Git listing each time.
+
+## Git process lifetime
+
+File discovery, Git status, find-in-files discovery, and the Git diff panel use
+one bounded Git command helper. It drains output while the child runs, limits
+commands to ten seconds and output to 128 MiB, and terminates, reaps, and closes
+children on cancellation or failure. Filesystem-monitor hooks are disabled for
+these commands. Moe's own asynchronous children use the cleanup implementation
+from its `fix/git-refresh-lifecycle` branch.

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -28,7 +28,7 @@ feature "uirelays":
   requires "gh:nim-lang/uirelays#688dd44"
 
 feature "kosmo":
-  requires "gh:fox0430/moe#18f2e9d"
+  requires "gh:elcritch/moe#fix/git-refresh-lifecycle"
   # requires "gh:elcritch/moe#integration-improvements"
 
 feature "references":

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -22,6 +22,7 @@ requires "gh:elcritch/terminex#fix/bounded-pty-shutdown"
 requires "https://github.com/Araq/iconbundler"
 requires "libbacktrace"
 requires "zippy >= 0.10.20"
+requires "dmon >= 0.5.0"
 
 feature "uirelays":
   requires "gh:nim-lang/uirelays#688dd44"

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -1,4 +1,4 @@
-version       = "0.17.2"
+version       = "0.17.3"
 author        = "Jaremy Creechley"
 description   = "Nim-native UI toolkit"
 license       = "BSD-3-Clause"

--- a/src/merenda/kosmo/filetree.nim
+++ b/src/merenda/kosmo/filetree.nim
@@ -3,6 +3,7 @@
 import std/[algorithm, options, os, sets, strutils, tables, times, unicode]
 
 import ../nimkit as nimkit except performKeyEquivalent
+import ./workspacefiles
 from ../nimkit/foundation/selectors import performKeyEquivalent
 from ../nimkit/view/viewgeometry import setFrameFromLayout
 
@@ -27,7 +28,7 @@ type
   KosmoFileTree* = ref object of nimkit.OutlineView
     xRootPath: string
     xRootPaths: seq[string]
-    xFileSystem: nimkit.FileSystemBrowserModel
+    xWorkspaceFiles: WorkspaceFiles
     xChildren: Table[string, seq[string]]
     xOnOpenFile: FileTreeOpenHandler
     xOpenDisposition: FileTreeOpenDisposition
@@ -88,7 +89,7 @@ proc loadChildPaths(tree: KosmoFileTree, parentIdentifier: string) =
   if parentIdentifier.len == 0:
     children.add tree.xRootPaths
   elif parentIdentifier.expandableDirectory():
-    for entry in tree.xFileSystem.entries(parentIdentifier):
+    for entry in tree.xWorkspaceFiles.entries(parentIdentifier):
       children.add entry.path
   tree.xChildren[parentIdentifier] = children
 
@@ -446,7 +447,7 @@ proc `filterText=`*(tree: KosmoFileTree, text: string) =
   tree.reloadFilteredTree()
 
 proc reloadRoots(tree: KosmoFileTree, expanded: seq[string]) =
-  tree.xFileSystem.invalidate()
+  tree.xWorkspaceFiles.setRoots(tree.xRootPaths)
   tree.xChildren.clear()
   tree.invalidateSearchIndex()
   tree.xVisibleChildren.clear()
@@ -509,7 +510,16 @@ proc addRootPath*(tree: KosmoFileTree, path: string): bool {.discardable.} =
 
 proc refresh*(tree: KosmoFileTree) =
   ## Discard cached directory listings and reload the visible hierarchy.
-  tree.xFileSystem.invalidate()
+  tree.xWorkspaceFiles.refresh()
+  tree.xChildren.clear()
+  tree.invalidateSearchIndex()
+  tree.reloadFilteredTree()
+
+proc workspaceFiles*(tree: KosmoFileTree): WorkspaceFiles =
+  ## The shared workspace inventory, also used by quick open.
+  tree.xWorkspaceFiles
+
+proc applyWorkspaceFiles(tree: KosmoFileTree) {.slot.} =
   tree.xChildren.clear()
   tree.invalidateSearchIndex()
   tree.reloadFilteredTree()
@@ -548,11 +558,15 @@ proc applyRefreshedGitStatus(
 ) {.slot.} =
   tree.applyGitStatus(snapshot)
 
+proc workspaceGitChanged(tree: KosmoFileTree) {.slot.} =
+  if not tree.xGitStatusService.isNil:
+    discard tree.xGitStatusService.refresh()
+
 proc startGitStatusMonitoring*(
-    tree: KosmoFileTree,
-    refreshInterval: Duration = nimkit.DefaultGitStatusRefreshInterval,
+    tree: KosmoFileTree, refreshInterval: Duration = initDuration()
 ): nimkit.GitStatusService =
-  ## Start periodic asynchronous Git decorations for this tree.
+  ## Watch workspace changes and refresh Git on demand. A positive interval
+  ## explicitly opts into additional periodic refreshes for compatibility.
   if tree.isNil:
     return
   if not tree.xGitStatusService.isNil:
@@ -561,6 +575,8 @@ proc startGitStatusMonitoring*(
   result.connect(nimkit.gitStatusDidRefresh, tree, applyRefreshedGitStatus)
   tree.xGitStatusService = result
   result.rootPaths = tree.xRootPaths
+  tree.xWorkspaceFiles.connect(workspaceRepositoryDidChange, tree, workspaceGitChanged)
+  tree.xWorkspaceFiles.startMonitoring()
 
 proc refreshGitStatus*(tree: KosmoFileTree): bool {.discardable.} =
   ## Request an immediate status refresh in addition to the periodic schedule.
@@ -574,9 +590,15 @@ proc waitForGitStatus*(
     tree.xGitStatusService.waitForIdle(timeoutMilliseconds)
 
 proc stopGitStatusMonitoring*(tree: KosmoFileTree) =
-  ## Stop and join the Git status worker owned by this tree.
-  if tree.isNil or tree.xGitStatusService.isNil:
+  ## Release workspace watches and this tree's Git subscription.
+  if tree.isNil:
     return
+  tree.xWorkspaceFiles.stopMonitoring()
+  if tree.xGitStatusService.isNil:
+    return
+  tree.xWorkspaceFiles.disconnect(
+    workspaceRepositoryDidChange, tree, workspaceGitChanged
+  )
   tree.xGitStatusService.disconnect(
     nimkit.gitStatusDidRefresh, tree, applyRefreshedGitStatus
   )
@@ -791,7 +813,8 @@ proc newKosmoFileTree*(
 ): KosmoFileTree =
   result = KosmoFileTree()
   result.initOutlineViewFields(frame)
-  result.xFileSystem = nimkit.initFileSystemBrowserModel()
+  result.xWorkspaceFiles = newWorkspaceFiles()
+  result.xWorkspaceFiles.connect(workspaceFilesDidChange, result, applyWorkspaceFiles)
   result.xGitFileStates = initTable[string, nimkit.GitFileState]()
   result.xGitDescendantStates = initTable[string, nimkit.GitFileState]()
   result.xGitChildren = initTable[string, seq[string]]()

--- a/src/merenda/kosmo/gitdiff.nim
+++ b/src/merenda/kosmo/gitdiff.nim
@@ -1,24 +1,16 @@
 ## Standard Git hunks in retained native sections with full-context syntax highlighting.
 
-import
-  std/[
-    atomics, isolation, monotimes, os, osproc, sets, streams, strutils, tables, times,
-    unicode,
-  ]
+import std/[atomics, isolation, monotimes, os, sets, strutils, tables, times, unicode]
 import sigils/[core, threadProxies, threads]
 import threading/smartptrs
-when defined(posix):
-  import std/posix
 import ../nimkit as nimkit
 import ../nimkit/foundation/backgroundworkers
+import ../nimkit/foundation/gitprocesses
 import ../nimkit/foundation/selectors as nimkitSelectors
 from ../nimkit/view/viewgeometry import setFrameFromLayout
 import ../nimkit/foundation/mainthreadwork
 
 const KosmoGitDiffTabIdentifier* = "kosmo.gitDiff"
-const
-  GitProcessStartAttempts = 20
-  GitProcessStartRetryMilliseconds = 25
 
 type
   GitDiffHighlightKey = tuple[source, language: string]
@@ -105,62 +97,18 @@ proc newGitDiffControl(): SharedPtr[GitDiffControl] =
   result = newSharedPtr(GitDiffControl)
   result[].cancelled.store(false, moRelaxed)
 
-proc executeGitOnce(
-    root: string, args: openArray[string], control: SharedPtr[GitDiffControl]
-): tuple[output: string, code: int] =
-  if control[].cancelled.load(moAcquire):
-    raise newException(IOError, "Git diff cancelled")
-  var arguments = @["--no-optional-locks", "--literal-pathspecs", "-C", root]
-  arguments.add args
-  let process =
-    startProcess("git", args = arguments, options = {poUsePath, poStdErrToStdOut})
-  defer:
-    if process.peekExitCode() == -1:
-      process.kill()
-      discard process.waitForExit()
-    process.close()
-  var buffer: array[16384, char]
-  while true:
-    if control[].cancelled.load(moAcquire):
-      raise newException(IOError, "Git diff cancelled")
-    when defined(posix):
-      var ready = TPollfd(fd: process.outputHandle(), events: POLLIN)
-      if posix.poll(addr ready, 1, 25) > 0:
-        let count = posix.read(process.outputHandle(), addr buffer[0], buffer.len)
-        if count == 0:
-          break
-        if count < 0:
-          raise newException(IOError, "Could not read Git output")
-        let offset = result.output.len
-        result.output.setLen(offset + count)
-        copyMem(addr result.output[offset], addr buffer[0], count)
-    else:
-      if process.hasData():
-        let count = process.outputStream().readData(addr buffer[0], buffer.len)
-        if count > 0:
-          let offset = result.output.len
-          result.output.setLen(offset + count)
-          copyMem(addr result.output[offset], addr buffer[0], count)
-      elif process.peekExitCode() != -1:
-        break
-      else:
-        sleep(25)
-  while process.peekExitCode() == -1:
-    if control[].cancelled.load(moAcquire):
-      raise newException(IOError, "Git diff cancelled")
-    sleep(25)
-  result.code = process.peekExitCode()
-
 proc executeGit(
     root: string, args: openArray[string], control: SharedPtr[GitDiffControl]
 ): tuple[output: string, code: int] =
-  for attempt in 0 ..< GitProcessStartAttempts:
-    try:
-      return executeGitOnce(root, args, control)
-    except CatchableError:
-      if control[].cancelled.load(moAcquire) or attempt + 1 == GitProcessStartAttempts:
-        raise
-      sleep(GitProcessStartRetryMilliseconds)
+  var arguments = @["--literal-pathspecs"]
+  arguments.add args
+  let command = runGitCommand(
+    root,
+    arguments,
+    cancelled = proc(): bool =
+      control[].cancelled.load(moAcquire),
+  )
+  (command.output, command.exitCode)
 
 proc readGitDiff(
     rootPath: string, control: SharedPtr[GitDiffControl]
@@ -211,11 +159,10 @@ proc readGitDiff(
         if path.len > 0 and path notin seen:
           seen.incl path
           let isAddition = not hasHead or path in untrackedPaths
-          var args =
-            @[
-              "diff", "--no-ext-diff", "--no-textconv", "--no-color", "--no-renames",
-              "--unified=2147483647",
-            ]
+          var args = @[
+            "diff", "--no-ext-diff", "--no-textconv", "--no-color", "--no-renames",
+            "--unified=2147483647",
+          ]
           if isAddition:
             args.add ["--no-index", "--", "/dev/null", path]
           else:

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -4501,7 +4501,7 @@ proc newKosmoApplication*(
     fileTree = newKosmoFileTree(initialRootPath)
     fileBrowserPanel = newKosmoFileBrowserPanel(fileTree)
     searchPanel = newKosmoFileSearchPanel(fileTree.rootPath)
-    quickOpenPanel = newKosmoQuickOpenPanel(fileTree.rootPath)
+    quickOpenPanel = newKosmoQuickOpenPanel(fileTree.rootPath, fileTree.workspaceFiles)
     sidebarTabs = nimkit.newCompactTabView(
       [
         nimkit.initCompactTabItem(
@@ -4622,7 +4622,6 @@ proc newKosmoApplication*(
   controller.frontend = result.unsafeWeakRef()
   sidebarPane.dockController = controller.unsafeWeakRef()
   sidebarPane.observeWindow(result.window)
-  quickOpenPanel.workspaceFiles = fileTree.workspaceFiles
   quickOpenPanel.observeWindow(result.window)
   documentView.onShowFileExplorer = proc() =
     if not controller.frontend.isNil:

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -2,8 +2,7 @@
 
 when not defined(features.merenda.kosmo):
   {.
-    error:
-      """
+    error: """
 Kosmo requires the "kosmo" feature. Enable it with Atlas:
 
   atlas install -tuk --features:kosmo
@@ -21,6 +20,7 @@ import
   ./[
     cli, config, filesearchpanel, filetree, gitdiff, moe, moehighlighting,
     panedocuments, quickopen, searchbar, settings, shortcuts, terminalsearch,
+    workspacefiles,
   ]
 import moepkg/celina_backend as celina
 
@@ -3605,6 +3605,20 @@ proc openTerminalLink(lifecycle: KosmoWindowLifecycle, link: string) {.slot.} =
   if not frontend.isNil and not frontend.application.isNil:
     discard frontend.application.workspace().openUrl(link)
 
+proc workspaceGitChanged(lifecycle: KosmoWindowLifecycle) {.slot.} =
+  if not lifecycle.frontend.isNil and not lifecycle.frontend[].xClosed:
+    # All panes share one Moe engine. Invalidate once, not once per pane.
+    lifecycle.frontend[].dockController.editor.notifyGitRepositoryChanged()
+
+proc pollWorkspaceGit(lifecycle: KosmoWindowLifecycle) {.slot.} =
+  if not lifecycle.frontend.isNil and not lifecycle.frontend[].xClosed:
+    let frontend = lifecycle.frontend[]
+    let controller = frontend.dockController
+    frontend.fileTree.workspaceFiles.setGitRoots(controller.editor.gitWatchRoots())
+    if controller.editor.pollGitStatus():
+      for group in controller.groups:
+        group.editorView.refresh()
+
 proc newTerminalDocument(
     controller: KosmoDockController, options: nimkit.TerminexSpawnOptions
 ): KosmoPaneDocument =
@@ -4001,11 +4015,10 @@ proc showSettings*(frontend: KosmoApplication): bool {.discardable.} =
     frontend.xSettingsWindow.updateMoeThemes(
       moeThemeSettings, selectedMoeThemeIdentifier
     )
-  result =
-    not frontend.application.showWindow(
-      frontend.xSettingsWindow.window, frontend.xSettingsWindow.contentView,
-      frontend.xSettingsWindow.firstResponder,
-    ).isNil
+  result = not frontend.application.showWindow(
+    frontend.xSettingsWindow.window, frontend.xSettingsWindow.contentView,
+    frontend.xSettingsWindow.firstResponder,
+  ).isNil
 
 proc showGitDiff*(frontend: KosmoApplication): bool {.discardable.} =
   ## Show full-file Git changes for the active project's repository.
@@ -4318,11 +4331,7 @@ proc configureKosmoSettingsMenu(frontend: KosmoApplication) =
   let applicationMenu = mainMenu[0].submenu()
   if not applicationMenu.isNil and applicationMenu.len > 2:
     let settingsItem = applicationMenu[2]
-    let manager =
-      if frontend.xWindowManager.isNil:
-        nil
-      else:
-        frontend.xWindowManager[]
+    let manager = if frontend.xWindowManager.isNil: nil else: frontend.xWindowManager[]
     settingsItem.identifier = KosmoShowSettingsAction
     settingsItem.action = nimkit.actionSelector(KosmoShowSettingsAction)
     settingsItem.target = nimkit.newActionTarget(
@@ -4377,11 +4386,7 @@ proc configureKosmoWorkspaceMenu(frontend: KosmoApplication) =
   let windowMenu = frontend.application.windowsMenu()
   if windowMenu.isNil or not windowMenu.menuItemWithIdentifier(KosmoNextTabAction).isNil:
     return
-  let manager =
-    if frontend.xWindowManager.isNil:
-      nil
-    else:
-      frontend.xWindowManager[]
+  let manager = if frontend.xWindowManager.isNil: nil else: frontend.xWindowManager[]
 
   proc addAction(title, identifier: string) =
     let item = nimkit.newMenuItem(title, nimkit.actionSelector(identifier))
@@ -4617,6 +4622,7 @@ proc newKosmoApplication*(
   controller.frontend = result.unsafeWeakRef()
   sidebarPane.dockController = controller.unsafeWeakRef()
   sidebarPane.observeWindow(result.window)
+  quickOpenPanel.workspaceFiles = fileTree.workspaceFiles
   quickOpenPanel.observeWindow(result.window)
   documentView.onShowFileExplorer = proc() =
     if not controller.frontend.isNil:
@@ -4739,6 +4745,13 @@ proc newKosmoApplication*(
   if manager.config.moeTheme.len > 0:
     discard result.setMoeTheme(manager.config.moeTheme)
   if monitorsGitStatus:
+    result.dockController.editor.useEventDrivenGit()
+    fileTree.workspaceFiles.connect(
+      workspaceRepositoryDidChange, result.xWindowLifecycle, workspaceGitChanged
+    )
+    fileTree.workspaceFiles.connect(
+      workspacePulse, result.xWindowLifecycle, pollWorkspaceGit
+    )
     discard fileTree.startGitStatusMonitoring()
 
 proc newKosmoApplication*(
@@ -4950,6 +4963,7 @@ proc close*(frontend: KosmoApplication) =
     frontend.searchPanel.close()
   if not frontend.fileTree.isNil:
     frontend.fileTree.stopGitStatusMonitoring()
+    frontend.fileTree.workspaceFiles.close()
   if not frontend.xWindowManager.isNil:
     frontend.xWindowManager[].unregister(frontend)
 

--- a/src/merenda/kosmo/moe.nim
+++ b/src/merenda/kosmo/moe.nim
@@ -463,6 +463,24 @@ proc close*(editor: KosmoEditor) =
     editor.editor.releaseExternalResources()
     editor.editor = nil
 
+proc useEventDrivenGit*(editor: KosmoEditor) =
+  ## Enable after the frontend installs workspace notifications and idle ticks.
+  if not editor.isNil and not editor.editor.isNil:
+    editor.editor.setFrontendGitRefreshMode(grmEventDriven)
+
+proc notifyGitRepositoryChanged*(editor: KosmoEditor, rootPath = "") =
+  ## Invalidate Moe's Git cache on the editor's owning thread.
+  if not editor.isNil and not editor.editor.isNil:
+    editor.editor.notifyGitRepositoryChanged(rootPath)
+
+proc pollGitStatus*(editor: KosmoEditor): bool =
+  ## Advance pending work; report published Git changes requiring a repaint.
+  if not editor.isNil and not editor.editor.isNil:
+    let previous = editor.editor.frontendGitStatusRevision()
+    editor.inWorkingDirectory:
+      editor.editor.tick()
+    result = previous != editor.editor.frontendGitStatusRevision()
+
 proc readEncodingSample(path: string): string =
   let sampleLength = min(getFileSize(path), (EncodingDetectionSampleSize + 4).int64).int
   if sampleLength == 0:
@@ -650,6 +668,22 @@ proc tabs*(editor: KosmoEditor): seq[KosmoTab] =
       temporary:
         editor.temporaryBufferId.isSome and buffer.id == editor.temporaryBufferId.get,
     )
+
+proc gitWatchRoots*(editor: KosmoEditor): seq[string] =
+  ## Parent directories of open files, resolving relative paths in editor context.
+  if editor.isNil or editor.editor.isNil:
+    return
+  let base =
+    if editor.workingDirectory.len > 0:
+      editor.workingDirectory
+    else:
+      getCurrentDir()
+  for tab in editor.tabs():
+    if tab.filePath.isSome:
+      let root = absolutePath(tab.filePath.get, base).parentDir()
+      if root notin result:
+        result.add root
+  result.sort()
 
 proc bufferText*(editor: KosmoEditor, id: KosmoBufferId): Option[string] =
   ## Return the current in-memory text for a buffer, including unsaved edits.

--- a/src/merenda/kosmo/quickopen.nim
+++ b/src/merenda/kosmo/quickopen.nim
@@ -538,7 +538,9 @@ proc observeWindow*(panel: KosmoQuickOpenPanel, window: nimkit.Window) =
   panel.observeProtocol(window, nimkit.WindowAppearanceEvents)
   panel.applyQuickOpenAppearance(window.effectiveAppearance())
 
-proc newKosmoQuickOpenPanel*(rootPath = ""): KosmoQuickOpenPanel =
+proc newKosmoQuickOpenPanel*(
+    rootPath = "", files: WorkspaceFiles = nil
+): KosmoQuickOpenPanel =
   result = KosmoQuickOpenPanel(xRootPath: rootPath)
   result.initBoxFields("Open File")
   result.styleId = QuickOpenPanelStyleId
@@ -642,7 +644,14 @@ proc newKosmoQuickOpenPanel*(rootPath = ""): KosmoQuickOpenPanel =
   result.hidden = true
   result.filterFiles()
 
-  result.workspaceFiles = newWorkspaceFiles()
+  result.workspaceFiles =
+    if files.isNil:
+      newWorkspaceFiles()
+    else:
+      files
+  if files.isNil:
+    # Standalone pickers retain their initial root until the first load.
+    result.xRootPath = rootPath
 
 proc rootPath*(panel: KosmoQuickOpenPanel): string =
   if panel.isNil: "" else: panel.xRootPath

--- a/src/merenda/kosmo/quickopen.nim
+++ b/src/merenda/kosmo/quickopen.nim
@@ -1,17 +1,13 @@
 ## Fuzzy project-file picker used by Kosmo's quick-open command.
 
-import
-  std/[
-    algorithm, isolation, math, monotimes, os, osproc, sets, streams, strutils, tables,
-    times,
-  ]
+import std/[algorithm, math, monotimes, os, strutils, tables, times]
 
-import sigils/[core, threadProxies, threads]
-import threading/smartptrs
+import sigils/[core, threads]
 from figdraw import ZLevel
 
 import ../nimkit as nimkit
-import ../nimkit/foundation/backgroundworkers
+import ./workspacefiles
+export workspacefiles.projectFiles
 from ../nimkit/view/viewgeometry import setFrameFromLayout
 
 const
@@ -32,21 +28,11 @@ const
   QuickOpenResultsStyleId = "kosmo.quick-open.results"
   NoMatchingFilesTitle = "No matching files"
   LoadingFilesTitle = "Loading files…"
-  GitProcessStartAttempts = 20
-  GitProcessStartRetryMilliseconds = 25
 
 type
   KosmoQuickOpenHandler* = proc(path: string) {.closure.}
 
-  QuickOpenFileWorker = ref object of AgentActor
-
   QuickOpenProgressIndicator = ref object of nimkit.ProgressIndicator
-
-  QuickOpenFileResult = object
-    roots: seq[string]
-    labels: seq[string]
-    paths: seq[string]
-    generation: uint64
 
   KosmoQuickOpenPanel* = ref object of nimkit.Box
     queryField*: nimkit.TextField
@@ -63,8 +49,7 @@ type
     xObservedWindow: WeakRef[nimkit.Window]
     xPresentationOffset: float32
     xPresentationAnimation: nimkit.Animation
-    xFileWorker: AgentProxy[QuickOpenFileWorker]
-    xLoadGeneration: uint64
+    xWorkspaceFiles: WorkspaceFiles
     xLoading: bool
 
   KosmoQuickOpenFieldEditor = ref object of nimkit.FieldEditor
@@ -72,10 +57,6 @@ type
 
   KosmoQuickOpenFieldCell = ref object of nimkit.TextFieldCell
     editor: KosmoQuickOpenFieldEditor
-
-  GitCommandResult = object
-    output: string
-    exitCode: int
 
   RankedFile = object
     path: string
@@ -106,6 +87,7 @@ protocol QuickOpenProgressDrawing of nimkit.ViewDrawingProtocol:
 proc moveHighlight(panel: KosmoQuickOpenPanel, delta: int)
 proc activateHighlighted(panel: KosmoQuickOpenPanel)
 proc filterFiles(panel: KosmoQuickOpenPanel)
+proc scrollHighlightedToVisible(panel: KosmoQuickOpenPanel)
 
 func fuzzyFileScore*(candidate, query: string): int =
   ## Score a case-insensitive fuzzy subsequence match.
@@ -164,177 +146,53 @@ proc fuzzyFilterFiles*(files: openArray[string], query: string): seq[string] =
   for match in ranked:
     result.add match.path
 
-proc runGit(rootPath: string, arguments: openArray[string]): GitCommandResult =
-  var gitArguments = @["-C", rootPath, "--no-optional-locks"]
-  gitArguments.add arguments
-  for attempt in 0 ..< GitProcessStartAttempts:
-    result = GitCommandResult(exitCode: -1)
-    var
-      process: Process
-      processStarted = false
-    try:
-      process = startProcess(
-        "git", args = gitArguments, options = {poUsePath, poStdErrToStdOut}
-      )
-      processStarted = true
-      result.output = process.outputStream().readAll()
-      result.exitCode = process.waitForExit()
-    except CatchableError:
-      result.output = getCurrentExceptionMsg()
-    finally:
-      if not process.isNil:
-        process.close()
-    if processStarted:
-      return
-    if attempt + 1 < GitProcessStartAttempts:
-      sleep(GitProcessStartRetryMilliseconds)
+proc applyProjectFiles(panel: KosmoQuickOpenPanel) {.slot.} =
+  template files(): untyped =
+    panel.xWorkspaceFiles.snapshot()
 
-proc nextNulField(value: string, cursor: var int): string =
-  if cursor >= value.len:
-    return
-  let fieldEnd = value.find('\0', cursor)
-  if fieldEnd < 0:
-    result = value[cursor ..^ 1]
-    cursor = value.len
-  else:
-    result = value[cursor ..< fieldEnd]
-    cursor = fieldEnd + 1
-
-proc gitProjectFiles(
-    rootPath: string
-): tuple[isRepository, succeeded: bool, files: seq[string]] =
-  let listing = runGit(
-    rootPath,
-    ["ls-files", "--cached", "--others", "--exclude-standard", "-z", "--", "."],
-  )
-  if listing.exitCode != 0:
-    return
-  result.isRepository = true
-  result.succeeded = true
-
-  var
-    cursor = 0
-    seen = initHashSet[string]()
-  while cursor < listing.output.len:
-    let relativePath = listing.output.nextNulField(cursor)
-    if relativePath.len == 0:
-      continue
-    if relativePath notin seen and fileExists(rootPath / relativePath):
-      seen.incl relativePath
-      result.files.add relativePath
-
-proc filesystemProjectFiles(rootPath: string): seq[string] =
-  var
-    directories = @[rootPath]
-    seen = initHashSet[string]()
-  while directories.len > 0:
-    let directory = directories.pop()
-    try:
-      for kind, path in walkDir(directory):
-        case kind
-        of pcDir:
-          if path.extractFilename() != ".git":
-            directories.add path
-        of pcLinkToDir:
-          discard
-        of pcFile, pcLinkToFile:
-          let relativePath = relativePath(path, rootPath)
-          if relativePath notin seen:
-            seen.incl relativePath
-            result.add relativePath
-    except OSError:
-      discard
-
-proc projectFiles*(rootPath: string): seq[string] =
-  ## List project files, respecting Git's standard ignore rules in work trees.
-  if rootPath.len == 0 or not dirExists(rootPath):
-    return
-  let root = absolutePath(rootPath)
-  let gitFiles = gitProjectFiles(root)
-  if gitFiles.isRepository:
-    if gitFiles.succeeded:
-      result = gitFiles.files
-  else:
-    result = filesystemProjectFiles(root)
-  result.sort(system.cmp[string])
-
-proc normalizedRoots(rootPaths: openArray[string]): seq[string] =
-  for root in rootPaths:
-    if root.len > 0 and dirExists(root):
-      let path = normalizedPath(absolutePath(root))
-      if path notin result:
-        result.add path
-
-proc loadProjectFiles(
-  worker: AgentProxy[QuickOpenFileWorker], roots: seq[string], generation: uint64
-) {.signal.}
-
-proc projectFilesLoaded(
-  worker: QuickOpenFileWorker, files: SharedPtr[QuickOpenFileResult]
-) {.signal.}
-
-proc loadProjectFiles(
-    worker: QuickOpenFileWorker, roots: seq[string], generation: uint64
-) {.slot.} =
-  var loaded = QuickOpenFileResult(roots: roots, generation: generation)
-  var seen = initHashSet[string]()
-  for root in roots:
-    var prefix = root.extractFilename()
-    for other in roots:
-      if other != root and other.extractFilename() == prefix:
-        prefix = root
-        break
-    for relative in projectFiles(root):
-      let path = normalizedPath(root / relative)
-      if path notin seen:
-        seen.incl path
-        loaded.labels.add(
-          if roots.len == 1:
-            relative
-          else:
-            prefix / relative
-        )
-        loaded.paths.add path
-  emit worker.projectFilesLoaded(newSharedPtr(unsafeIsolate(move loaded)))
-
-proc applyProjectFiles(
-    panel: KosmoQuickOpenPanel, loaded: SharedPtr[QuickOpenFileResult]
-) {.slot.} =
-  if loaded[].generation != panel.xLoadGeneration:
-    return
-  var files = move loaded[]
-  panel.xRootPaths = move files.roots
-  panel.xRootPath =
-    if panel.xRootPaths.len > 0:
-      panel.xRootPaths[0]
+  let highlighted =
+    if panel.xHighlightedIndex in 0 ..< panel.xFilteredFiles.len:
+      panel.xFilteredFiles[panel.xHighlightedIndex]
     else:
       ""
-  panel.xProjectFiles = move files.labels
+  panel.xRootPaths = files.roots
+  panel.xRootPath =
+    if files.roots.len > 0:
+      files.roots[0]
+    else:
+      ""
+  panel.xProjectFiles = files.labels
   panel.xFilePaths.clear()
-  for index, label in panel.xProjectFiles:
+  for index, label in files.labels:
     panel.xFilePaths[label] = files.paths[index]
   panel.xLoading = false
   panel.progressIndicator.stopAnimation()
   panel.filterFiles()
+  let selected = panel.xFilteredFiles.find(highlighted)
+  if selected >= 0:
+    panel.xHighlightedIndex = selected
+    panel.scrollHighlightedToVisible()
+
+proc workspaceFiles*(panel: KosmoQuickOpenPanel): WorkspaceFiles =
+  panel.xWorkspaceFiles
+
+proc `workspaceFiles=`*(panel: KosmoQuickOpenPanel, files: WorkspaceFiles) =
+  ## Borrow the browser's controller, rather than maintaining a second index.
+  if files.isNil or panel.xWorkspaceFiles == files:
+    return
+  if not panel.xWorkspaceFiles.isNil:
+    panel.xWorkspaceFiles.disconnect(workspaceFilesDidChange, panel, applyProjectFiles)
+  panel.xWorkspaceFiles = files
+  files.connect(workspaceFilesDidChange, panel, applyProjectFiles)
+  panel.applyProjectFiles()
 
 proc beginProjectFileLoad(panel: KosmoQuickOpenPanel, rootPaths: openArray[string]) =
-  let roots = normalizedRoots(rootPaths)
-  inc panel.xLoadGeneration
-  panel.xRootPaths = roots
-  panel.xRootPath =
-    if roots.len > 0:
-      roots[0]
-    else:
-      ""
-  panel.xProjectFiles.setLen(0)
-  panel.xFilteredFiles.setLen(0)
-  panel.xFilePaths.clear()
-  panel.xHighlightedIndex = -1
-  panel.xFirstIndex = 0
-  panel.xLoading = true
-  panel.progressIndicator.startAnimation()
+  panel.xWorkspaceFiles.setRoots(rootPaths)
+  panel.applyProjectFiles()
+  panel.xLoading = panel.xWorkspaceFiles.isLoading()
+  if panel.xLoading:
+    panel.progressIndicator.startAnimation()
   panel.resultsView.needsDisplay = true
-  emit panel.xFileWorker.loadProjectFiles(roots, panel.xLoadGeneration)
 
 proc visibleItemCount(panel: KosmoQuickOpenPanel): int =
   let availableRows =
@@ -715,17 +573,11 @@ proc newKosmoQuickOpenPanel*(rootPath = ""): KosmoQuickOpenPanel =
         else:
           panel[].visibleItemCount(),
       firstIndex: proc(): int =
-        if panel.isNil:
-          0
-        else:
-          panel[].xFirstIndex,
+        if panel.isNil: 0 else: panel[].xFirstIndex,
       selectedIndex: proc(): int =
         -1,
       highlightedIndex: proc(): int =
-        if panel.isNil:
-          -1
-        else:
-          panel[].xHighlightedIndex,
+        if panel.isNil: -1 else: panel[].xHighlightedIndex,
       rowHeight: proc(): float32 =
         QuickOpenRowHeight,
       itemText: proc(index: int): string =
@@ -790,17 +642,7 @@ proc newKosmoQuickOpenPanel*(rootPath = ""): KosmoQuickOpenPanel =
   result.hidden = true
   result.filterFiles()
 
-  var worker = QuickOpenFileWorker()
-  result.xFileWorker = worker.moveToThread(nimkitWorkerPool())
-  connectThreaded(
-    result.xFileWorker, loadProjectFiles, result.xFileWorker, loadProjectFiles
-  )
-  connectThreaded(
-    result.xFileWorker,
-    projectFilesLoaded,
-    result,
-    KosmoQuickOpenPanel.applyProjectFiles(),
-  )
+  result.workspaceFiles = newWorkspaceFiles()
 
 proc rootPath*(panel: KosmoQuickOpenPanel): string =
   if panel.isNil: "" else: panel.xRootPath
@@ -846,42 +688,7 @@ proc reloadProjectFiles*(panel: KosmoQuickOpenPanel, rootPaths: openArray[string
   ## Index all roots, preserving distinct names and deduplicating overlapping files.
   if panel.isNil:
     return
-  inc panel.xLoadGeneration
-  panel.xLoading = false
-  panel.progressIndicator.stopAnimation()
-  var roots: seq[string]
-  for root in rootPaths:
-    if root.len > 0 and dirExists(root):
-      let path = normalizedPath(absolutePath(root))
-      if path notin roots:
-        roots.add path
-  panel.xRootPaths = roots
-  panel.xRootPath =
-    if roots.len > 0:
-      roots[0]
-    else:
-      ""
-  panel.xProjectFiles.setLen(0)
-  panel.xFilePaths.clear()
-  var seen = initHashSet[string]()
-  for root in roots:
-    var prefix = root.extractFilename()
-    for other in roots:
-      if other != root and other.extractFilename() == prefix:
-        prefix = root
-        break
-    for relative in projectFiles(root):
-      let path = normalizedPath(root / relative)
-      if path notin seen:
-        seen.incl path
-        let label =
-          if roots.len == 1:
-            relative
-          else:
-            prefix / relative
-        panel.xProjectFiles.add label
-        panel.xFilePaths[label] = path
-  panel.filterFiles()
+  panel.xWorkspaceFiles.reload(rootPaths)
 
 proc reloadProjectFiles*(panel: KosmoQuickOpenPanel, rootPath = "") =
   ## Refresh a single root, or the current roots when no argument is supplied.
@@ -936,7 +743,7 @@ proc present*(
     return
   panel.xOnOpen = onOpen
   if panel.isOpen():
-    if normalizedRoots(rootPaths) != panel.xRootPaths:
+    if @rootPaths != panel.xRootPaths:
       panel.beginProjectFileLoad(rootPaths)
     return window.makeFirstResponder(panel.queryField)
 

--- a/src/merenda/kosmo/workspacefiles.nim
+++ b/src/merenda/kosmo/workspacefiles.nim
@@ -1,0 +1,273 @@
+## Shared, asynchronous file inventory for Kosmo's browser and quick open.
+## GUI consumers borrow one controller; worker snapshots contain only value data.
+
+import std/[algorithm, isolation, monotimes, os, sets, strutils, tables, times]
+import sigils/[core, threadProxies, threads]
+import threading/smartptrs
+import ../nimkit/containers/filebrowsers
+import ../nimkit/foundation/backgroundworkers
+import ./workspacewatch
+import ../nimkit/foundation/gitprocesses
+
+type
+  WorkspaceFileSnapshot* = object
+    roots*: seq[string]
+    labels*: seq[string]
+    paths*: seq[string]
+    listings: Table[string, seq[FileBrowserEntry]]
+    generation: uint64
+
+  WorkspaceFileWorker = ref object of AgentActor
+
+  WorkspaceFiles* = ref object of Agent
+    worker: AgentProxy[WorkspaceFileWorker]
+    roots: seq[string]
+    gitRoots: seq[string]
+    current: WorkspaceFileSnapshot
+    fallback: FileSystemBrowserModel
+    generation: uint64
+    active: bool
+    pending: bool
+    closed: bool
+    watch: WorkspaceWatch
+
+proc nextNulField(value: string, cursor: var int): string =
+  if cursor >= value.len:
+    return
+  let fieldEnd = value.find('\0', cursor)
+  if fieldEnd < 0:
+    result = value[cursor ..^ 1]
+    cursor = value.len
+  else:
+    result = value[cursor ..< fieldEnd]
+    cursor = fieldEnd + 1
+
+proc gitProjectFiles(
+    rootPath: string
+): tuple[isRepository, succeeded: bool, files: seq[string]] =
+  let listing = runGitCommand(
+    rootPath,
+    ["ls-files", "--cached", "--others", "--exclude-standard", "-z", "--", "."],
+  )
+  if listing.exitCode != 0:
+    return
+  result.isRepository = true
+  result.succeeded = true
+
+  var
+    cursor = 0
+    seen = initHashSet[string]()
+  while cursor < listing.output.len:
+    let relativePath = listing.output.nextNulField(cursor)
+    if relativePath.len == 0:
+      continue
+    if relativePath notin seen and fileExists(rootPath / relativePath):
+      seen.incl relativePath
+      result.files.add relativePath
+
+proc filesystemProjectFiles(rootPath: string): seq[string] =
+  var
+    directories = @[rootPath]
+    seen = initHashSet[string]()
+  while directories.len > 0:
+    let directory = directories.pop()
+    try:
+      for kind, path in walkDir(directory):
+        case kind
+        of pcDir:
+          if path.extractFilename() != ".git":
+            directories.add path
+        of pcLinkToDir:
+          discard
+        of pcFile, pcLinkToFile:
+          let relativePath = relativePath(path, rootPath)
+          if relativePath notin seen:
+            seen.incl relativePath
+            result.add relativePath
+    except OSError:
+      discard
+
+proc projectFiles*(rootPath: string): seq[string] =
+  ## List project files, respecting Git's standard ignore rules in work trees.
+  if rootPath.len == 0 or not dirExists(rootPath):
+    return
+  let root = absolutePath(rootPath)
+  let gitFiles = gitProjectFiles(root)
+  if gitFiles.isRepository:
+    if gitFiles.succeeded:
+      result = gitFiles.files
+  else:
+    result = filesystemProjectFiles(root)
+  result.sort(system.cmp[string])
+
+proc normalizedRoots(rootPaths: openArray[string]): seq[string] =
+  for root in rootPaths:
+    if root.len > 0 and dirExists(root):
+      let path = normalizedPath(absolutePath(root))
+      if path notin result:
+        result.add path
+
+proc readWorkspaceFiles(roots: seq[string], generation: uint64): WorkspaceFileSnapshot =
+  result = WorkspaceFileSnapshot(roots: roots, generation: generation)
+  var seen = initHashSet[string]()
+  var model = initFileSystemBrowserModel()
+  for root in roots:
+    var prefix = root.extractFilename()
+    for other in roots:
+      if other != root and other.extractFilename() == prefix:
+        prefix = root
+        break
+    for relative in projectFiles(root):
+      let path = normalizedPath(root / relative)
+      if path notin seen:
+        seen.incl path
+        result.labels.add(
+          if roots.len == 1:
+            relative
+          else:
+            prefix / relative
+        )
+        result.paths.add path
+      # Seed the browser from the same inventory, retaining ignored siblings and
+      # empty directories. Ignored subtrees remain lazy, not recursively scanned.
+      var parent = path.parentDir()
+      while parent.len > 0 and not model.isDirectoryLoaded(parent):
+        result.listings[parent] = model.entries(parent)
+        if parent == root:
+          break
+        parent = parent.parentDir()
+    result.listings[root] = model.entries(root)
+
+proc workspaceFilesDidChange*(files: WorkspaceFiles) {.signal.}
+proc workspaceRepositoryDidChange*(files: WorkspaceFiles) {.signal.}
+proc workspacePulse*(files: WorkspaceFiles) {.signal.}
+proc loadFiles(
+  worker: AgentProxy[WorkspaceFileWorker], roots: seq[string], generation: uint64
+) {.signal.}
+
+proc filesLoaded(
+  worker: WorkspaceFileWorker, snapshot: SharedPtr[WorkspaceFileSnapshot]
+) {.signal.}
+
+proc loadFiles(
+    worker: WorkspaceFileWorker, roots: seq[string], generation: uint64
+) {.slot.} =
+  var snapshot = readWorkspaceFiles(roots, generation)
+  emit worker.filesLoaded(newSharedPtr(unsafeIsolate(move snapshot)))
+
+proc refresh*(files: WorkspaceFiles)
+
+proc watchChanged(files: WorkspaceFiles) {.slot.} =
+  if not files.closed:
+    files.refresh()
+    emit files.workspaceRepositoryDidChange()
+
+proc watchPulse(files: WorkspaceFiles) {.slot.} =
+  if not files.closed:
+    emit files.workspacePulse()
+
+proc startMonitoring*(files: WorkspaceFiles) =
+  if files.watch.isNil and not files.closed:
+    files.watch = newWorkspaceWatch()
+    files.watch.connect(workspaceWatchChanged, files, watchChanged)
+    files.watch.connect(workspaceWatchPulse, files, watchPulse)
+    files.watch.setRoots(files.roots & files.gitRoots)
+
+proc setGitRoots*(files: WorkspaceFiles, roots: openArray[string]) =
+  ## Cover open buffers outside the browser's roots without indexing their folders.
+  if files.closed or files.gitRoots == @roots:
+    return
+  files.gitRoots = @roots
+  if not files.watch.isNil:
+    files.watch.setRoots(files.roots & files.gitRoots)
+
+proc stopMonitoring*(files: WorkspaceFiles) =
+  if not files.watch.isNil:
+    files.watch.close()
+    files.watch = nil
+
+proc receiveFiles(
+    files: WorkspaceFiles, snapshot: SharedPtr[WorkspaceFileSnapshot]
+) {.slot.} =
+  if files.closed:
+    return
+  files.active = false
+  if snapshot[].generation == files.generation:
+    files.current = move snapshot[]
+    files.fallback.invalidate()
+    emit files.workspaceFilesDidChange()
+  if files.pending:
+    files.pending = false
+    files.refresh()
+
+proc newWorkspaceFiles*(): WorkspaceFiles =
+  ## Create an owner-thread controller borrowing NimKit's shared worker pool.
+  result = WorkspaceFiles()
+  var worker = WorkspaceFileWorker()
+  result.worker = worker.moveToThread(nimkitWorkerPool())
+  connectThreaded(result.worker, loadFiles, result.worker, loadFiles)
+  connectThreaded(result.worker, filesLoaded, result, WorkspaceFiles.receiveFiles())
+
+proc snapshot*(files: WorkspaceFiles): lent WorkspaceFileSnapshot =
+  files.current
+
+proc isLoading*(files: WorkspaceFiles): bool =
+  files.active or files.pending
+
+proc entries*(files: WorkspaceFiles, directory: string): seq[FileBrowserEntry] =
+  ## Shared browser listings; unindexed (including ignored) folders load lazily.
+  if directory in files.current.listings:
+    files.current.listings[directory]
+  else:
+    files.fallback.entries(directory)
+
+proc refresh*(files: WorkspaceFiles) =
+  ## Invalidate in-flight work and coalesce changes into one follow-up scan.
+  if files.closed:
+    return
+  inc files.generation
+  files.current.listings.clear()
+  files.fallback.invalidate()
+  if files.active:
+    files.pending = true
+  else:
+    files.active = true
+    emit files.worker.loadFiles(files.roots, files.generation)
+
+proc setRoots*(files: WorkspaceFiles, roots: openArray[string]) =
+  let next = normalizedRoots(roots)
+  if next != files.roots:
+    files.roots = next
+    files.current = WorkspaceFileSnapshot(roots: next)
+    files.fallback.invalidate()
+    if not files.watch.isNil:
+      files.watch.setRoots(next & files.gitRoots)
+    files.refresh()
+
+proc reload*(files: WorkspaceFiles, roots: openArray[string]) =
+  ## Synchronous compatibility entry point for tools and tests.
+  if files.closed:
+    return
+  inc files.generation
+  files.pending = false
+  files.roots = normalizedRoots(roots)
+  if not files.watch.isNil:
+    files.watch.setRoots(files.roots & files.gitRoots)
+  files.current = readWorkspaceFiles(files.roots, files.generation)
+  files.fallback.invalidate()
+  emit files.workspaceFilesDidChange()
+
+proc waitForFiles*(files: WorkspaceFiles, timeoutMilliseconds: Natural = 10_000): bool =
+  let deadline = getMonoTime() + initDuration(milliseconds = timeoutMilliseconds)
+  while files.isLoading() and getMonoTime() < deadline:
+    discard getCurrentSigilThread().pollAll(NonBlocking)
+    sleep(1)
+  not files.isLoading()
+
+proc close*(files: WorkspaceFiles) =
+  ## Ignore queued results without stopping other users of the shared pool.
+  if not files.isNil:
+    files.stopMonitoring()
+    files.closed = true
+    files.pending = false
+    files.active = false

--- a/src/merenda/kosmo/workspacewatch.nim
+++ b/src/merenda/kosmo/workspacewatch.nim
@@ -1,0 +1,197 @@
+## Dmon invalidation delivered on the GUI thread. Callbacks touch only a locked
+## inbox, never GUI objects or dmon's watch list (callbacks can hold its lock).
+
+import std/[algorithm, exitprocs, locks, os, strutils, tables, times]
+import chronicles
+import dmon
+import sigils/[core, threadChronos, threadProxies, threads]
+import ../nimkit/foundation/backgroundworkers
+
+type
+  WorkspaceWatchTicker = ref object of AgentActor
+  WorkspaceWatch* = ref object of Agent
+    token: uint
+    roots: seq[string]
+    directories: seq[string]
+    watches: seq[WatchId]
+    timer: SigilTimer
+    ticker: AgentProxy[WorkspaceWatchTicker]
+    active: bool
+    fallback: bool
+    elapsed: int
+
+var
+  watchUsers: int
+  ownsDmon: bool
+  nextToken: uint
+  inboxLock: Lock
+  inbox: Table[uint, bool]
+
+initLock(inboxLock)
+
+proc stopWatchBackend() {.noconv.} =
+  if ownsDmon and dmonInst.initialized:
+    deinitDmon()
+    ownsDmon = false
+
+proc didChange(
+    watchId: WatchId,
+    action: DmonAction,
+    rootDir, filepath, oldfilepath: string,
+    userData: pointer,
+) =
+  # Some backends can finish a callback after unwatch. Tokens are never reused;
+  # removing the inbox makes late notifications harmless without dangling pointers.
+  let token = cast[uint](userData)
+  withLock inboxLock:
+    if token in inbox:
+      inbox[token] = true
+
+proc workspaceWatchChanged*(watch: WorkspaceWatch) {.signal.}
+proc workspaceWatchPulse*(watch: WorkspaceWatch) {.signal.}
+proc pulsed(ticker: WorkspaceWatchTicker) {.signal.}
+proc pulse(ticker: WorkspaceWatchTicker) {.slot.} =
+  emit ticker.pulsed()
+
+proc setRoots*(watch: WorkspaceWatch, roots: openArray[string])
+
+proc deliver(watch: WorkspaceWatch) {.slot.} =
+  if not watch.active:
+    return
+  watch.elapsed = min(watch.elapsed + 1, 30)
+  var dirty: bool
+  withLock inboxLock:
+    dirty = inbox.getOrDefault(watch.token)
+    inbox[watch.token] = false
+  # A timer drains notifications, not the filesystem. Fall back only when
+  # native coverage cannot be established (including dmon's Linux recursion bug).
+  if dirty or (watch.fallback and watch.elapsed >= 30):
+    watch.elapsed = 0
+    # A .git file can appear or change targets after the project was opened.
+    watch.setRoots(watch.roots)
+    emit watch.workspaceWatchChanged()
+  emit watch.workspaceWatchPulse()
+
+proc metadataDirectories(root: string): seq[string] =
+  var current = root
+  while current.len > 0:
+    let marker = current / ".git"
+    var gitDir: string
+    if dirExists(marker):
+      gitDir = marker
+    elif fileExists(marker):
+      try:
+        let content = readFile(marker).strip()
+        if content.startsWith("gitdir: "):
+          gitDir = normalizedPath(absolutePath(content[8 ..^ 1], current))
+      except OSError, IOError:
+        discard
+    if gitDir.len > 0:
+      result.add gitDir
+      if fileExists(gitDir / "commondir"):
+        try:
+          result.add normalizedPath(
+            absolutePath(readFile(gitDir / "commondir").strip(), gitDir)
+          )
+        except OSError, IOError:
+          discard
+      return
+    let parent = current.parentDir()
+    if parent == current:
+      return
+    current = parent
+
+proc setRoots*(watch: WorkspaceWatch, roots: openArray[string]) =
+  ## Also cover linked worktree metadata and shared refs outside project roots.
+  if not watch.active:
+    return
+  var directories: seq[string]
+  for root in roots:
+    if root notin directories:
+      directories.add root
+    for metadata in metadataDirectories(root):
+      if metadata notin directories:
+        directories.add metadata
+  var minimal: seq[string]
+  for directory in directories:
+    var covered = false
+    for parent in directories:
+      if parent != directory:
+        let prefix = parent & (if parent[^1] in {DirSep, AltSep}: ""
+        else: $DirSep)
+        if directory.startsWith(prefix):
+          covered = true
+          break
+    if not covered:
+      minimal.add directory
+  directories = minimal
+  directories.sort()
+  watch.roots = @roots
+  if directories == watch.directories:
+    return
+  for id in watch.watches:
+    unwatch(id)
+  watch.watches.setLen(0)
+  watch.directories = directories
+  watch.fallback = false
+  when defined(linux):
+    # dmon 0.5.0 concatenates absolute event paths when watching newly created
+    # directories, asserting in its monitor thread. Do not crash the application.
+    watch.fallback = true
+  else:
+    for directory in directories:
+      if dirExists(directory):
+        if dmonInst.numWatches >= 64:
+          watch.fallback = true
+        else:
+          try:
+            watch.watches.add dmon.watch(
+              directory, didChange, {Recursive}, cast[pointer](watch.token)
+            )
+          except CatchableError:
+            watch.fallback = true
+      else:
+        watch.fallback = true
+  if watch.fallback:
+    warn "Kosmo workspace watcher using periodic fallback", roots = watch.roots
+  withLock inboxLock:
+    inbox[watch.token] = true
+
+proc newWorkspaceWatch*(): WorkspaceWatch =
+  ## Own a subscription; all lifecycle calls belong on the GUI thread.
+  if watchUsers == 0 and not dmonInst.initialized:
+    initDmon()
+    startDmonThread()
+    ownsDmon = true
+    # Keep dmon's global backend at application lifetime, like the worker pool.
+    # Windows only own watches, avoiding backend reinitialization on every close.
+    addExitProc(stopWatchBackend)
+  inc watchUsers
+  inc nextToken
+  result = WorkspaceWatch(active: true, token: nextToken)
+  withLock inboxLock:
+    inbox[result.token] = true
+  let timerThread = nimkitTimerThread()
+  var ticker = WorkspaceWatchTicker()
+  result.ticker = ticker.moveToThread(timerThread)
+  result.timer = newSigilTimer(initDuration(milliseconds = 100))
+  connectThreaded(result.timer, timeout, result.ticker, WorkspaceWatchTicker.pulse())
+  connectThreaded(result.ticker, pulsed, result, WorkspaceWatch.deliver())
+  result.timer.start(timerThread)
+
+proc usesPollingFallback*(watch: WorkspaceWatch): bool =
+  watch.fallback
+
+proc close*(watch: WorkspaceWatch) =
+  if watch.isNil or not watch.active:
+    return
+  watch.active = false
+  watch.timer.cancel(nimkitTimerThread())
+  for id in watch.watches:
+    unwatch(id)
+  watch.watches.setLen(0)
+  dec watchUsers
+  withLock inboxLock:
+    inbox.del(watch.token)
+  watch.timer = nil
+  watch.ticker = nil

--- a/src/merenda/nimkit/foundation/backgroundworkers.nim
+++ b/src/merenda/nimkit/foundation/backgroundworkers.nim
@@ -3,12 +3,18 @@
 
 import std/exitprocs
 import sigils/threads
+import sigils/threadChronos
 
 var
   backgroundPool {.threadvar.}: SigilThreadPoolPtr
+  backgroundTimers {.threadvar.}: SigilChronosThreadPtr
   exitRegistered {.threadvar.}: bool
 
 proc stopBackgroundPool() {.noconv.} =
+  if not backgroundTimers.isNil:
+    backgroundTimers.stop(immediate = true)
+    backgroundTimers.join()
+    backgroundTimers = nil
   if not backgroundPool.isNil:
     backgroundPool.stop(immediate = true)
     backgroundPool.join()
@@ -24,3 +30,11 @@ proc nimkitWorkerPool*(): SigilThreadPoolPtr =
     addExitProc(stopBackgroundPool)
     exitRegistered = true
   backgroundPool
+
+proc nimkitTimerThread*(): SigilChronosThreadPtr =
+  ## Borrow the application-lifetime timer thread; clients cancel their own timers.
+  discard nimkitWorkerPool()
+  if backgroundTimers.isNil:
+    backgroundTimers = newSigilChronosThread()
+    backgroundTimers.start()
+  backgroundTimers

--- a/src/merenda/nimkit/foundation/filesearch.nim
+++ b/src/merenda/nimkit/foundation/filesearch.nim
@@ -2,14 +2,14 @@
 
 import
   std/[
-    algorithm, atomics, mimetypes, monotimes, os, osproc, sets, streams, strutils,
-    tables, times, unicode,
+    algorithm, atomics, mimetypes, monotimes, os, sets, strutils, tables, times, unicode
   ]
 
 import faststreams/inputs
 import regex
 import sigils/[core, threads]
 import threading/smartptrs
+import ./gitprocesses
 
 const
   DefaultFileSearchMaxResults* = 10_000
@@ -256,18 +256,15 @@ type GitFileList = object
 proc gitSearchFiles(
     rootPath: string, options: FileSearchOptions, control: SharedPtr[FileSearchControl]
 ): GitFileList =
-  var process: Process
   try:
-    process = startProcess(
-      "git",
-      args = [
-        "-C", rootPath, "--no-optional-locks", "ls-files", "--cached", "--others",
-        "--exclude-standard", "-z", "--", ".",
-      ],
-      options = {poUsePath, poStdErrToStdOut},
+    let listing = runGitCommand(
+      rootPath,
+      ["ls-files", "--cached", "--others", "--exclude-standard", "-z", "--", "."],
+      cancelled = proc(): bool =
+        control.cancellationRequested(),
     )
-    let output = process.outputStream().readAll()
-    if process.waitForExit() != 0:
+    let output = listing.output
+    if listing.exitCode != 0:
       return
     result.succeeded = true
 
@@ -291,9 +288,6 @@ proc gitSearchFiles(
     result.paths.sort()
   except CatchableError:
     discard
-  finally:
-    if not process.isNil:
-      process.close()
 
 type FileSearchTraversalState = object
   options: FileSearchOptions

--- a/src/merenda/nimkit/foundation/gitprocesses.nim
+++ b/src/merenda/nimkit/foundation/gitprocesses.nim
@@ -1,0 +1,101 @@
+## Bounded, fully reaped Git commands for background workspace discovery.
+
+import std/[monotimes, os, osproc, times]
+when defined(posix):
+  import std/posix
+elif defined(windows):
+  import winim/lean
+
+type GitCommandResult* = object
+  output*: string
+  exitCode*: int
+
+proc releaseProcess(process: var Process) =
+  if process.isNil:
+    return
+  try:
+    if process.running():
+      try:
+        process.terminate()
+      except OSError:
+        if process.running():
+          process.kill()
+      if process.waitForExit(100) == -1:
+        process.kill()
+    discard process.waitForExit()
+  finally:
+    process.close()
+    process = nil
+
+proc runGitCommand*(
+    root: string,
+    args: openArray[string],
+    timeoutMilliseconds: Positive = 10_000,
+    cancelled: proc(): bool {.closure, gcsafe.} = nil,
+): GitCommandResult =
+  ## Drain output while the child runs, avoiding pipe-capacity deadlocks. Never
+  ## enable filesystem-monitor hooks: workspace monitoring already belongs to us.
+  result.exitCode = -1
+  var process: Process
+  var arguments = @["-C", root, "--no-optional-locks", "-c", "core.fsmonitor=false"]
+  arguments.add args
+  try:
+    if not cancelled.isNil and cancelled():
+      raise newException(IOError, "Git workspace command cancelled")
+    process =
+      startProcess("git", args = arguments, options = {poUsePath, poStdErrToStdOut})
+    let handle = process.outputHandle()
+    when defined(posix):
+      let flags = fcntl(handle, F_GETFL)
+      if flags < 0 or fcntl(handle, F_SETFL, flags or O_NONBLOCK) < 0:
+        raiseOSError(osLastError())
+    let deadline = getMonoTime() + initDuration(milliseconds = timeoutMilliseconds)
+    var buffer: array[16_384, char]
+    var exited = false
+    while true:
+      if not cancelled.isNil and cancelled():
+        raise newException(IOError, "Git workspace command cancelled")
+      var count = 0
+      when defined(posix):
+        count = posix.read(handle, addr buffer[0], buffer.len).int
+        if count < 0 and errno notin [EAGAIN, EINTR]:
+          raiseOSError(osLastError())
+      elif defined(windows):
+        var available, bytesRead: DWORD
+        if PeekNamedPipe(cast[HANDLE](handle), nil, 0, nil, addr available, nil) != 0 and
+            available > 0:
+          if ReadFile(
+            cast[HANDLE](handle),
+            addr buffer[0],
+            min(available.int, buffer.len).DWORD,
+            addr bytesRead,
+            nil,
+          ) == 0:
+            raiseOSError(osLastError())
+          count = bytesRead.int
+      if count > 0:
+        if result.output.len + count > 128 * 1024 * 1024:
+          raise newException(IOError, "Git output exceeded the workspace limit")
+        let offset = result.output.len
+        result.output.setLen(offset + count)
+        copyMem(addr result.output[offset], addr buffer[0], count)
+      elif exited:
+        result.exitCode = process.waitForExit()
+        break
+      elif not process.running():
+        # Drain once more after observing exit; output may have arrived between
+        # the empty nonblocking read and the child closing its pipe.
+        exited = true
+      else:
+        sleep(5)
+      if getMonoTime() >= deadline:
+        raise newException(IOError, "Git workspace command timed out")
+  except CatchableError:
+    result.output = getCurrentExceptionMsg()
+    result.exitCode = -1
+  finally:
+    try:
+      releaseProcess(process)
+    except CatchableError:
+      result.output = "Unable to release Git process: " & getCurrentExceptionMsg()
+      result.exitCode = -1

--- a/src/merenda/nimkit/foundation/gitstatus.nim
+++ b/src/merenda/nimkit/foundation/gitstatus.nim
@@ -1,8 +1,10 @@
 ## Asynchronous Git work-tree status snapshots backed by a Sigils worker pool.
 
-import std/[monotimes, os, osproc, streams, strutils, times]
+import std/[monotimes, os, strutils, times]
 
 import sigils/[core, threadChronos, threadProxies, threads]
+import ./backgroundworkers
+import ./gitprocesses
 
 const DefaultGitStatusRefreshInterval*: Duration = initDuration(seconds = 3)
 
@@ -29,10 +31,6 @@ type
     isRepository*: bool
     errorMessage*: string
     workerThreadId*: int
-
-  GitCommandResult = object
-    output: string
-    exitCode: int
 
   GitStatusWorker = ref object of AgentActor
   GitStatusRefreshTicker = ref object of AgentActor
@@ -127,19 +125,6 @@ proc parseGitStatusPorcelain*(
         workTreeCode: code[1],
       )
 
-proc runGit(rootPath: string, args: openArray[string]): GitCommandResult =
-  var process: Process
-  var arguments = @["-C", rootPath, "--no-optional-locks"]
-  arguments.add args
-  try:
-    process =
-      startProcess("git", args = arguments, options = {poUsePath, poStdErrToStdOut})
-    result.output = process.outputStream().readAll()
-    result.exitCode = process.waitForExit()
-  finally:
-    if not process.isNil:
-      process.close()
-
 proc readGitStatus(rootPath: string): GitStatusSnapshot =
   result.rootPath = absolutePath(rootPath)
   result.workerThreadId = getThreadId()
@@ -148,13 +133,13 @@ proc readGitStatus(rootPath: string): GitStatusSnapshot =
     return
 
   try:
-    let repository = runGit(result.rootPath, ["rev-parse", "--show-prefix"])
+    let repository = runGitCommand(result.rootPath, ["rev-parse", "--show-prefix"])
     if repository.exitCode != 0:
       result.errorMessage = repository.output.strip()
       return
     let
       repositoryPrefix = repository.output.strip()
-      status = runGit(
+      status = runGitCommand(
         result.rootPath,
         [
           "status", "--porcelain=v1", "-z", "--untracked-files=all",
@@ -210,7 +195,7 @@ proc completeGitStatus(
     return
   service.xActiveIdentifier = 0
   for snapshot in snapshots:
-    if snapshot.rootPath in service.xRootPaths:
+    if not service.xRefreshPending and snapshot.rootPath in service.xRootPaths:
       if snapshot.rootPath == service.xRootPaths[0]:
         service.xLastSnapshot = snapshot
       emit service.gitStatusDidRefresh(snapshot)
@@ -281,8 +266,7 @@ proc newGitStatusService*(
 ): GitStatusService =
   ## Start a one-worker Git service and optionally refresh it on an interval.
   startLocalThreadDefault()
-  result = GitStatusService(xPool: newSigilThreadPool(workers = 1))
-  result.xPool.start()
+  result = GitStatusService(xPool: nimkitWorkerPool())
   var worker = GitStatusWorker()
   result.xWorker = worker.moveToThread(result.xPool)
   connectThreaded(result.xWorker, executeGitStatus, result.xWorker, executeGitStatus)
@@ -291,8 +275,7 @@ proc newGitStatusService*(
   )
 
   if refreshInterval.inNanoseconds > 0:
-    result.xTimerThread = newSigilChronosThread()
-    result.xTimerThread.start()
+    result.xTimerThread = nimkitTimerThread()
     var ticker = GitStatusRefreshTicker()
     result.xTicker = ticker.moveToThread(result.xTimerThread)
     result.xTimer = newSigilTimer(refreshInterval)
@@ -330,20 +313,17 @@ proc waitForIdle*(
   not service.isRefreshing() and not service.xRefreshPending
 
 proc close*(service: GitStatusService) =
-  ## Stop the refresh timer and join the Git worker.
+  ## Cancel this subscription, leaving the shared workers available to other clients.
   if service.isNil or service.xClosed:
     return
   service.xClosed = true
   if not service.xTimer.isNil and not service.xTimerThread.isNil:
     service.xTimer.cancel(service.xTimerThread)
-  if not service.xTimerThread.isNil:
-    service.xTimerThread.stop(immediate = true)
-    service.xTimerThread.join()
-  service.xPool.stop(immediate = true)
-  service.xPool.join()
   discard service.poll()
   service.xTimer = nil
   service.xTicker = nil
   service.xTimerThread = nil
+  service.xWorker = nil
+  service.xPool = nil
   service.xActiveIdentifier = 0
   service.xRefreshPending = false

--- a/tests/kosmo/quickopen.nim
+++ b/tests/kosmo/quickopen.nim
@@ -4,6 +4,7 @@ import figdraw
 
 import merenda/nimkit
 import merenda/kosmo/kosmo
+import merenda/kosmo/workspacefiles
 
 proc renderedText(node: Fig): string =
   for rune in node.textLayout.runes:
@@ -63,6 +64,19 @@ suite "Kosmo quick open":
       removeDir(root)
 
     check projectFiles(root) == @[".gitignore", "README.md", "notes.private"]
+
+  test "standalone quick open retains its root for no-argument reloads":
+    let root = createTempDir("merenda-kosmo-quick-open-root-", "")
+    writeFile(root / "retained.nim", "discard\n")
+    let panel = newKosmoQuickOpenPanel(root)
+    defer:
+      panel.workspaceFiles.close()
+      removeDir(root)
+
+    check panel.rootPath() == root
+    panel.reloadProjectFiles()
+    check panel.rootPath() == root
+    check panel.projectFiles() == @["retained.nim"]
 
   test "popup blurs translucent panel input and result row surfaces":
     let

--- a/tests/kosmo/workspacefiles.nim
+++ b/tests/kosmo/workspacefiles.nim
@@ -1,0 +1,210 @@
+import std/[monotimes, os, tempfiles, times, unittest]
+import sigils/[core, threads]
+import merenda/nimkit
+import merenda/nimkit/foundation/gitprocesses
+import merenda/kosmo/[kosmo, workspacefiles]
+
+type InventorySpy = ref object of Agent
+  changes: int
+
+proc changed(spy: InventorySpy) {.slot.} =
+  inc spy.changes
+
+template eventually(condition: untyped) =
+  block:
+    let deadline = getMonoTime() + initDuration(seconds = 10)
+    while not (condition) and getMonoTime() < deadline:
+      discard getCurrentSigilThread().pollAll(NonBlocking)
+      sleep(10)
+    check condition
+
+suite "Kosmo shared workspace inventory":
+  test "browser and quick open share updates and keep their visibility policies":
+    let root = createTempDir("kosmo-shared-inventory-", "")
+    defer:
+      removeDir(root)
+    createDir(root / "build")
+    writeFile(root / ".gitignore", "build/\n")
+    writeFile(root / "main.nim", "discard\n")
+    writeFile(root / "build" / "ignored.nim", "discard\n")
+    require runGitCommand(root, ["init", "-q"]).exitCode == 0
+    let frontend = newKosmoApplication(
+      newApplication("Shared inventory"), root, monitorsGitStatus = false
+    )
+    defer:
+      frontend.close()
+    let files = frontend.fileTree.workspaceFiles
+    check files == frontend.quickOpenPanel.workspaceFiles
+    require files.waitForFiles()
+    check "main.nim" in frontend.quickOpenPanel.projectFiles()
+    check "build/ignored.nim" notin frontend.quickOpenPanel.projectFiles()
+    frontend.fileTree.expandItem(root / "build")
+    check frontend.fileTree.rowForItem(root / "build" / "ignored.nim") >= 0
+    writeFile(root / "new.nim", "discard\n")
+    files.refresh()
+    require files.waitForFiles()
+    check "new.nim" in frontend.quickOpenPanel.projectFiles()
+    check frontend.fileTree.rowForItem(root / "new.nim") >= 0
+
+  test "root replacement rejects queued snapshots and coalesces refreshes":
+    let first = createTempDir("kosmo-inventory-first-", "")
+    let second = createTempDir("kosmo-inventory-second-", "")
+    defer:
+      removeDir(first)
+      removeDir(second)
+    writeFile(first / "old.nim", "discard")
+    writeFile(second / "new.nim", "discard")
+    let files = newWorkspaceFiles()
+    defer:
+      files.close()
+    let spy = InventorySpy()
+    files.connect(workspaceFilesDidChange, spy, changed)
+    files.setRoots([first])
+    files.setRoots([second])
+    for index in 0 ..< 20:
+      files.refresh()
+    require files.waitForFiles()
+    check files.snapshot().roots == @[second]
+    check files.snapshot().labels == @["new.nim"]
+    check spy.changes == 1
+    files.close()
+    files.close()
+    files.refresh()
+    check not files.isLoading()
+
+  test "filesystem notifications update both views and Moe without typing":
+    let root = createTempDir("kosmo-watched-inventory-", "")
+    defer:
+      removeDir(root)
+    writeFile(root / "main.nim", "discard\n")
+    require runGitCommand(root, ["init", "-q"]).exitCode == 0
+    require runGitCommand(root, ["add", "."]).exitCode == 0
+    require runGitCommand(
+      root,
+      [
+        "-c", "user.name=Kosmo Tests", "-c", "user.email=tests@example.invalid",
+        "commit", "-qm", "initial",
+      ],
+    ).exitCode == 0
+    let frontend = newKosmoApplication(newApplication("Watched inventory"), root)
+    defer:
+      frontend.close()
+    require frontend.openPath(root / "main.nim")
+    require frontend.fileTree.workspaceFiles.waitForFiles()
+    createDir(root / "nested")
+    writeFile(root / "nested" / "created.nim", "discard\n")
+    eventually("nested/created.nim" in frontend.quickOpenPanel.projectFiles())
+    frontend.fileTree.expandItem(root / "nested")
+    check frontend.fileTree.rowForItem(root / "nested" / "created.nim") >= 0
+    moveFile(root / "nested" / "created.nim", root / "nested" / "renamed.nim")
+    eventually(
+      "nested/renamed.nim" in frontend.quickOpenPanel.projectFiles() and
+        "nested/created.nim" notin frontend.quickOpenPanel.projectFiles()
+    )
+    require runGitCommand(root, ["checkout", "-qb", "watch-test"]).exitCode == 0
+    eventually(frontend.editorView.editor.status().gitBranch == "watch-test")
+    removeFile(root / "nested" / "renamed.nim")
+    eventually("nested/renamed.nim" notin frontend.quickOpenPanel.projectFiles())
+
+  test "linked worktree metadata changes refresh Moe status":
+    let
+      repository = createTempDir("kosmo-worktree-repository-", "")
+      linked = createTempDir("kosmo-linked-parent-", "") / "checkout"
+    defer:
+      removeDir(linked.parentDir())
+      removeDir(repository)
+    writeFile(repository / "main.nim", "discard\n")
+    require runGitCommand(repository, ["init", "-q"]).exitCode == 0
+    require runGitCommand(repository, ["add", "."]).exitCode == 0
+    require runGitCommand(
+      repository,
+      [
+        "-c", "user.name=Kosmo Tests", "-c", "user.email=tests@example.invalid",
+        "commit", "-qm", "initial",
+      ],
+    ).exitCode == 0
+    require runGitCommand(
+      repository, ["worktree", "add", "-qb", "linked-start", linked]
+    ).exitCode == 0
+    let frontend = newKosmoApplication(newApplication("Linked worktree"), linked)
+    defer:
+      frontend.close()
+    require frontend.openPath(linked / "main.nim")
+    require frontend.fileTree.workspaceFiles.waitForFiles()
+    eventually(frontend.editorView.editor.status().gitBranch == "linked-start")
+
+    require runGitCommand(linked, ["checkout", "-qb", "linked-next"]).exitCode == 0
+    eventually(frontend.editorView.editor.status().gitBranch == "linked-next")
+
+  test "an open buffer outside project roots keeps its Git metadata watched":
+    let
+      projectRoot = createTempDir("kosmo-project-root-", "")
+      externalRoot = createTempDir("kosmo-external-buffer-", "")
+    defer:
+      removeDir(projectRoot)
+      removeDir(externalRoot)
+    writeFile(externalRoot / "external.nim", "discard\n")
+    require runGitCommand(externalRoot, ["init", "-q"]).exitCode == 0
+    require runGitCommand(externalRoot, ["add", "."]).exitCode == 0
+    require runGitCommand(
+      externalRoot,
+      [
+        "-c", "user.name=Kosmo Tests", "-c", "user.email=tests@example.invalid",
+        "commit", "-qm", "initial",
+      ],
+    ).exitCode == 0
+    require runGitCommand(externalRoot, ["checkout", "-qb", "external-start"]).exitCode ==
+      0
+    let frontend = newKosmoApplication(newApplication("External buffer"), projectRoot)
+    defer:
+      frontend.close()
+    require frontend.openPath(externalRoot / "external.nim")
+    eventually(frontend.editorView.editor.status().gitBranch == "external-start")
+
+    require runGitCommand(externalRoot, ["checkout", "-qb", "external-next"]).exitCode ==
+      0
+    eventually(frontend.editorView.editor.status().gitBranch == "external-next")
+
+  test "closing one project leaves another workspace watcher active":
+    let
+      firstRoot = createTempDir("kosmo-first-window-watch-", "")
+      secondRoot = createTempDir("kosmo-second-window-watch-", "")
+      manager = newKosmoWindowManager(newApplication("Multiple watchers"))
+      first = newKosmoApplication(manager, firstRoot, monitorsGitStatus = false)
+      second = newKosmoApplication(manager, secondRoot, monitorsGitStatus = false)
+    defer:
+      first.close()
+      second.close()
+      removeDir(firstRoot)
+      removeDir(secondRoot)
+    first.fileTree.workspaceFiles.startMonitoring()
+    second.fileTree.workspaceFiles.startMonitoring()
+    require first.fileTree.workspaceFiles.waitForFiles()
+    require second.fileTree.workspaceFiles.waitForFiles()
+    first.close()
+
+    writeFile(secondRoot / "survives.nim", "discard\n")
+    eventually("survives.nim" in second.quickOpenPanel.projectFiles())
+
+  when not defined(linux):
+    test "idle monitoring does not repeatedly scan the workspace":
+      let root = createTempDir("kosmo-idle-inventory-", "")
+      defer:
+        removeDir(root)
+      let frontend = newKosmoApplication(newApplication("Idle inventory"), root)
+      defer:
+        frontend.close()
+      let spy = InventorySpy()
+      frontend.fileTree.workspaceFiles.connect(workspaceFilesDidChange, spy, changed)
+      require frontend.fileTree.workspaceFiles.waitForFiles()
+      # Drain the initial dmon notification and then observe a full old poll period.
+      let settle = getMonoTime() + initDuration(seconds = 1)
+      while getMonoTime() < settle:
+        discard getCurrentSigilThread().pollAll(NonBlocking)
+        sleep(10)
+      let baseline = spy.changes
+      let deadline = getMonoTime() + initDuration(milliseconds = 3500)
+      while getMonoTime() < deadline:
+        discard getCurrentSigilThread().pollAll(NonBlocking)
+        sleep(10)
+      check spy.changes == baseline

--- a/tests/nimkit/gitstatus.nim
+++ b/tests/nimkit/gitstatus.nim
@@ -1,8 +1,12 @@
-import std/[monotimes, os, osproc, streams, tempfiles, times, unittest]
+import std/[monotimes, os, osproc, streams, strutils, tempfiles, times, unittest]
+
+when defined(posix):
+  import std/posix
 
 import sigils/core
 
 import merenda/nimkit/foundation/gitstatus
+import merenda/nimkit/foundation/gitprocesses
 
 type GitStatusSpy = ref object of Agent
   snapshots: seq[GitStatusSnapshot]
@@ -41,6 +45,66 @@ func entryForPath(
       return (true, entry)
 
 suite "nimkit Git status service":
+  test "Git commands drain output larger than a pipe buffer":
+    let root = createTempDir("merenda-git-process-output-", "")
+    defer:
+      removeDir(root)
+    discard runGit(root, ["init", "-q"])
+    let payload = repeat("0123456789abcdef\n", 32 * 1024)
+    writeFile(root / "large.txt", payload)
+    let stored = runGitCommand(root, ["hash-object", "-w", "large.txt"])
+    require stored.exitCode == 0
+
+    let loaded = runGitCommand(root, ["cat-file", "blob", stored.output.strip()])
+    check loaded.exitCode == 0
+    check loaded.output == payload
+
+  test "Git command failures retain diagnostics and permit later commands":
+    let root = createTempDir("merenda-git-process-error-", "")
+    defer:
+      removeDir(root)
+    discard runGit(root, ["init", "-q"])
+
+    let failed = runGitCommand(root, ["definitely-not-a-git-command"])
+    check failed.exitCode != 0
+    check "not a git command" in failed.output
+    let recovered = runGitCommand(root, ["rev-parse", "--is-inside-work-tree"])
+    check recovered.exitCode == 0
+    check recovered.output.strip() == "true"
+
+  when defined(posix):
+    test "timed out Git commands are bounded and reaped":
+      let root = createTempDir("merenda-git-process-timeout-", "")
+      var helperPid: Pid
+      defer:
+        if helperPid > 0 and posix.kill(helperPid, 0) == 0:
+          discard posix.kill(helperPid, SIGKILL)
+        removeDir(root)
+      discard runGit(root, ["init", "-q"])
+      let
+        pidPath = root / "git-command.pid"
+        alias =
+          "alias.waitforever=!printf '%s %s' \"$PPID\" \"$$\" > " & quoteShell(pidPath) &
+          "; exec sleep 30"
+        started = getMonoTime()
+        timedOut =
+          runGitCommand(root, ["-c", alias, "waitforever"], timeoutMilliseconds = 250)
+      check timedOut.exitCode == -1
+      check timedOut.output == "Git workspace command timed out"
+      check getMonoTime() - started < initDuration(seconds = 5)
+      require fileExists(pidPath)
+
+      let pids = readFile(pidPath).splitWhitespace()
+      require pids.len == 2
+      let gitPid = Pid(pids[0].parseInt())
+      helperPid = Pid(pids[1].parseInt())
+      let reapDeadline = getMonoTime() + initDuration(seconds = 2)
+      while posix.kill(gitPid, 0) == 0 and getMonoTime() < reapDeadline:
+        sleep(10)
+      check posix.kill(gitPid, 0) != 0
+      check errno == ESRCH
+      check runGitCommand(root, ["status", "--short"]).exitCode == 0
+
   test "parses modified untracked renamed conflicted and ignored records":
     let
       root = absolutePath("parser-root")

--- a/tests/tkosmo.nim
+++ b/tests/tkosmo.nim
@@ -15,6 +15,7 @@ import kosmo/quickopen
 import kosmo/terminalclipboard
 import kosmo/terminalsearch
 import kosmo/workspaceroots
+import kosmo/workspacefiles
 
 proc runeIndexOf(source, needle: string): int =
   let byteIndex = source.find(needle)


### PR DESCRIPTION
## Summary
- Use the Moe PR branch for event-driven Git cache invalidation and child-process cleanup.
- Share one asynchronous workspace inventory and directory cache between the file browser and quick open, with stale-result rejection and coalesced refreshes.
- Use dmon notifications for file and Git metadata changes, including linked worktrees and open buffers outside browser roots; collect Moe results while idle.
- Share worker/timer threads and centralize bounded, cancellable Git subprocess cleanup for discovery, status, search, and diffs.
- Preserve standalone quick-open reload behavior and document the current Linux polling fallback for the dmon 0.5.0 recursive-watch bug.

## Validation
- atlas-run tests: 4/4 passed locally.
- atlas-run tests kosmo: passed after the standalone-picker fix.
- atlas-run tests --compile-only examples/all_compile.nim: compiled.
- Tests cover create/rename/delete events, linked worktrees, external buffers, idle behavior, multiple watcher lifetimes, stale roots, large Git output, timeout/reaping, and constructor compatibility.

All four updated macOS/Linux CI checks passed for e4b2c8dc (run 34088044112). Linux CI compiles tests; the macOS job executes them.
