### PR TITLE
Hide ignored files and bound Kosmo workspace loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,9 +801,11 @@ visible when switching between Files and Find.
 
 The lower sidebar uses compact SVG tabs for the lazy file tree and regular-expression
 find-in-files results. A single click on a result opens it as a temporary preview;
-double-clicking promotes it to a permanent editor tab. Git-ignored files and
-dot-directories remain visible in the file tree with muted gray text. The Files tab's
-bottom popup switches among All Files, Visible Files, and Changed Files.
+double-clicking promotes it to a permanent editor tab. The file tree defaults to Visible Files, which hides dotfiles, dot-directories,
+and Git-ignored files and directories, including in filename searches. Git ignore
+filtering updates when repository status refreshes. The Files tab's bottom popup
+switches among All Files, Visible Files, and Changed Files. All Files reveals hidden
+and ignored entries, with ignored files and dot-directories shown in muted gray text.
 With the file tree focused, Shift-F selects Visible Files, Shift-A selects All Files,
 and Shift-G selects Changed Files. Shift-H toggles between All Files and Visible Files
 (from Changed Files, it switches to All Files). These keys remain normal typing keys

--- a/README.md
+++ b/README.md
@@ -810,8 +810,19 @@ With the file tree focused, Shift-F selects Visible Files, Shift-A selects All F
 and Shift-G selects Changed Files. Shift-H toggles between All Files and Visible Files
 (from Changed Files, it switches to All Files). These keys remain normal typing keys
 in the file-name filter and other text fields.
-Shift-E expands all folders in the current view; when all are expanded, it collapses
-the whole tree.
+Shift-E expands folders within the automatic depth and entry limits; repeating it
+collapses the tree. You can expand individual folders beyond those limits.
+Workspace discovery is bounded: non-Git indexing scans at most eight folder levels
+and 10,000 directory entries, with a one-second traversal deadline. Git inventories
+retain at most 10,000 files. Quick Open and filename search can therefore show a
+partial inventory in large workspaces; open a narrower project folder for complete
+results. Folder contents load on demand when expanded. Filesystem roots such as `/`
+are only indexed at their top level and are never watched. Launching without a path
+from `/` starts with an empty workspace; use File > Open Folder… to choose a project.
+Native project watches are shallow and limited to 64 paths per workspace (including
+shallow Git metadata watches that exclude the object database); periodic reconciliation refreshes the bounded inventory for
+paths outside that coverage.
+
 Command-F on macOS or Control-F elsewhere opens a live file-name filter; matching files
 remain nested beneath their folder hierarchy. Find in Files searches Git tracked and
 untracked non-ignored files and skips binary or unsupported text encodings by default;

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -1,4 +1,4 @@
-version       = "0.17.5"
+version       = "0.17.6"
 author        = "Jaremy Creechley"
 description   = "Nim-native UI toolkit"
 license       = "BSD-3-Clause"

--- a/src/merenda/kosmo/filetree.nim
+++ b/src/merenda/kosmo/filetree.nim
@@ -107,6 +107,17 @@ proc hiddenPath(tree: KosmoFileTree, path: string): bool =
       break
     currentPath = parentPath
 
+proc ignoredPath(tree: KosmoFileTree, path: string): bool =
+  var currentPath = path
+  while currentPath.len > 0 and currentPath notin tree.xRootPaths:
+    if currentPath in tree.xGitFileStates and
+        tree.xGitFileStates[currentPath] == nimkit.gfsIgnored:
+      return true
+    let parentPath = currentPath.parentDir()
+    if parentPath == currentPath:
+      break
+    currentPath = parentPath
+
 proc treePathExists(path: string): bool =
   fileExists(path) or dirExists(path) or symlinkExists(path)
 
@@ -152,7 +163,7 @@ proc displayModeIncludes(tree: KosmoFileTree, path: string): bool =
   of FileTreeDisplayMode.AllFiles:
     path.treePathExists()
   of FileTreeDisplayMode.VisibleFiles:
-    path.treePathExists() and not tree.hiddenPath(path)
+    path.treePathExists() and not tree.hiddenPath(path) and not tree.ignoredPath(path)
   of FileTreeDisplayMode.SourceControlChanges:
     (path in tree.xGitFileStates and tree.xGitFileStates[path] != nimkit.gfsIgnored) or
       path in tree.xGitDescendantStates
@@ -233,8 +244,10 @@ proc rebuildMatchingPaths(tree: KosmoFileTree): seq[string] =
   else:
     tree.ensureSearchIndex()
     for entry in tree.xSearchEntries:
-      if (tree.xDisplayMode != FileTreeDisplayMode.VisibleFiles or not entry.hidden) and
-          entry.normalizedName.contains(needle):
+      if (
+        tree.xDisplayMode != FileTreeDisplayMode.VisibleFiles or
+        (not entry.hidden and not tree.ignoredPath(entry.path))
+      ) and entry.normalizedName.contains(needle):
         tree.includePathAndAncestors(entry.path, result)
 
 proc reloadFilteredTree(tree: KosmoFileTree, updateSearchExpansion = true) =
@@ -423,7 +436,7 @@ func displayMode*(tree: KosmoFileTree): FileTreeDisplayMode =
   tree.xDisplayMode
 
 proc `displayMode=`*(tree: KosmoFileTree, mode: FileTreeDisplayMode) =
-  ## Choose whether the tree shows every file, non-hidden files, or Git changes.
+  ## Choose whether the tree shows every file, non-hidden/non-ignored files, or Git changes.
   if tree.isNil or tree.xDisplayMode == mode:
     return
   tree.xDisplayMode = mode
@@ -814,7 +827,7 @@ protocol KosmoFileBrowserPanelLayout of nimkit.ViewLayoutProtocol:
 proc newKosmoFileTree*(
     rootPath = "", frame: nimkit.Rect = nimkit.AutoRect
 ): KosmoFileTree =
-  result = KosmoFileTree()
+  result = KosmoFileTree(xDisplayMode: FileTreeDisplayMode.VisibleFiles)
   result.initOutlineViewFields(frame)
   result.xWorkspaceFiles = newWorkspaceFiles()
   result.xWorkspaceFiles.connect(workspaceFilesDidChange, result, applyWorkspaceFiles)
@@ -844,8 +857,7 @@ proc newKosmoFileBrowserPanel*(tree: KosmoFileTree): KosmoFileBrowserPanel =
   let
     filterField = nimkit.newTextField()
     scopeMenu = nimkit.newMenu("Files Shown")
-    scopeButton =
-      nimkit.newPopupMenuButton(FileTreeDisplayMode.AllFiles.title(), scopeMenu)
+    scopeButton = nimkit.newPopupMenuButton(tree.displayMode().title(), scopeMenu)
     closeFilterButton = nimkit.newButton("×")
     promptLabel = KosmoFileFilterPromptLabel()
   promptLabel.initLabelFields("Filter Files")

--- a/src/merenda/kosmo/filetree.nim
+++ b/src/merenda/kosmo/filetree.nim
@@ -204,27 +204,23 @@ proc includePathAndAncestors(
       if currentPath.len > 0 and currentPath notin expanded:
         expanded.add currentPath
 
-proc collectSearchEntries(
-    tree: KosmoFileTree, parentIdentifier: string, seen: var HashSet[string]
-) =
-  for path in tree.rawChildPaths(parentIdentifier):
-    if path.expandableDirectory():
-      tree.collectSearchEntries(path, seen)
-    elif path notin seen:
-      seen.incl path
-      tree.xSearchEntries.add FileTreeSearchEntry(
-        path: path,
-        normalizedName: path.fileBrowserDisplayName().toLower(),
-        hidden: tree.hiddenPath(path),
-      )
-
 proc ensureSearchIndex(tree: KosmoFileTree) =
   if tree.xSearchIndexValid:
     return
   tree.xSearchEntries.setLen(0)
   var seen = initHashSet[string]()
   for root in tree.xRootPaths:
-    tree.collectSearchEntries(root, seen)
+    for relative in projectFiles(
+      root, includeIgnored = tree.xDisplayMode == FileTreeDisplayMode.AllFiles
+    ):
+      let path = root / relative
+      if path notin seen:
+        seen.incl path
+        tree.xSearchEntries.add FileTreeSearchEntry(
+          path: path,
+          normalizedName: path.fileBrowserDisplayName().toLower(),
+          hidden: tree.hiddenPath(path),
+        )
   tree.xSearchIndexValid = true
 
 proc invalidateSearchIndex(tree: KosmoFileTree) =
@@ -440,6 +436,7 @@ proc `displayMode=`*(tree: KosmoFileTree, mode: FileTreeDisplayMode) =
   if tree.isNil or tree.xDisplayMode == mode:
     return
   tree.xDisplayMode = mode
+  tree.invalidateSearchIndex()
   tree.reloadFilteredTree()
 
 proc filterText*(tree: KosmoFileTree): string =
@@ -566,6 +563,7 @@ proc applyGitStatus*(tree: KosmoFileTree, snapshot: nimkit.GitStatusSnapshot) =
     return
   tree.xGitFileStates = fileStates
   tree.xGitDescendantStates = descendantStates
+  tree.invalidateSearchIndex()
   tree.rebuildGitChildren()
   tree.reloadFilteredTree()
 
@@ -640,17 +638,22 @@ proc selectScope(panel: KosmoFileBrowserPanel, mode: FileTreeDisplayMode) =
 
 proc toggleTreeExpansion(tree: KosmoFileTree) =
   var
-    pending = @[""]
+    pending = @[(path: "", depth: -1)]
     directories: seq[string]
     seen = initHashSet[string]()
     hasCollapsedDirectory = false
-  while pending.len > 0:
+    visited: int
+  while pending.len > 0 and visited < DefaultWorkspaceEntryLimit:
     let parent = pending.pop()
-    for path in tree.filteredChildPaths(parent):
+    for path in tree.filteredChildPaths(parent.path):
+      if visited >= DefaultWorkspaceEntryLimit:
+        break
+      inc visited
       if path notin seen and tree.isTreeDirectory(path):
         seen.incl path
         directories.add path
-        pending.add path
+        if parent.depth + 1 < DefaultWorkspaceDepth and not path.isFilesystemRoot():
+          pending.add (path: path, depth: parent.depth + 1)
         if not tree.isItemExpanded(path):
           hasCollapsedDirectory = true
   tree.expandedItemIdentifiers =

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -4525,6 +4525,8 @@ proc newKosmoApplication*(
         ""
       elif dirExists(filePath):
         absolutePath(filePath)
+      elif getCurrentDir().isFilesystemRoot():
+        ""
       else:
         getCurrentDir()
     editorWorkingDirectory =

--- a/src/merenda/kosmo/workspacefiles.nim
+++ b/src/merenda/kosmo/workspacefiles.nim
@@ -1,7 +1,7 @@
 ## Shared, asynchronous file inventory for Kosmo's browser and quick open.
 ## GUI consumers borrow one controller; worker snapshots contain only value data.
 
-import std/[algorithm, isolation, monotimes, os, sets, strutils, tables, times]
+import std/[algorithm, isolation, monotimes, os, sets, strutils, times]
 import sigils/[core, threadProxies, threads]
 import threading/smartptrs
 import ../nimkit/containers/filebrowsers
@@ -9,12 +9,20 @@ import ../nimkit/foundation/backgroundworkers
 import ./workspacewatch
 import ../nimkit/foundation/gitprocesses
 
+const
+  DefaultWorkspaceDepth* = 8
+  DefaultWorkspaceEntryLimit* = 10_000
+
+proc isFilesystemRoot*(path: string): bool =
+  let normalized = normalizedPath(absolutePath(path))
+  normalized.parentDir().len == 0 or normalized.parentDir() == normalized
+
 type
   WorkspaceFileSnapshot* = object
     roots*: seq[string]
     labels*: seq[string]
     paths*: seq[string]
-    listings: Table[string, seq[FileBrowserEntry]]
+    directories: seq[string]
     generation: uint64
 
   WorkspaceFileWorker = ref object of AgentActor
@@ -44,7 +52,7 @@ proc nextNulField(value: string, cursor: var int): string =
     cursor = fieldEnd + 1
 
 proc gitProjectFiles(
-    rootPath: string
+    rootPath: string, maxEntries: Positive
 ): tuple[isRepository, succeeded: bool, files: seq[string]] =
   let listing = runGitCommand(
     rootPath,
@@ -58,7 +66,7 @@ proc gitProjectFiles(
   var
     cursor = 0
     seen = initHashSet[string]()
-  while cursor < listing.output.len:
+  while cursor < listing.output.len and result.files.len < maxEntries:
     let relativePath = listing.output.nextNulField(cursor)
     if relativePath.len == 0:
       continue
@@ -66,39 +74,53 @@ proc gitProjectFiles(
       seen.incl relativePath
       result.files.add relativePath
 
-proc filesystemProjectFiles(rootPath: string): seq[string] =
+proc filesystemProjectFiles(
+    rootPath: string, maxDepth: Natural, maxEntries: Positive
+): seq[string] =
   var
-    directories = @[rootPath]
-    seen = initHashSet[string]()
-  while directories.len > 0:
+    directories = @[(path: rootPath, depth: 0)]
+    visited: int
+  let deadline = getMonoTime() + initDuration(seconds = 1)
+  while directories.len > 0 and visited < maxEntries and getMonoTime() < deadline:
     let directory = directories.pop()
     try:
-      for kind, path in walkDir(directory):
+      for kind, path in walkDir(directory.path):
+        if visited >= maxEntries or getMonoTime() >= deadline:
+          return
+        inc visited
         case kind
         of pcDir:
-          if path.extractFilename() != ".git":
-            directories.add path
+          if directory.depth < maxDepth and path.extractFilename() != ".git":
+            directories.add (path: path, depth: directory.depth + 1)
         of pcLinkToDir:
           discard
         of pcFile, pcLinkToFile:
-          let relativePath = relativePath(path, rootPath)
-          if relativePath notin seen:
-            seen.incl relativePath
-            result.add relativePath
+          result.add relativePath(path, rootPath)
     except OSError:
       discard
 
-proc projectFiles*(rootPath: string): seq[string] =
-  ## List project files, respecting Git's standard ignore rules in work trees.
+proc projectFiles*(
+    rootPath: string,
+    maxDepth: Natural = DefaultWorkspaceDepth,
+    maxEntries: Positive = DefaultWorkspaceEntryLimit,
+    includeIgnored = false,
+): seq[string] =
+  ## Bound automatic discovery; non-Git scans stop at the depth, entry, or time
+  ## budget. Filesystem roots are shallow. Explicit folder browsing remains lazy.
   if rootPath.len == 0 or not dirExists(rootPath):
     return
   let root = absolutePath(rootPath)
-  let gitFiles = gitProjectFiles(root)
-  if gitFiles.isRepository:
-    if gitFiles.succeeded:
-      result = gitFiles.files
+  if root.isFilesystemRoot():
+    result = filesystemProjectFiles(root, 0, maxEntries)
+  elif includeIgnored:
+    result = filesystemProjectFiles(root, maxDepth, maxEntries)
   else:
-    result = filesystemProjectFiles(root)
+    let gitFiles = gitProjectFiles(root, maxEntries)
+    if gitFiles.isRepository:
+      if gitFiles.succeeded:
+        result = gitFiles.files
+    else:
+      result = filesystemProjectFiles(root, maxDepth, maxEntries)
   result.sort(system.cmp[string])
 
 proc normalizedRoots(rootPaths: openArray[string]): seq[string] =
@@ -111,7 +133,7 @@ proc normalizedRoots(rootPaths: openArray[string]): seq[string] =
 proc readWorkspaceFiles(roots: seq[string], generation: uint64): WorkspaceFileSnapshot =
   result = WorkspaceFileSnapshot(roots: roots, generation: generation)
   var seen = initHashSet[string]()
-  var model = initFileSystemBrowserModel()
+  var seenDirectories = initHashSet[string]()
   for root in roots:
     var prefix = root.extractFilename()
     for other in roots:
@@ -129,15 +151,13 @@ proc readWorkspaceFiles(roots: seq[string], generation: uint64): WorkspaceFileSn
             prefix / relative
         )
         result.paths.add path
-      # Seed the browser from the same inventory, retaining ignored siblings and
-      # empty directories. Ignored subtrees remain lazy, not recursively scanned.
+      # Watch a bounded set of indexed parents without eagerly listing them.
       var parent = path.parentDir()
-      while parent.len > 0 and not model.isDirectoryLoaded(parent):
-        result.listings[parent] = model.entries(parent)
-        if parent == root:
-          break
+      while parent.len > 0 and parent != root and result.directories.len < 48:
+        if parent notin seenDirectories:
+          seenDirectories.incl parent
+          result.directories.add parent
         parent = parent.parentDir()
-    result.listings[root] = model.entries(root)
 
 proc workspaceFilesDidChange*(files: WorkspaceFiles) {.signal.}
 proc workspaceRepositoryDidChange*(files: WorkspaceFiles) {.signal.}
@@ -172,7 +192,7 @@ proc startMonitoring*(files: WorkspaceFiles) =
     files.watch = newWorkspaceWatch(files.reconciliationInterval)
     files.watch.connect(workspaceWatchChanged, files, watchChanged)
     files.watch.connect(workspaceWatchPulse, files, watchPulse)
-    files.watch.setRoots(files.roots & files.gitRoots)
+    files.watch.setRoots(files.roots & files.gitRoots, files.current.directories)
 
 proc setGitRoots*(files: WorkspaceFiles, roots: openArray[string]) =
   ## Cover open buffers outside the browser's roots without indexing their folders.
@@ -180,7 +200,7 @@ proc setGitRoots*(files: WorkspaceFiles, roots: openArray[string]) =
     return
   files.gitRoots = @roots
   if not files.watch.isNil:
-    files.watch.setRoots(files.roots & files.gitRoots)
+    files.watch.setRoots(files.roots & files.gitRoots, files.current.directories)
 
 proc stopMonitoring*(files: WorkspaceFiles) =
   if not files.watch.isNil:
@@ -195,6 +215,8 @@ proc receiveFiles(
   files.active = false
   if snapshot[].generation == files.generation:
     files.current = move snapshot[]
+    if not files.watch.isNil:
+      files.watch.setRoots(files.roots & files.gitRoots, files.current.directories)
     files.fallback.invalidate()
     if not files.watch.isNil:
       files.watch.markReconciled()
@@ -221,17 +243,13 @@ proc isLoading*(files: WorkspaceFiles): bool =
 
 proc entries*(files: WorkspaceFiles, directory: string): seq[FileBrowserEntry] =
   ## Shared browser listings; unindexed (including ignored) folders load lazily.
-  if directory in files.current.listings:
-    files.current.listings[directory]
-  else:
-    files.fallback.entries(directory)
+  files.fallback.entries(directory)
 
 proc refresh*(files: WorkspaceFiles) =
   ## Invalidate in-flight work and coalesce changes into one follow-up scan.
   if files.closed:
     return
   inc files.generation
-  files.current.listings.clear()
   files.fallback.invalidate()
   if files.active:
     files.pending = true
@@ -257,10 +275,11 @@ proc reload*(files: WorkspaceFiles, roots: openArray[string]) =
   files.pending = false
   files.roots = normalizedRoots(roots)
   if not files.watch.isNil:
-    files.watch.setRoots(files.roots & files.gitRoots)
+    files.watch.setRoots(files.roots & files.gitRoots, files.current.directories)
   files.current = readWorkspaceFiles(files.roots, files.generation)
   files.fallback.invalidate()
   if not files.watch.isNil:
+    files.watch.setRoots(files.roots & files.gitRoots, files.current.directories)
     files.watch.markReconciled()
   emit files.workspaceFilesDidChange()
 

--- a/src/merenda/kosmo/workspacewatch.nim
+++ b/src/merenda/kosmo/workspacewatch.nim
@@ -14,8 +14,11 @@ type
   WorkspaceWatch* = ref object of Agent
     token: uint
     roots: seq[string]
+    folders: seq[string]
+    metadata: seq[string]
     directories: seq[string]
     watches: seq[WatchId]
+    handles: Table[string, WatchId]
     timer: SigilTimer
     ticker: AgentProxy[WorkspaceWatchTicker]
     active: bool
@@ -59,7 +62,9 @@ proc pulsed(ticker: WorkspaceWatchTicker) {.signal.}
 proc pulse(ticker: WorkspaceWatchTicker) {.slot.} =
   emit ticker.pulsed()
 
-proc setRoots*(watch: WorkspaceWatch, roots: openArray[string])
+proc setRoots*(
+  watch: WorkspaceWatch, roots: openArray[string], folders: openArray[string] = []
+)
 
 proc deliver(watch: WorkspaceWatch) {.slot.} =
   if not watch.active:
@@ -83,7 +88,7 @@ proc deliver(watch: WorkspaceWatch) {.slot.} =
     if reconciliationDue:
       watch.reconciliationPending = true
     # A .git file can appear or change targets after the project was opened.
-    watch.setRoots(watch.roots)
+    watch.setRoots(watch.roots, watch.folders)
     emit watch.workspaceWatchChanged()
   emit watch.workspaceWatchPulse()
 
@@ -116,57 +121,90 @@ proc metadataDirectories(root: string): seq[string] =
       return
     current = parent
 
-proc setRoots*(watch: WorkspaceWatch, roots: openArray[string]) =
-  ## Also cover linked worktree metadata and shared refs outside project roots.
+proc watchedMetadataDirectories(root: string): seq[string] =
+  for metadata in metadataDirectories(root):
+    if metadata notin result:
+      result.add metadata
+    # HEAD/index live directly in the Git directory. Watch refs separately so
+    # native backends never recurse through the object database or ignored files.
+    var pending = @[metadata / "refs"]
+    var visited: int
+    while pending.len > 0 and result.len < 16 and visited < 64:
+      let directory = pending.pop()
+      if dirExists(directory):
+        result.add directory
+        try:
+          for kind, path in walkDir(directory):
+            if visited >= 64:
+              break
+            inc visited
+            if kind == pcDir:
+              pending.add path
+        except OSError:
+          discard
+
+proc setRoots*(
+    watch: WorkspaceWatch, roots: openArray[string], folders: openArray[string] = []
+) =
+  ## Project directories and Git metadata use shallow, bounded watches.
+  ## Filesystem roots are never watched, and each workspace has at most 64 paths.
   if not watch.active:
     return
-  var directories: seq[string]
+  var
+    directories: seq[string]
+    metadataPaths: seq[string]
   for root in roots:
-    if root notin directories:
-      directories.add root
-    for metadata in metadataDirectories(root):
-      if metadata notin directories:
-        directories.add metadata
-  var minimal: seq[string]
-  for directory in directories:
-    var covered = false
-    for parent in directories:
-      if parent != directory:
-        let prefix = parent & (if parent[^1] in {DirSep, AltSep}: ""
-        else: $DirSep)
-        if directory.startsWith(prefix):
-          covered = true
-          break
-    if not covered:
-      minimal.add directory
-  directories = minimal
+    let path = normalizedPath(absolutePath(root))
+    if path.parentDir().len > 0 and path.parentDir() != path:
+      if path notin directories and directories.len < 64:
+        directories.add path
+      for metadata in watchedMetadataDirectories(path):
+        if metadata notin directories and directories.len < 64:
+          directories.add metadata
+          metadataPaths.add metadata
+  for folder in folders:
+    let path = normalizedPath(absolutePath(folder))
+    if path.parentDir().len > 0 and path.parentDir() != path and path notin directories and
+        directories.len < 64:
+      directories.add path
   directories.sort()
+  metadataPaths.sort()
   watch.roots = @roots
-  if directories == watch.directories:
+  watch.folders = @folders
+  if directories == watch.directories and metadataPaths == watch.metadata:
     return
-  for id in watch.watches:
-    unwatch(id)
-  watch.watches.setLen(0)
+  var removed: seq[string]
+  for directory, id in watch.handles:
+    if directory notin directories:
+      unwatch(id)
+      removed.add directory
+  for directory in removed:
+    watch.handles.del(directory)
+  watch.metadata = metadataPaths
   watch.directories = directories
   watch.fallback = false
   when defined(linux):
     # dmon 0.5.0 concatenates absolute event paths when watching newly created
     # directories, asserting in its monitor thread. Do not crash the application.
-    watch.fallback = true
+    watch.fallback = directories.len > 0
   else:
     for directory in directories:
-      if dirExists(directory):
+      if directory in watch.handles:
+        discard
+      elif dirExists(directory):
         if dmonInst.numWatches >= 64:
           watch.fallback = true
         else:
           try:
-            watch.watches.add dmon.watch(
-              directory, didChange, {Recursive}, cast[pointer](watch.token)
-            )
+            watch.handles[directory] =
+              dmon.watch(directory, didChange, {}, cast[pointer](watch.token))
           except CatchableError:
             watch.fallback = true
       else:
         watch.fallback = true
+  watch.watches.setLen(0)
+  for id in watch.handles.values:
+    watch.watches.add id
   if watch.fallback:
     warn "Kosmo workspace watcher using periodic fallback", roots = watch.roots
   withLock inboxLock:

--- a/tests/kosmo/filetree.nim
+++ b/tests/kosmo/filetree.nim
@@ -176,6 +176,7 @@ suite "Kosmo":
           ],
       )
     )
+    tree.displayMode = FileTreeDisplayMode.AllFiles
     tree.expandItem(folder)
     tree.expandItem(githubFolder)
     tree.expandItem(ignoredFolder)

--- a/tests/kosmo/filetreeinteractions.nim
+++ b/tests/kosmo/filetreeinteractions.nim
@@ -3,7 +3,7 @@ import std/[os, strutils, tempfiles, unicode, unittest]
 import figdraw
 
 import merenda/nimkit
-import merenda/kosmo/kosmo
+import merenda/kosmo/[kosmo, workspacefiles]
 
 proc renderedText(node: Fig): string =
   for rune in node.textLayout.runes:
@@ -49,6 +49,8 @@ suite "Kosmo file tree interactions":
     defer:
       window.close()
       removeDir(root)
+    check tree.displayMode == FileTreeDisplayMode.VisibleFiles
+    check panel.scopeButton.title == "Visible Files"
     window.setContentView(panel)
     panel.layoutSubtreeIfNeeded()
     require window.makeFirstResponder(tree)
@@ -104,6 +106,7 @@ suite "Kosmo file tree interactions":
       removeFile(ignoredPath)
       removeDir(root)
 
+    tree.displayMode = FileTreeDisplayMode.AllFiles
     discard buildRenders(tree)
     check not tree.rendersTextWithColor("ignored.log", ignoredColor)
 
@@ -200,7 +203,10 @@ suite "Kosmo file tree interactions":
       removeDir(root)
 
     let tree = newKosmoFileTree(root)
-    check tree.displayMode == FileTreeDisplayMode.AllFiles
+    check tree.displayMode == FileTreeDisplayMode.VisibleFiles
+    check tree.rowForItem(hiddenFile) < 0
+    check tree.rowForItem(hiddenFolder) < 0
+    tree.displayMode = FileTreeDisplayMode.AllFiles
     check tree.rowForItem(hiddenFile) >= 0
     check tree.rowForItem(hiddenFolder) >= 0
 
@@ -235,6 +241,60 @@ suite "Kosmo file tree interactions":
     check tree.rowForItem(unicodeDeletedFile) >= 0
     check tree.rowForItem(deletedFile) < 0
     tree.filterText = ""
+
+  test "visible scope excludes ignored paths and refreshes cached searches":
+    let
+      root = createTempDir("merenda-kosmo-tree-ignored-", "")
+      ignoredFolder = root / "build"
+      ignoredFile = root / "needle.log"
+      ignoredChild = ignoredFolder / "needle.nim"
+      visibleFolder = root / "source"
+      visibleFile = visibleFolder / "needle.nim"
+    defer:
+      removeDir(root)
+    createDir(ignoredFolder)
+    createDir(visibleFolder)
+    for path in [ignoredFile, ignoredChild, visibleFile]:
+      writeFile(path, "content")
+    let tree = newKosmoFileTree(root)
+    defer:
+      tree.workspaceFiles.close()
+    tree.displayMode = FileTreeDisplayMode.VisibleFiles
+    tree.filterText = "needle"
+    check tree.rowForItem(ignoredChild) >= 0
+    check tree.rowForItem(ignoredFile) >= 0
+
+    tree.applyGitStatus(
+      GitStatusSnapshot(
+        rootPath: absolutePath(root),
+        isRepository: true,
+        entries:
+          @[
+            GitStatusEntry(path: ignoredFolder, state: gfsIgnored),
+            GitStatusEntry(path: ignoredFile, state: gfsIgnored),
+          ],
+      )
+    )
+    check tree.rowForItem(ignoredFolder) < 0
+    check tree.rowForItem(ignoredChild) < 0
+    check tree.rowForItem(ignoredFile) < 0
+    check tree.rowForItem(visibleFolder) >= 0
+    check tree.rowForItem(visibleFile) >= 0
+
+    tree.displayMode = FileTreeDisplayMode.AllFiles
+    check tree.rowForItem(ignoredChild) >= 0
+    check tree.rowForItem(ignoredFile) >= 0
+    tree.displayMode = FileTreeDisplayMode.VisibleFiles
+    tree.filterText = ""
+    check tree.rowForItem(ignoredFolder) < 0
+    check tree.rowForItem(ignoredFile) < 0
+    tree.filterText = "needle"
+    tree.applyGitStatus(
+      GitStatusSnapshot(rootPath: absolutePath(root), isRepository: true)
+    )
+    check tree.rowForItem(ignoredFolder) >= 0
+    check tree.rowForItem(ignoredChild) >= 0
+    check tree.rowForItem(ignoredFile) >= 0
 
   test "double clicking a deleted ancestor folder toggles it":
     let
@@ -362,12 +422,12 @@ suite "Kosmo file tree interactions":
     window.setContentView(panel)
     panel.layoutSubtreeIfNeeded()
 
-    check panel.scopeButton.title == "All Files"
+    check panel.scopeButton.title == "Visible Files"
     check panel.scopeButton.menu().items().len == 3
     check panel.scopeButton.menu()[0].title == "All Files"
     check panel.scopeButton.menu()[1].title == "Visible Files"
     check panel.scopeButton.menu()[2].title == "Changed Files"
-    check panel.scopeButton.menu()[0].state == bsOn
+    check panel.scopeButton.menu()[1].state == bsOn
     check panel.scopeButton.frame().minY >= panel.fileTree.frame().maxY
     check panel.filterField.hidden
 

--- a/tests/kosmo/workspacefiles.nim
+++ b/tests/kosmo/workspacefiles.nim
@@ -1,4 +1,4 @@
-import std/[importutils, monotimes, os, tempfiles, times, unittest]
+import std/[importutils, monotimes, os, tables, tempfiles, times, unittest]
 import dmon
 import sigils/[core, threads]
 import merenda/nimkit
@@ -23,6 +23,80 @@ template eventually(condition: untyped) =
     check condition
 
 suite "Kosmo shared workspace inventory":
+  test "non-Git discovery limits depth and entries while browsing stays lazy":
+    let root = createTempDir("kosmo-bounded-inventory-", "")
+    defer:
+      removeDir(root)
+    writeFile(root / "top.txt", "top")
+    var deep = root
+    for index in 0 ..< DefaultWorkspaceDepth + 2:
+      deep = deep / "nested"
+      createDir(deep)
+    writeFile(deep / "deep.txt", "deep")
+    check "top.txt" in projectFiles(root)
+    check relativePath(deep / "deep.txt", root) notin projectFiles(root)
+    check relativePath(deep / "deep.txt", root) in
+      projectFiles(root, maxDepth = DefaultWorkspaceDepth + 2)
+    check projectFiles(root, maxDepth = 0) == @["top.txt"]
+
+    let files = newWorkspaceFiles()
+    defer:
+      files.close()
+    files.reload([root])
+    check files.fallback.cachedDirectoryCount() == 0
+    check files.entries(deep).len == 1
+    check files.entries(deep)[0].path == deep / "deep.txt"
+    check files.fallback.cachedDirectoryCount() == 1
+
+    let flat = root / "flat"
+    createDir(flat)
+    for index in 0 ..< 12:
+      writeFile(flat / ($index & ".txt"), "file")
+    check projectFiles(flat, maxEntries = 3).len == 3
+    # Directories count toward the budget even when they contain no files.
+    check projectFiles(root / "nested", maxEntries = 3).len == 0
+
+  test "filesystem roots are shallow and have no native workspace watches":
+    var root = getCurrentDir()
+    while root.parentDir().len > 0 and root.parentDir() != root:
+      root = root.parentDir()
+    check root.isFilesystemRoot()
+    for path in projectFiles(root, maxEntries = 20):
+      check path.extractFilename() == path
+    let watch = newWorkspaceWatch()
+    defer:
+      watch.close()
+    watch.setRoots([root], [root])
+    check watch.directories.len == 0
+    check watch.watches.len == 0
+    check not watch.usesPollingFallback()
+
+  test "workspace directory watches are shallow and capped":
+    let root = createTempDir("kosmo-bounded-watches-", "")
+    defer:
+      removeDir(root)
+    var folders: seq[string]
+    for index in 0 ..< 70:
+      let folder = root / $index
+      createDir(folder)
+      folders.add folder
+    let watch = newWorkspaceWatch()
+    defer:
+      watch.close()
+    watch.setRoots([root], folders)
+    check watch.directories.len == 64
+    check watch.metadata.len == 0
+    check watch.watches.len <= 64
+    let rootHandle = watch.handles.getOrDefault(root)
+    createDir(root / ".git" / "objects" / "pack")
+    createDir(root / ".git" / "refs" / "heads" / "feature")
+    watch.setRoots([root], folders)
+    check root / ".git" in watch.metadata
+    check root / ".git" / "refs" / "heads" / "feature" in watch.metadata
+    check root / ".git" / "objects" notin watch.directories
+    when not defined(linux):
+      check uint32(watch.handles[root]) == uint32(rootHandle)
+
   test "browser and quick open share updates and keep their visibility policies":
     let root = createTempDir("kosmo-shared-inventory-", "")
     defer:

--- a/tests/kosmo/workspacefiles.nim
+++ b/tests/kosmo/workspacefiles.nim
@@ -34,9 +34,7 @@ suite "Kosmo shared workspace inventory":
     writeFile(root / "build" / "ignored.nim", "discard\n")
     writeFile(root / ".hidden" / "secret.nim", "discard\n")
     require runGitCommand(root, ["init", "-q"]).exitCode == 0
-    let frontend = newKosmoApplication(
-      newApplication("Shared inventory"), root, monitorsGitStatus = false
-    )
+    let frontend = newKosmoApplication(newApplication("Shared inventory"), root)
     defer:
       frontend.close()
     let files = frontend.fileTree.workspaceFiles
@@ -44,6 +42,11 @@ suite "Kosmo shared workspace inventory":
     require files.waitForFiles()
     check "main.nim" in frontend.quickOpenPanel.projectFiles()
     check "build/ignored.nim" notin frontend.quickOpenPanel.projectFiles()
+    require frontend.fileTree.waitForGitStatus()
+    check frontend.fileTree.displayMode == FileTreeDisplayMode.VisibleFiles
+    check frontend.fileTree.rowForItem(root / "build") < 0
+    check frontend.fileTree.rowForItem(root / ".hidden") < 0
+    frontend.fileTree.displayMode = FileTreeDisplayMode.AllFiles
     frontend.fileTree.expandItem(root / "build")
     check frontend.fileTree.rowForItem(root / "build" / "ignored.nim") >= 0
     frontend.fileTree.expandItem(root / ".hidden")
@@ -51,6 +54,7 @@ suite "Kosmo shared workspace inventory":
     frontend.fileTree.displayMode = FileTreeDisplayMode.VisibleFiles
     check frontend.fileTree.rowForItem(root / "main.nim") >= 0
     check frontend.fileTree.rowForItem(root / ".hidden") < 0
+    check frontend.fileTree.rowForItem(root / "build") < 0
     writeFile(root / "new.nim", "discard\n")
     files.refresh()
     require files.waitForFiles()


### PR DESCRIPTION
Kosmo showed Git-ignored entries in Visible Files and could recursively inventory and watch an entire filesystem when launched with `/` as its working directory.

The browser now defaults to Visible Files, excluding dotfiles and Git-ignored files and directories from the tree and filename searches. All Files remains available to reveal them.

Workspace loading is bounded and folder listings are lazy:
- Non-Git discovery stops after eight directory levels, 10,000 entries, or a one-second traversal deadline. Git inventories retain up to 10,000 files per root.
- Filename search and expand-all use bounded discovery. Individual folders can still be expanded beyond the automatic limits.
- Launching without a path from a filesystem root starts with an empty workspace. Explicit filesystem roots are indexed shallowly and never watched.
- Native watches cover at most 64 shallow paths per workspace, including bounded Git ref directories; they do not recurse through projects or Git object databases. Existing subscriptions survive coverage changes. Periodic reconciliation refreshes paths outside native coverage.

Large workspaces may have partial Quick Open and filename-search inventories; opening a narrower project folder gives more complete results. The README documents the limits.

Validation:
- Full `atlas-run tests`: 4/4 passed, with `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false` to disable local signing for temporary test repositories.
- `atlas-run tests --compile-only examples/all_compile.nim`: passed.
- Regression coverage includes hidden/ignored entries, scope defaults, refreshed searches, scan depth and entry limits, lazy deep-folder browsing, filesystem roots, watch limits, retained watch subscriptions, and live nested-file updates.
- Formatted touched Nim files with `nph`; `git diff --check` passed.
