### PR TITLE
Route CLI paths and piped diffs to Kosmo

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,6 +772,13 @@ a path starts with a dash. Tagged releases provide Linux, macOS, and Windows
 binaries; see [Releasing Kosmo binaries](docs/releasing-kosmo.md) for artifact and
 macOS signing details.
 
+Pipe unified Git output to `kosmo --diff` to render a static snapshot in Kosmo's
+Git Diff view, for example `git diff some-folder | kosmo --diff`. The same process
+and embedded-terminal routing rules apply. Piped diffs are limited to 8 MiB and
+do not enable the repository Refresh action. If no Kosmo process is running, the
+command opens an editor-only window; start Kosmo first when combining `--diff`
+with `--bg`.
+
 File > New… opens a blank tab in the active editor pane. File > Open Project…
 opens a folder in a new window with its own file browser. File > Open… opens
 files in the current window and appends selected folders to that window's

--- a/README.md
+++ b/README.md
@@ -757,12 +757,18 @@ rights for those glyphs. See `data/FONT-LICENSES.md` before redistributing Kosmo
 }
 ```
 
-Run `kosmo --bg [file-or-folder]` to launch the standalone editor detached from
-the invoking shell. Kosmo preserves the current working directory, forwards the
-remaining command-line arguments to its detached process, and disconnects its
-standard input, output, and error streams. Use `kosmo --help` to see the
-available standalone options. Use `kosmo --bg -- --dash-prefixed-path` when the
-path itself starts with a dash. Tagged releases provide Linux, macOS, and Windows
+Run `kosmo file-or-folder` from a shell to reuse a running Kosmo process. Files
+open as permanent tabs in the active window, while folders open as project roots
+in new windows. Multiple paths are accepted; when a request contains folders,
+Kosmo creates one project window, adds each folder as a root, and opens the files
+there. Relative paths are resolved from the invoking shell, and missing file
+paths open as new named buffers when their parent folder exists.
+
+Kosmo terminals route the command back to the window that created that terminal.
+Commands from other shells use the newest responsive Kosmo process. If none is
+running, Kosmo starts normally; add `--bg` to detach it from the invoking shell.
+Use `kosmo --help` to see the standalone options, and use `kosmo -- --name` when
+a path starts with a dash. Tagged releases provide Linux, macOS, and Windows
 binaries; see [Releasing Kosmo binaries](docs/releasing-kosmo.md) for artifact and
 macOS signing details.
 

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -1,4 +1,4 @@
-version       = "0.17.6"
+version       = "0.17.7"
 author        = "Jaremy Creechley"
 description   = "Nim-native UI toolkit"
 license       = "BSD-3-Clause"

--- a/src/merenda/kosmo/cli.nim
+++ b/src/merenda/kosmo/cli.nim
@@ -1,6 +1,6 @@
 ## Command-line handling and detached launching for standalone Kosmo.
 
-import std/os
+import std/[os, sets]
 
 when defined(windows):
   import std/[widestrs, winlean]
@@ -14,7 +14,7 @@ const
   KosmoVersionFlag* = "--version"
   KosmoUsage* =
     """
-Usage: kosmo [--bg] [--version] [--] [file-or-folder]
+Usage: kosmo [--bg] [--version] [--] [file-or-folder ...]
 
 Options:
   --bg        Start Kosmo detached from the invoking shell.
@@ -29,6 +29,12 @@ type KosmoStandaloneCommandLine* = object ## Parsed standalone command-line opti
   version*: bool
   arguments*: seq[string]
   filePath*: string
+  paths*: seq[string]
+
+type KosmoCliPathResolution* = object
+  ## Absolute paths ready for local opening or transport to another process.
+  paths*: seq[string]
+  errors*: seq[string]
 
 proc parseKosmoCommandLine*(arguments: openArray[string]): KosmoStandaloneCommandLine =
   ## Parse standalone Kosmo options while retaining every non-option argument.
@@ -41,6 +47,7 @@ proc parseKosmoCommandLine*(arguments: openArray[string]): KosmoStandaloneComman
       if not hasFilePath:
         result.filePath = argument
         hasFilePath = true
+      result.paths.add argument
     else:
       case argument
       of "--":
@@ -57,6 +64,30 @@ proc parseKosmoCommandLine*(arguments: openArray[string]): KosmoStandaloneComman
         if not hasFilePath:
           result.filePath = argument
           hasFilePath = true
+        result.paths.add argument
+
+proc resolveKosmoCliPaths*(
+    paths: openArray[string], workingDirectory = getCurrentDir()
+): KosmoCliPathResolution =
+  ## Resolve CLI paths against the invoking shell. Existing directories and
+  ## regular files are accepted; a missing file is accepted when its parent
+  ## directory exists. Missing directory-shaped paths are rejected.
+  var seen = initHashSet[string]()
+  for original in paths:
+    if original.len == 0:
+      result.errors.add "Kosmo cannot open an empty path"
+      continue
+    let path = normalizedPath(absolutePath(original, workingDirectory))
+    let directoryShaped = original[^1] in {DirSep, AltSep}
+    if dirExists(path) or fileExists(path) or
+        (not directoryShaped and dirExists(path.parentDir())):
+      if path notin seen:
+        seen.incl path
+        result.paths.add path
+    elif directoryShaped:
+      result.errors.add "Kosmo project folder does not exist: " & path
+    else:
+      result.errors.add "Kosmo cannot open path: " & path
 
 when defined(windows):
   const CreateNewProcessGroup = 0x00000200'i32

--- a/src/merenda/kosmo/cli.nim
+++ b/src/merenda/kosmo/cli.nim
@@ -1,6 +1,6 @@
 ## Command-line handling and detached launching for standalone Kosmo.
 
-import std/[os, sets]
+import std/[os, sets, terminal]
 
 when defined(windows):
   import std/[widestrs, winlean]
@@ -12,12 +12,16 @@ const
   KosmoHelpFlag* = "--help"
   KosmoShortHelpFlag* = "-h"
   KosmoVersionFlag* = "--version"
+  KosmoDiffFlag* = "--diff"
+  KosmoCliDiffInputLimit* = 8 * 1024 * 1024
   KosmoUsage* =
     """
 Usage: kosmo [--bg] [--version] [--] [file-or-folder ...]
+       command-producing-diff | kosmo --diff
 
 Options:
   --bg        Start Kosmo detached from the invoking shell.
+  --diff      Render a unified Git diff read from standard input.
   --version   Show the Kosmo version.
   --          Stop parsing options.
   -h, --help  Show this help text.
@@ -27,6 +31,7 @@ type KosmoStandaloneCommandLine* = object ## Parsed standalone command-line opti
   background*: bool
   help*: bool
   version*: bool
+  diff*: bool
   arguments*: seq[string]
   filePath*: string
   paths*: seq[string]
@@ -59,6 +64,8 @@ proc parseKosmoCommandLine*(arguments: openArray[string]): KosmoStandaloneComman
         result.help = true
       of KosmoVersionFlag:
         result.version = true
+      of KosmoDiffFlag:
+        result.diff = true
       else:
         result.arguments.add argument
         if not hasFilePath:
@@ -88,6 +95,24 @@ proc resolveKosmoCliPaths*(
       result.errors.add "Kosmo project folder does not exist: " & path
     else:
       result.errors.add "Kosmo cannot open path: " & path
+
+proc kosmoCliInputIsTerminal*(): bool =
+  ## Return whether `--diff` would read interactively instead of from a pipe.
+  stdin.isatty()
+
+proc readKosmoCliDiff*(input: File, maxBytes = KosmoCliDiffInputLimit): string =
+  ## Read a bounded diff payload, including an empty diff from a clean work tree.
+  const ChunkSize = 64 * 1024
+  var buffer: array[ChunkSize, char]
+  while true:
+    let count = input.readChars(buffer)
+    if count == 0:
+      break
+    if result.len + count > maxBytes:
+      raise newException(ValueError, "Kosmo diff input exceeds the 8 MiB limit")
+    let start = result.len
+    result.setLen(start + count)
+    copyMem(addr result[start], addr buffer[0], count)
 
 when defined(windows):
   const CreateNewProcessGroup = 0x00000200'i32

--- a/src/merenda/kosmo/cliopen.nim
+++ b/src/merenda/kosmo/cliopen.nim
@@ -1,0 +1,361 @@
+## Local command-line request routing for a running Kosmo application.
+
+import std/[algorithm, json, nativesockets, net, os, sets, strutils, sysrand, times]
+
+import sigils/[core, threadChronos, threadProxies, threads]
+
+import ../nimkit/foundation/backgroundworkers
+
+const
+  KosmoCliProtocolVersion* = 1
+  KosmoCliEndpointEnvironment* = "KOSMO_CLI_ENDPOINT"
+  KosmoCliWindowEnvironment* = "KOSMO_CLI_WINDOW"
+  KosmoCliMaxPaths* = 64
+  KosmoCliMaxMessageBytes* = 1024 * 1024
+  KosmoCliConnectTimeoutMilliseconds* = 2_000
+  KosmoCliResponseTimeoutMilliseconds* = 10_000
+  KosmoCliPollInterval = initDuration(milliseconds = 50)
+  KosmoCliCurrentEndpointName = "current.json"
+
+type
+  KosmoCliOpenRequest* = object
+    requestId*: string
+    paths*: seq[string]
+    originWindow*: string
+
+  KosmoCliOpenResponse* = object
+    delivered*: bool
+    errors*: seq[string]
+
+  KosmoCliOpenHandler* =
+    proc(request: KosmoCliOpenRequest): KosmoCliOpenResponse {.closure.}
+
+  KosmoCliEndpoint = object
+    version: int
+    instanceId: string
+    processId: int
+    port: int
+    token: string
+
+  KosmoCliClient = object
+    socket: Socket
+    input: string
+
+  KosmoCliTicker = ref object of AgentActor
+
+  KosmoCliOpenServer* = ref object of Agent
+    socket: Socket
+    clients: seq[KosmoCliClient]
+    ticker: AgentProxy[KosmoCliTicker]
+    timer: SigilTimer
+    endpoint: KosmoCliEndpoint
+    registryDirectory: string
+    endpointPath: string
+    handler: KosmoCliOpenHandler
+    closed: bool
+
+proc kosmoCliTicked(ticker: KosmoCliTicker) {.signal.}
+
+proc tick(ticker: KosmoCliTicker) {.slot.} =
+  emit ticker.kosmoCliTicked()
+
+func defaultKosmoCliRegistryDirectory*(): string =
+  getConfigDir() / "kosmo" / "cli"
+
+proc randomIdentifier*(): string =
+  for value in urandom(16):
+    result.add value.toHex(2).toLowerAscii()
+
+func endpointJson(endpoint: KosmoCliEndpoint): JsonNode =
+  %*{
+    "version": endpoint.version,
+    "instanceId": endpoint.instanceId,
+    "processId": endpoint.processId,
+    "port": endpoint.port,
+    "token": endpoint.token,
+  }
+
+proc parseEndpoint(content: string): KosmoCliEndpoint =
+  let node = parseJson(content)
+  result = KosmoCliEndpoint(
+    version: node["version"].getInt(),
+    instanceId: node["instanceId"].getStr(),
+    processId: node["processId"].getInt(),
+    port: node["port"].getInt(),
+    token: node["token"].getStr(),
+  )
+  if result.version != KosmoCliProtocolVersion or result.instanceId.len == 0 or
+      result.token.len < 16 or result.port notin 1 .. 65_535:
+    raise newException(ValueError, "Invalid Kosmo CLI endpoint")
+
+proc secureRegistryDirectory(path: string) =
+  createDir(path)
+  when defined(posix):
+    setFilePermissions(path, {fpUserRead, fpUserWrite, fpUserExec})
+
+proc writeEndpoint(path: string, endpoint: KosmoCliEndpoint) =
+  path.parentDir().secureRegistryDirectory()
+  let temporary = path & "." & $getCurrentProcessId() & ".tmp"
+  try:
+    writeFile(temporary, $endpoint.endpointJson())
+    when defined(posix):
+      setFilePermissions(temporary, {fpUserRead, fpUserWrite})
+    moveFile(temporary, path)
+  except:
+    discard tryRemoveFile(temporary)
+    raise
+
+proc readEndpoint(path: string): KosmoCliEndpoint =
+  if path.len == 0 or not fileExists(path) or symlinkExists(path):
+    raise newException(IOError, "Kosmo CLI endpoint is unavailable")
+  parseEndpoint(readFile(path))
+
+proc requestJson(endpoint: KosmoCliEndpoint, request: KosmoCliOpenRequest): JsonNode =
+  %*{
+    "version": KosmoCliProtocolVersion,
+    "instanceId": endpoint.instanceId,
+    "token": endpoint.token,
+    "requestId": request.requestId,
+    "paths": request.paths,
+    "originWindow": request.originWindow,
+  }
+
+proc parseRequest(content: string, endpoint: KosmoCliEndpoint): KosmoCliOpenRequest =
+  let node = parseJson(content)
+  if node["version"].getInt() != KosmoCliProtocolVersion or
+      node["instanceId"].getStr() != endpoint.instanceId or
+      node["token"].getStr() != endpoint.token:
+    raise newException(ValueError, "Kosmo CLI authentication failed")
+  result.requestId = node["requestId"].getStr()
+  result.originWindow = node{"originWindow"}.getStr()
+  for path in node["paths"]:
+    result.paths.add path.getStr()
+  if result.requestId.len == 0 or result.paths.len == 0 or
+      result.paths.len > KosmoCliMaxPaths:
+    raise newException(ValueError, "Invalid Kosmo CLI open request")
+  for path in result.paths:
+    if path.len == 0 or not path.isAbsolute():
+      raise newException(ValueError, "Kosmo CLI paths must be absolute")
+
+func responseJson(response: KosmoCliOpenResponse): JsonNode =
+  %*{
+    "version": KosmoCliProtocolVersion,
+    "delivered": response.delivered,
+    "errors": response.errors,
+  }
+
+proc parseResponse(content: string): KosmoCliOpenResponse =
+  let node = parseJson(content)
+  if node["version"].getInt() != KosmoCliProtocolVersion:
+    raise newException(ValueError, "Incompatible Kosmo CLI response")
+  result.delivered = node["delivered"].getBool()
+  for message in node["errors"]:
+    result.errors.add message.getStr()
+
+proc addEndpointCandidate(
+    candidates: var seq[string], seen: var HashSet[string], path: string
+) =
+  if path.len > 0 and path notin seen:
+    seen.incl path
+    candidates.add path
+
+proc endpointCandidates(registryDirectory, preferredEndpoint: string): seq[string] =
+  var seen = initHashSet[string]()
+  result.addEndpointCandidate(seen, preferredEndpoint)
+  result.addEndpointCandidate(seen, registryDirectory / KosmoCliCurrentEndpointName)
+  if dirExists(registryDirectory):
+    var instances: seq[(Time, string)]
+    try:
+      for kind, path in walkDir(registryDirectory):
+        if kind == pcFile and path.extractFilename().startsWith("instance-") and
+            path.endsWith(".json"):
+          instances.add (getLastModificationTime(path), path)
+    except OSError:
+      discard
+    instances.sort(
+      proc(left, right: (Time, string)): int =
+        cmp(right[0], left[0])
+    )
+    for instance in instances:
+      result.addEndpointCandidate(seen, instance[1])
+
+proc sendRequest(
+    endpoint: KosmoCliEndpoint, request: KosmoCliOpenRequest
+): KosmoCliOpenResponse =
+  let socket = newSocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, buffered = false)
+  defer:
+    socket.close()
+  socket.connect(
+    "127.0.0.1", Port(endpoint.port), timeout = KosmoCliConnectTimeoutMilliseconds
+  )
+  socket.send($endpoint.requestJson(request) & "\n")
+  try:
+    let response = socket.recvLine(
+      timeout = KosmoCliResponseTimeoutMilliseconds, maxLength = KosmoCliMaxMessageBytes
+    )
+    if response.len == 0:
+      raise newException(IOError, "Kosmo closed the CLI connection without a response")
+    result = parseResponse(response)
+  except CatchableError:
+    result.delivered = true
+    result.errors.add "Kosmo did not confirm the CLI open request"
+
+proc openInRunningKosmo*(
+    paths: openArray[string],
+    preferredEndpoint = getEnv(KosmoCliEndpointEnvironment),
+    originWindow = getEnv(KosmoCliWindowEnvironment),
+    registryDirectory = defaultKosmoCliRegistryDirectory(),
+): KosmoCliOpenResponse =
+  ## Forward absolute paths to a responsive Kosmo process. `delivered` remains
+  ## false when no usable process was found.
+  if paths.len == 0 or paths.len > KosmoCliMaxPaths:
+    result.errors.add "A Kosmo CLI request must contain 1 to 64 paths"
+    return
+  let request = KosmoCliOpenRequest(
+    requestId: randomIdentifier(), paths: @paths, originWindow: originWindow
+  )
+  for path in endpointCandidates(registryDirectory, preferredEndpoint):
+    try:
+      let endpoint = readEndpoint(path)
+      result = endpoint.sendRequest(request)
+      if result.delivered:
+        return
+    except CatchableError:
+      discard
+
+proc removeEndpointIfOwned(path, token: string) =
+  try:
+    if fileExists(path) and readEndpoint(path).token == token:
+      removeFile(path)
+  except CatchableError:
+    discard
+
+proc processClient(server: KosmoCliOpenServer, index: int): bool =
+  ## Return true while this client should remain connected.
+  var chunk: string
+  let received = server.clients[index].socket.recv(chunk, 64 * 1024)
+  if received == 0:
+    return
+  server.clients[index].input.add chunk
+  if server.clients[index].input.len > KosmoCliMaxMessageBytes:
+    server.clients[index].socket.send(
+      $(
+        KosmoCliOpenResponse(errors: @["Kosmo CLI request is too large"]).responseJson()
+      ) & "\n"
+    )
+    return
+  let lineEnd = server.clients[index].input.find('\n')
+  if lineEnd < 0:
+    return true
+  var
+    request: KosmoCliOpenRequest
+    response: KosmoCliOpenResponse
+  try:
+    request = parseRequest(server.clients[index].input[0 ..< lineEnd], server.endpoint)
+  except CatchableError as error:
+    response.errors.add error.msg
+    server.clients[index].socket.send($response.responseJson() & "\n")
+    return
+  response.delivered = true
+  try:
+    response = server.handler(request)
+    response.delivered = true
+  except CatchableError as error:
+    response.errors.add error.msg
+  server.clients[index].socket.send($response.responseJson() & "\n")
+
+proc poll(server: KosmoCliOpenServer) {.slot.} =
+  if server.isNil or server.closed:
+    return
+  var serverHandles = @[server.socket.getFd()]
+  if selectRead(serverHandles, 0) > 0 and server.clients.len < 8:
+    try:
+      var client: owned(Socket)
+      server.socket.accept(client)
+      client.getFd().setBlocking(false)
+      server.clients.add KosmoCliClient(socket: client)
+    except OSError:
+      discard
+  var index: int
+  while index < server.clients.len:
+    var clientHandles = @[server.clients[index].socket.getFd()]
+    var keep = true
+    if selectRead(clientHandles, 0) > 0:
+      try:
+        keep = server.processClient(index)
+      except CatchableError:
+        keep = false
+    if keep:
+      inc index
+    else:
+      server.clients[index].socket.close()
+      server.clients.delete(index)
+
+proc startKosmoCliOpenServer*(
+    handler: KosmoCliOpenHandler, registryDirectory = defaultKosmoCliRegistryDirectory()
+): KosmoCliOpenServer =
+  ## Listen on an authenticated loopback endpoint and publish this process as
+  ## the newest CLI destination.
+  if handler.isNil:
+    raise newException(ValueError, "Kosmo CLI open handler is required")
+  let socket = newSocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, buffered = false)
+  var
+    endpoint: KosmoCliEndpoint
+    endpointPath: string
+  try:
+    socket.bindAddr(Port(0), "127.0.0.1")
+    socket.listen()
+    socket.getFd().setBlocking(false)
+    endpoint = KosmoCliEndpoint(
+      version: KosmoCliProtocolVersion,
+      instanceId: randomIdentifier(),
+      processId: getCurrentProcessId(),
+      port: socket.getLocalAddr()[1].int,
+      token: randomIdentifier(),
+    )
+    endpointPath = registryDirectory / ("instance-" & endpoint.instanceId & ".json")
+    writeEndpoint(endpointPath, endpoint)
+    writeEndpoint(registryDirectory / KosmoCliCurrentEndpointName, endpoint)
+    result = KosmoCliOpenServer(
+      socket: socket,
+      endpoint: endpoint,
+      registryDirectory: registryDirectory,
+      endpointPath: endpointPath,
+      handler: handler,
+    )
+    var ticker = KosmoCliTicker()
+    let timerThread = nimkitTimerThread()
+    result.ticker = ticker.moveToThread(timerThread)
+    result.timer = newSigilTimer(KosmoCliPollInterval)
+    connectThreaded(result.timer, timeout, result.ticker, KosmoCliTicker.tick())
+    connectThreaded(result.ticker, kosmoCliTicked, result, KosmoCliOpenServer.poll())
+    result.timer.start(timerThread)
+  except:
+    socket.close()
+    endpointPath.removeEndpointIfOwned(endpoint.token)
+    (registryDirectory / KosmoCliCurrentEndpointName).removeEndpointIfOwned(
+      endpoint.token
+    )
+    raise
+
+proc endpointPath*(server: KosmoCliOpenServer): string =
+  if not server.isNil:
+    result = server.endpointPath
+
+proc close*(server: KosmoCliOpenServer) =
+  if server.isNil or server.closed:
+    return
+  server.closed = true
+  if not server.timer.isNil:
+    server.timer.cancel(nimkitTimerThread())
+  for client in server.clients.mitems:
+    client.socket.close()
+  server.clients.setLen(0)
+  if not server.socket.isNil:
+    server.socket.close()
+  server.endpointPath.removeEndpointIfOwned(server.endpoint.token)
+  (server.registryDirectory / KosmoCliCurrentEndpointName).removeEndpointIfOwned(
+    server.endpoint.token
+  )
+  server.timer = nil
+  server.ticker = nil

--- a/src/merenda/kosmo/cliopen.nim
+++ b/src/merenda/kosmo/cliopen.nim
@@ -7,21 +7,29 @@ import sigils/[core, threadChronos, threadProxies, threads]
 import ../nimkit/foundation/backgroundworkers
 
 const
-  KosmoCliProtocolVersion* = 1
+  KosmoCliProtocolVersion* = 2
   KosmoCliEndpointEnvironment* = "KOSMO_CLI_ENDPOINT"
   KosmoCliWindowEnvironment* = "KOSMO_CLI_WINDOW"
   KosmoCliMaxPaths* = 64
-  KosmoCliMaxMessageBytes* = 1024 * 1024
+  KosmoCliMaxDiffBytes* = 8 * 1024 * 1024
+  KosmoCliMaxMessageBytes* = KosmoCliMaxDiffBytes * 6 + 64 * 1024
   KosmoCliConnectTimeoutMilliseconds* = 2_000
   KosmoCliResponseTimeoutMilliseconds* = 10_000
   KosmoCliPollInterval = initDuration(milliseconds = 50)
   KosmoCliCurrentEndpointName = "current.json"
 
 type
+  KosmoCliRequestKind* = enum
+    kcrOpenPaths
+    kcrShowDiff
+
   KosmoCliOpenRequest* = object
     requestId*: string
+    kind*: KosmoCliRequestKind
     paths*: seq[string]
     originWindow*: string
+    workingDirectory*: string
+    diffText*: string
 
   KosmoCliOpenResponse* = object
     delivered*: bool
@@ -116,8 +124,11 @@ proc requestJson(endpoint: KosmoCliEndpoint, request: KosmoCliOpenRequest): Json
     "instanceId": endpoint.instanceId,
     "token": endpoint.token,
     "requestId": request.requestId,
+    "kind": request.kind.ord,
     "paths": request.paths,
     "originWindow": request.originWindow,
+    "workingDirectory": request.workingDirectory,
+    "diffText": request.diffText,
   }
 
 proc parseRequest(content: string, endpoint: KosmoCliEndpoint): KosmoCliOpenRequest =
@@ -127,15 +138,29 @@ proc parseRequest(content: string, endpoint: KosmoCliEndpoint): KosmoCliOpenRequ
       node["token"].getStr() != endpoint.token:
     raise newException(ValueError, "Kosmo CLI authentication failed")
   result.requestId = node["requestId"].getStr()
+  let kind = node["kind"].getInt()
+  if kind notin KosmoCliRequestKind.low.ord .. KosmoCliRequestKind.high.ord:
+    raise newException(ValueError, "Invalid Kosmo CLI request kind")
+  result.kind = KosmoCliRequestKind(kind)
   result.originWindow = node{"originWindow"}.getStr()
+  result.workingDirectory = node{"workingDirectory"}.getStr()
+  result.diffText = node{"diffText"}.getStr()
   for path in node["paths"]:
     result.paths.add path.getStr()
-  if result.requestId.len == 0 or result.paths.len == 0 or
-      result.paths.len > KosmoCliMaxPaths:
+  if result.requestId.len == 0:
     raise newException(ValueError, "Invalid Kosmo CLI open request")
-  for path in result.paths:
-    if path.len == 0 or not path.isAbsolute():
-      raise newException(ValueError, "Kosmo CLI paths must be absolute")
+  case result.kind
+  of kcrOpenPaths:
+    if result.paths.len == 0 or result.paths.len > KosmoCliMaxPaths:
+      raise newException(ValueError, "Invalid Kosmo CLI open request")
+    for path in result.paths:
+      if path.len == 0 or not path.isAbsolute():
+        raise newException(ValueError, "Kosmo CLI paths must be absolute")
+  of kcrShowDiff:
+    if result.paths.len > 0 or result.workingDirectory.len == 0 or
+        not result.workingDirectory.isAbsolute() or
+        result.diffText.len > KosmoCliMaxDiffBytes:
+      raise newException(ValueError, "Invalid Kosmo CLI diff request")
 
 func responseJson(response: KosmoCliOpenResponse): JsonNode =
   %*{
@@ -200,6 +225,20 @@ proc sendRequest(
     result.delivered = true
     result.errors.add "Kosmo did not confirm the CLI open request"
 
+proc sendToRunningKosmo(
+    request: KosmoCliOpenRequest,
+    preferredEndpoint = getEnv(KosmoCliEndpointEnvironment),
+    registryDirectory = defaultKosmoCliRegistryDirectory(),
+): KosmoCliOpenResponse =
+  for path in endpointCandidates(registryDirectory, preferredEndpoint):
+    try:
+      let endpoint = readEndpoint(path)
+      result = endpoint.sendRequest(request)
+      if result.delivered:
+        return
+    except CatchableError:
+      discard
+
 proc openInRunningKosmo*(
     paths: openArray[string],
     preferredEndpoint = getEnv(KosmoCliEndpointEnvironment),
@@ -211,17 +250,41 @@ proc openInRunningKosmo*(
   if paths.len == 0 or paths.len > KosmoCliMaxPaths:
     result.errors.add "A Kosmo CLI request must contain 1 to 64 paths"
     return
-  let request = KosmoCliOpenRequest(
-    requestId: randomIdentifier(), paths: @paths, originWindow: originWindow
+  result = sendToRunningKosmo(
+    KosmoCliOpenRequest(
+      requestId: randomIdentifier(),
+      kind: kcrOpenPaths,
+      paths: @paths,
+      originWindow: originWindow,
+    ),
+    preferredEndpoint,
+    registryDirectory,
   )
-  for path in endpointCandidates(registryDirectory, preferredEndpoint):
-    try:
-      let endpoint = readEndpoint(path)
-      result = endpoint.sendRequest(request)
-      if result.delivered:
-        return
-    except CatchableError:
-      discard
+
+proc showDiffInRunningKosmo*(
+    diffText, workingDirectory: string,
+    preferredEndpoint = getEnv(KosmoCliEndpointEnvironment),
+    originWindow = getEnv(KosmoCliWindowEnvironment),
+    registryDirectory = defaultKosmoCliRegistryDirectory(),
+): KosmoCliOpenResponse =
+  ## Forward a bounded unified diff to a responsive Kosmo process.
+  if workingDirectory.len == 0 or not workingDirectory.isAbsolute():
+    result.errors.add "Kosmo CLI diff working directory must be absolute"
+    return
+  if diffText.len > KosmoCliMaxDiffBytes:
+    result.errors.add "Kosmo diff input exceeds the 8 MiB limit"
+    return
+  result = sendToRunningKosmo(
+    KosmoCliOpenRequest(
+      requestId: randomIdentifier(),
+      kind: kcrShowDiff,
+      originWindow: originWindow,
+      workingDirectory: workingDirectory,
+      diffText: diffText,
+    ),
+    preferredEndpoint,
+    registryDirectory,
+  )
 
 proc removeEndpointIfOwned(path, token: string) =
   try:

--- a/src/merenda/kosmo/gitdiff.nim
+++ b/src/merenda/kosmo/gitdiff.nim
@@ -15,6 +15,10 @@ const KosmoGitDiffTabIdentifier* = "kosmo.gitDiff"
 type
   GitDiffHighlightKey = tuple[source, language: string]
 
+  GitDiffSource* = enum
+    gdsRepository
+    gdsStandardInput
+
   GitFileDiff* = object
     path*: string
     patch*: string ## Standard three-line-context patch displayed by the viewer.
@@ -23,6 +27,7 @@ type
     binary*: bool
 
   GitDiffSnapshot* = object
+    source*: GitDiffSource
     rootPath*: string
     branch*: string
     hasHead*: bool
@@ -85,6 +90,7 @@ type
     readingGit: bool
     relayoutPending: bool
     generation: uint64
+    readGeneration: uint64
     loading: bool
     closed: bool
     control: SharedPtr[GitDiffControl]
@@ -199,6 +205,92 @@ proc readGitDiff(
 proc readGitDiff*(rootPath: string): GitDiffSnapshot =
   ## Read standard diff hunks plus full-file patches for syntax classification.
   readGitDiff(rootPath, newGitDiffControl())
+
+func normalizedPipedDiffPath(rawPath: string): string =
+  var path = rawPath.strip()
+  let tab = path.find('\t')
+  if tab >= 0:
+    path.setLen(tab)
+  if path.len >= 2 and path[0] == '"' and path[^1] == '"':
+    path = path[1 .. ^2]
+  if path.startsWith("a/") or path.startsWith("b/"):
+    path = path[2 .. ^1]
+  if path != "/dev/null":
+    result = path
+
+func pathFromGitDiffHeader(line: string): string =
+  var marker = line.rfind(" \"b/")
+  if marker >= 0:
+    return normalizedPipedDiffPath(line[marker + 1 .. ^1])
+  marker = line.rfind(" b/")
+  if marker >= 0:
+    result = normalizedPipedDiffPath(line[marker + 1 .. ^1])
+
+func withoutLineEnd(value: string): string =
+  result = value
+  result.stripLineEnd()
+
+proc summarizePipedFile(file: var GitFileDiff) =
+  file.syntaxPatch = file.patch
+  var inHunk: bool
+  for line in file.patch.splitLines():
+    if line.startsWith("@@ "):
+      inHunk = true
+    elif inHunk and line.startsWith("+"):
+      inc file.additions
+    elif inHunk and line.startsWith("-"):
+      inc file.deletions
+    elif line.startsWith("Binary files ") or line.startsWith("GIT binary patch"):
+      file.binary = true
+
+proc finishPipedFile(
+    snapshot: var GitDiffSnapshot,
+    current: var GitFileDiff,
+    oldPath: var string,
+    active: var bool,
+) =
+  if not active:
+    return
+  if current.path.len == 0:
+    current.path = oldPath
+  if current.path.len == 0:
+    current.path = "Patch " & $(snapshot.files.len + 1)
+  current.summarizePipedFile()
+  snapshot.files.add current
+  current = GitFileDiff()
+  oldPath.setLen(0)
+  active = false
+
+proc parseGitDiff*(
+    content: string, workingDirectory = getCurrentDir()
+): GitDiffSnapshot =
+  ## Parse ordinary `git diff` output into the retained Git Diff view model.
+  result.source = gdsStandardInput
+  result.rootPath = normalizedPath(absolutePath(workingDirectory))
+  var
+    current: GitFileDiff
+    oldPath: string
+    active: bool
+
+  for line in content.splitLines(keepEol = true):
+    if line.startsWith("diff --git "):
+      result.finishPipedFile(current, oldPath, active)
+      active = true
+      current.path = pathFromGitDiffHeader(line.withoutLineEnd())
+    elif not active and line.startsWith("--- "):
+      active = true
+    if not active:
+      continue
+    current.patch.add line
+    if line.startsWith("--- "):
+      oldPath = normalizedPipedDiffPath(line[4 .. ^1].withoutLineEnd())
+    elif line.startsWith("+++ "):
+      let newPath = normalizedPipedDiffPath(line[4 .. ^1].withoutLineEnd())
+      if newPath.len > 0:
+        current.path = newPath
+  result.finishPipedFile(current, oldPath, active)
+  if content.strip().len > 0 and result.files.len == 0:
+    result.errorMessage = "Standard input is not a unified Git diff."
 
 proc markdownLabel(value: string): string =
   for ch in value:
@@ -390,19 +482,25 @@ proc renderDiff(panel: KosmoGitDiffPanel) =
     deletions += file.deletions
     if file.binary:
       inc binaries
-  document.add "| Repository | " & panel.snapshot.rootPath.lastPathPart().markdownLabel() &
-    " |\n| --- | --- |\n"
-  if panel.snapshot.branch.len > 0:
-    document.add "| Branch | " & panel.snapshot.branch.markdownLabel() & " |\n"
+  if panel.snapshot.source == gdsStandardInput:
+    document.add "| Source | Standard input |\n| --- | --- |\n"
+  else:
+    document.add "| Repository | " &
+      panel.snapshot.rootPath.lastPathPart().markdownLabel() & " |\n| --- | --- |\n"
+    if panel.snapshot.branch.len > 0:
+      document.add "| Branch | " & panel.snapshot.branch.markdownLabel() & " |\n"
   document.add "| Location | " & panel.snapshot.rootPath.markdownLabel() & " |\n"
   if not panel.readingGit and panel.snapshot.errorMessage.len == 0:
     document.add "| Changes | " & $panel.snapshot.files.len & " files · +" & $additions &
       " / −" & $deletions
     if binaries > 0:
       document.add " · " & $binaries & " binary"
-    document.add " |\n| Compare | Working tree ↔ " &
-      (if panel.snapshot.hasHead: "HEAD" else: "empty tree") &
-      " · includes untracked files |\n"
+    if panel.snapshot.source == gdsStandardInput:
+      document.add " |\n| Compare | Piped unified diff |\n"
+    else:
+      document.add " |\n| Compare | Working tree ↔ " &
+        (if panel.snapshot.hasHead: "HEAD" else: "empty tree") &
+        " · includes untracked files |\n"
   document.add "\n"
   if panel.readingGit:
     document.add "Loading changes…\n"
@@ -410,7 +508,10 @@ proc renderDiff(panel: KosmoGitDiffPanel) =
     document.add "Could not load Git diff.\n\n" &
       panel.snapshot.errorMessage.fencedPatch()
   elif panel.snapshot.files.len == 0:
-    document.add "No changes. Your working tree matches HEAD.\n"
+    if panel.snapshot.source == gdsStandardInput:
+      document.add "The piped diff contains no changes.\n"
+    else:
+      document.add "No changes. Your working tree matches HEAD.\n"
   panel.markdownView.markdown = document
   panel.scheduleSectionLayout()
 
@@ -735,14 +836,23 @@ proc handleSharedKeys(panel: KosmoGitDiffPanel, event: nimkit.KeyEvent): bool =
     return true
 
 proc executeDiff(
-  worker: AgentProxy[GitDiffWorker], root: string, control: SharedPtr[GitDiffControl]
+  worker: AgentProxy[GitDiffWorker],
+  root: string,
+  generation: uint64,
+  control: SharedPtr[GitDiffControl],
 ) {.signal.}
 
-proc diffFinished(worker: GitDiffWorker, snapshot: GitDiffSnapshot) {.signal.}
+proc diffFinished(
+  worker: GitDiffWorker, snapshot: GitDiffSnapshot, generation: uint64
+) {.signal.}
+
 proc executeDiff(
-    worker: GitDiffWorker, root: string, control: SharedPtr[GitDiffControl]
+    worker: GitDiffWorker,
+    root: string,
+    generation: uint64,
+    control: SharedPtr[GitDiffControl],
 ) {.slot.} =
-  emit worker.diffFinished(readGitDiff(root, control))
+  emit worker.diffFinished(readGitDiff(root, control), generation)
 
 proc highlightDiff(
   worker: AgentProxy[GitDiffHighlightWorker],
@@ -806,7 +916,8 @@ proc updateLoading(panel: KosmoGitDiffPanel) =
   panel.loading = panel.readingGit
   for section in panel.sections.values:
     panel.loading = panel.loading or section.pending
-  panel.refreshButton.enabled = not panel.loading
+  panel.refreshButton.enabled =
+    not panel.loading and panel.snapshot.source == gdsRepository
 
 proc applyHighlighting(
     panel: KosmoGitDiffPanel, highlighted: SharedPtr[GitDiffHighlightResult]
@@ -920,15 +1031,41 @@ proc applyDiff(panel: KosmoGitDiffPanel, snapshot: GitDiffSnapshot) {.slot.} =
   panel.updateLoading()
   panel.renderDiff()
 
+proc repositoryDiffFinished(
+    panel: KosmoGitDiffPanel, snapshot: GitDiffSnapshot, generation: uint64
+) {.slot.} =
+  if not panel.closed and generation == panel.readGeneration:
+    panel.applyDiff(snapshot)
+
+proc displayDiff*(panel: KosmoGitDiffPanel, snapshot: GitDiffSnapshot) =
+  ## Replace the current contents with an already prepared, static snapshot.
+  if panel.isNil or panel.closed:
+    return
+  inc panel.readGeneration
+  panel.readingGit = false
+  panel.applyDiff(snapshot)
+
+proc refresh*(panel: KosmoGitDiffPanel)
+
+proc displayRepositoryDiff*(panel: KosmoGitDiffPanel, rootPath: string) =
+  ## Replace static input if needed, then refresh the selected repository.
+  if panel.isNil or panel.closed:
+    return
+  if panel.snapshot.source != gdsRepository or panel.snapshot.rootPath != rootPath:
+    panel.displayDiff(GitDiffSnapshot(source: gdsRepository, rootPath: rootPath))
+  panel.refresh()
+
 proc refresh*(panel: KosmoGitDiffPanel) =
   ## Refresh the current repository on a worker thread.
-  if not panel.closed and not panel.loading:
-    inc panel.generation
+  if not panel.closed and not panel.loading and panel.snapshot.source == gdsRepository:
+    inc panel.readGeneration
     panel.loading = true
     panel.readingGit = true
     panel.refreshButton.enabled = false
     panel.renderDiff()
-    emit panel.worker.executeDiff(panel.snapshot.rootPath, panel.control)
+    emit panel.worker.executeDiff(
+      panel.snapshot.rootPath, panel.readGeneration, panel.control
+    )
 
 proc waitForDiff*(panel: KosmoGitDiffPanel, timeoutMilliseconds = 10000): bool =
   ## Deliver worker results until the diff finishes, for callers without an event loop.
@@ -1004,8 +1141,8 @@ proc textViewForFile*(panel: KosmoGitDiffPanel, index: int): nimkit.TextView =
   if index in 0 ..< panel.snapshot.files.len:
     return panel.sections[panel.snapshot.files[index].path].textView
 
-proc newKosmoGitDiffPanel*(
-    rootPath: string, markdownStyle = nimkit.initMarkdownStyle()
+proc newKosmoGitDiffPanel(
+    rootPath: string, markdownStyle: nimkit.MarkdownStyle, refreshesRepository: bool
 ): KosmoGitDiffPanel =
   ## Construct a syntax-highlighted hunk reader with initially collapsed files.
   startLocalThreadDefault()
@@ -1114,5 +1251,24 @@ proc newKosmoGitDiffPanel*(
   var worker = GitDiffWorker()
   result.worker = worker.moveToThread(result.pool)
   connectThreaded(result.worker, executeDiff, result.worker, executeDiff)
-  connectThreaded(result.worker, diffFinished, result, KosmoGitDiffPanel.applyDiff())
-  result.refresh()
+  connectThreaded(
+    result.worker, diffFinished, result, KosmoGitDiffPanel.repositoryDiffFinished()
+  )
+  if refreshesRepository:
+    result.refresh()
+  else:
+    result.renderDiff()
+
+proc newKosmoGitDiffPanel*(
+    rootPath: string, markdownStyle = nimkit.initMarkdownStyle()
+): KosmoGitDiffPanel =
+  ## Construct a repository-backed Git Diff view.
+  newKosmoGitDiffPanel(rootPath, markdownStyle, refreshesRepository = true)
+
+proc newKosmoGitDiffPanel*(
+    snapshot: GitDiffSnapshot, markdownStyle = nimkit.initMarkdownStyle()
+): KosmoGitDiffPanel =
+  ## Construct a Git Diff view from a static snapshot such as piped input.
+  result =
+    newKosmoGitDiffPanel(snapshot.rootPath, markdownStyle, refreshesRepository = false)
+  result.displayDiff(snapshot)

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -18,15 +18,15 @@ from ../nimkit/view/viewgeometry import setFrameFromLayout
 import ../nimkit/foundation/selectors as nimkitSelectors
 import
   ./[
-    cli, config, contextpanel, filesearchpanel, filetree, gitdiff, moe, moehighlighting,
-    panedocuments, quickopen, searchbar, settings, shortcuts, terminalsearch,
-    workspacefiles,
+    cli, cliopen, config, contextpanel, filesearchpanel, filetree, gitdiff, moe,
+    moehighlighting, panedocuments, quickopen, searchbar, settings, shortcuts,
+    terminalsearch, workspacefiles,
   ]
 import moepkg/celina_backend as celina
 
 export
-  config, contextpanel, filesearchpanel, filetree, gitdiff, moe, moehighlighting,
-  panedocuments, quickopen, settings, shortcuts, terminalsearch
+  cliopen, config, contextpanel, filesearchpanel, filetree, gitdiff, moe,
+  moehighlighting, panedocuments, quickopen, settings, shortcuts, terminalsearch
 
 func nimblePackageVersion(manifest: string): string =
   for line in manifest.splitLines():
@@ -292,6 +292,7 @@ type
     configPath: string
     config: KosmoConfig
     frontends: seq[KosmoApplication]
+    cliServer: KosmoCliOpenServer
 
   KosmoWindowLifecycle = ref object of nimkit.Responder
     frontend: WeakRef[KosmoApplication]
@@ -323,6 +324,7 @@ type
     xTerminalLinksEnabled: bool
     xWindowManager: WeakRef[KosmoWindowManager]
     xWindowLifecycle: KosmoWindowLifecycle
+    xCliWindowId: string
     xHasFileBrowser: bool
     xClosed: bool
 
@@ -3658,10 +3660,20 @@ proc pollWorkspaceGit(lifecycle: KosmoWindowLifecycle) {.slot.} =
       for group in controller.groups:
         group.editorView.refresh()
 
+proc setTerminalEnvironment(
+    options: var nimkit.TerminexSpawnOptions, name, value: string
+) =
+  for variable in options.environment.mitems:
+    if variable.name == name:
+      variable.value = value
+      return
+  options.environment.add nimkit.initTerminalEnvironmentVariable(name, value)
+
 proc newTerminalDocument(
     controller: KosmoDockController, options: nimkit.TerminexSpawnOptions
 ): KosmoPaneDocument =
   let terminalView = newKosmoTerminalView()
+  var resolvedOptions = options
   if not controller.frontend.isNil:
     let frontend = controller.frontend[]
     terminalView.optionAsMeta = frontend.xTerminalOptionAsMeta
@@ -3669,8 +3681,17 @@ proc newTerminalDocument(
     terminalView.connect(
       nimkit.terminalHyperlinkWasActivated, frontend.xWindowLifecycle, openTerminalLink
     )
+    if not frontend.xWindowManager.isNil:
+      let manager = frontend.xWindowManager[]
+      if not manager.cliServer.isNil:
+        resolvedOptions.setTerminalEnvironment(
+          KosmoCliEndpointEnvironment, manager.cliServer.endpointPath()
+        )
+        resolvedOptions.setTerminalEnvironment(
+          KosmoCliWindowEnvironment, frontend.xCliWindowId
+        )
   try:
-    terminalView.start(options)
+    terminalView.start(resolvedOptions)
   except nimkit.TerminexSessionError:
     terminalView.close()
     raise
@@ -3689,7 +3710,7 @@ proc newTerminalDocument(
     onDuplicate = proc(document: KosmoPaneDocument): KosmoPaneDocument =
       discard document
       if not weakController.isNil:
-        result = weakController[].newTerminalDocument(options)
+        result = weakController[].newTerminalDocument(resolvedOptions)
     ,
   )
 
@@ -4343,6 +4364,11 @@ func hasFileBrowser*(frontend: KosmoApplication): bool =
   ## Return whether this window displays a project file browser.
   not frontend.isNil and frontend.xHasFileBrowser
 
+func cliWindowId*(frontend: KosmoApplication): string =
+  ## Return the private routing identifier inherited by terminals from this window.
+  if not frontend.isNil:
+    result = frontend.xCliWindowId
+
 func projectWindowTitle(rootPaths: openArray[string]): string =
   result = "Kosmo"
   if rootPaths.len > 0:
@@ -4637,6 +4663,7 @@ proc newKosmoApplication*(
     xTerminalLinksEnabled: true,
     xWindowManager: manager.unsafeWeakRef(),
     xHasFileBrowser: hasFileBrowser,
+    xCliWindowId: randomIdentifier(),
   )
   let
     controller = KosmoDockController(
@@ -4921,7 +4948,7 @@ proc openPath*(frontend: KosmoApplication, path: string): bool {.discardable.} =
       return not frontend.xWindowManager[].openProject(path).isNil
     let root = normalizedPath(absolutePath(path))
     result = root in frontend.fileTree.rootPaths or frontend.fileTree.addRootPath(root)
-  elif fileExists(path):
+  elif fileExists(path) or (not dirExists(path) and dirExists(path.parentDir())):
     let view = frontend.dockController.activeEditorView()
     if not view.isNil:
       result = view.openFile(path)
@@ -4929,6 +4956,59 @@ proc openPath*(frontend: KosmoApplication, path: string): bool {.discardable.} =
     frontend.updateProjectWindowTitle()
     if not frontend.searchPanel.isNil:
       frontend.searchPanel.rootPaths = frontend.fileTree.rootPaths
+
+proc frontendForCliRequest(
+    manager: KosmoWindowManager, originWindow: string
+): KosmoApplication =
+  if originWindow.len > 0:
+    for frontend in manager.frontends:
+      if not frontend.xClosed and frontend.xCliWindowId == originWindow:
+        return frontend
+  manager.activeFrontend()
+
+proc openCliRequest(
+    manager: KosmoWindowManager, request: KosmoCliOpenRequest
+): KosmoCliOpenResponse =
+  if manager.isNil:
+    result.errors.add "Kosmo has no active window manager"
+    return
+  var
+    folders: seq[string]
+    files: seq[string]
+  for path in request.paths:
+    if dirExists(path):
+      folders.add path
+    elif fileExists(path) or dirExists(path.parentDir()):
+      files.add path
+    else:
+      result.errors.add "Kosmo cannot open path: " & path
+
+  var destination: KosmoApplication
+  if folders.len > 0:
+    destination = manager.openProject(folders[0])
+    if destination.isNil:
+      result.errors.add "Kosmo could not open project folder: " & folders[0]
+    else:
+      for index in 1 ..< folders.len:
+        if not destination.openPath(folders[index]):
+          result.errors.add "Kosmo could not add project folder: " & folders[index]
+  elif files.len > 0:
+    destination = manager.frontendForCliRequest(request.originWindow)
+    if destination.isNil:
+      destination = newKosmoApplication(manager, hasFileBrowser = false)
+
+  if not destination.isNil:
+    for path in files:
+      if not destination.openPath(path):
+        result.errors.add "Kosmo could not open file: " & path
+    destination.show()
+  result.delivered = true
+
+when defined(merendaTests):
+  proc openCliRequestForTesting*(
+      manager: KosmoWindowManager, request: KosmoCliOpenRequest
+  ): KosmoCliOpenResponse =
+    manager.openCliRequest(request)
 
 proc openDocument*(
     frontend: KosmoApplication, document: KosmoPaneDocument
@@ -5014,7 +5094,7 @@ proc close*(manager: KosmoWindowManager) =
   for frontend in frontends:
     frontend.close()
 
-proc runKosmo*(filePath = "") =
+proc runKosmo*(paths: openArray[string]) =
   ## Run Kosmo as a standalone NimKit text-editor application.
   let
     app = nimkit.sharedApplication()
@@ -5025,13 +5105,39 @@ proc runKosmo*(filePath = "") =
       keyBindingsPath = if fileExists(keyBindingsPath): keyBindingsPath else: "",
       configPath = configPath,
     )
-  let frontend = newKosmoApplication(
-    manager, filePath, hasFileBrowser = filePath.len == 0 or not fileExists(filePath)
-  )
   defer:
     manager.close()
-  frontend.show()
-  frontend.application.run()
+  try:
+    manager.cliServer = startKosmoCliOpenServer(
+      proc(request: KosmoCliOpenRequest): KosmoCliOpenResponse =
+        manager.openCliRequest(request)
+    )
+  except CatchableError as error:
+    stderr.writeLine("Kosmo CLI routing is unavailable: " & error.msg)
+  defer:
+    if not manager.cliServer.isNil:
+      manager.cliServer.close()
+
+  if paths.len == 0:
+    newKosmoApplication(manager).show()
+  else:
+    let response = manager.openCliRequest(
+      KosmoCliOpenRequest(requestId: randomIdentifier(), paths: @paths)
+    )
+    for message in response.errors:
+      stderr.writeLine(message)
+  app.run()
+
+proc runKosmo*(filePath = "") =
+  ## Compatibility overload for callers opening one initial path.
+  if filePath.len > 0:
+    runKosmo([filePath])
+  else:
+    runKosmo(newSeq[string]())
+
+proc reportCliErrors(errors: openArray[string]) =
+  for message in errors:
+    stderr.writeLine(message)
 
 when isMainModule:
   let commandLine = parseKosmoCommandLine(commandLineParams())
@@ -5039,7 +5145,21 @@ when isMainModule:
     echo KosmoUsage
   elif commandLine.version:
     echo KosmoVersion
-  elif commandLine.background:
-    launchKosmoInBackground(commandLine.arguments)
   else:
-    runKosmo(commandLine.filePath)
+    let paths = resolveKosmoCliPaths(commandLine.paths)
+    if paths.errors.len > 0:
+      reportCliErrors(paths.errors)
+      quit(1)
+    if paths.paths.len > 0:
+      let response = openInRunningKosmo(paths.paths)
+      if response.delivered:
+        reportCliErrors(response.errors)
+        quit(if response.errors.len == 0: 0 else: 1)
+    if commandLine.background:
+      var arguments: seq[string]
+      if paths.paths.len > 0:
+        arguments.add "--"
+        arguments.add paths.paths
+      launchKosmoInBackground(arguments)
+    else:
+      runKosmo(paths.paths)

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -4080,8 +4080,9 @@ proc showSettings*(frontend: KosmoApplication): bool {.discardable.} =
     frontend.xSettingsWindow.firstResponder,
   ).isNil
 
-proc showGitDiff*(frontend: KosmoApplication): bool {.discardable.} =
-  ## Show full-file Git changes for the active project's repository.
+proc showGitDiffSnapshot(
+    frontend: KosmoApplication, snapshot: GitDiffSnapshot, refreshesRepository: bool
+): bool =
   if frontend.isNil or frontend.dockController.isNil:
     return
   let controller = frontend.dockController
@@ -4091,7 +4092,10 @@ proc showGitDiff*(frontend: KosmoApplication): bool {.discardable.} =
       if not group.window.isNil and not group.window.isClosed():
         if document.contentView of KosmoGitDiffPanel:
           frontend.gitDiffPanel = KosmoGitDiffPanel(document.contentView)
-          frontend.gitDiffPanel.refresh()
+          if refreshesRepository:
+            frontend.gitDiffPanel.displayRepositoryDiff(snapshot.rootPath)
+          else:
+            frontend.gitDiffPanel.displayDiff(snapshot)
         controller.activatePanelWindow(group.window)
         controller.activatePaneTab(group, document.identifier)
         return true
@@ -4106,15 +4110,16 @@ proc showGitDiff*(frontend: KosmoApplication): bool {.discardable.} =
   let group = controller.activePaneGroup()
   if group.isNil:
     return
-  let root =
-    if frontend.fileTree.rootPath.len > 0:
-      frontend.fileTree.rootPath
-    else:
-      getCurrentDir()
   let
-    panel = newKosmoGitDiffPanel(
-      root, group.pane.markdownControls.markdownPresentationStyle()
-    )
+    panel =
+      if refreshesRepository:
+        newKosmoGitDiffPanel(
+          snapshot.rootPath, group.pane.markdownControls.markdownPresentationStyle()
+        )
+      else:
+        newKosmoGitDiffPanel(
+          snapshot, group.pane.markdownControls.markdownPresentationStyle()
+        )
     weakFrontend = frontend.unsafeWeakRef()
     weakPanel = panel.unsafeWeakRef()
     document = newKosmoPaneDocument(
@@ -4122,7 +4127,7 @@ proc showGitDiff*(frontend: KosmoApplication): bool {.discardable.} =
       title = "Git Diff",
       contentView = panel,
       preferredFirstResponder = panel.markdownView.textView(),
-      tooltip = "Current Git diff",
+      tooltip = if refreshesRepository: "Current Git diff" else: "Piped Git diff",
       onClose = proc(document: KosmoPaneDocument): bool =
         discard document
         panel.close()
@@ -4143,6 +4148,27 @@ proc showGitDiff*(frontend: KosmoApplication): bool {.discardable.} =
     return true
   panel.close()
   frontend.gitDiffPanel = nil
+
+proc showGitDiff*(frontend: KosmoApplication): bool {.discardable.} =
+  ## Show full-file Git changes for the active project's repository.
+  if frontend.isNil:
+    return
+  let root =
+    if frontend.fileTree.rootPath.len > 0:
+      frontend.fileTree.rootPath
+    else:
+      getCurrentDir()
+  frontend.showGitDiffSnapshot(
+    GitDiffSnapshot(source: gdsRepository, rootPath: root), refreshesRepository = true
+  )
+
+proc showPipedGitDiff*(
+    frontend: KosmoApplication, content, workingDirectory: string
+): bool {.discardable.} =
+  ## Show a static unified diff received through standard input.
+  frontend.showGitDiffSnapshot(
+    parseGitDiff(content, workingDirectory), refreshesRepository = false
+  )
 
 func ownsWindow(frontend: KosmoApplication, window: nimkit.Window): bool =
   if frontend.isNil or window.isNil or frontend.dockController.isNil:
@@ -4972,6 +4998,18 @@ proc openCliRequest(
   if manager.isNil:
     result.errors.add "Kosmo has no active window manager"
     return
+  if request.kind == kcrShowDiff:
+    var destination = manager.frontendForCliRequest(request.originWindow)
+    if destination.isNil:
+      destination = newKosmoApplication(manager, hasFileBrowser = false)
+      destination.show()
+    let snapshot = parseGitDiff(request.diffText, request.workingDirectory)
+    if not destination.showGitDiffSnapshot(snapshot, refreshesRepository = false):
+      result.errors.add "Kosmo could not open the piped Git diff"
+    elif snapshot.errorMessage.len > 0:
+      result.errors.add snapshot.errorMessage
+    result.delivered = true
+    return
   var
     folders: seq[string]
     files: seq[string]
@@ -5094,8 +5132,7 @@ proc close*(manager: KosmoWindowManager) =
   for frontend in frontends:
     frontend.close()
 
-proc runKosmo*(paths: openArray[string]) =
-  ## Run Kosmo as a standalone NimKit text-editor application.
+proc runKosmoRequest(initialRequest: Option[KosmoCliOpenRequest]) =
   let
     app = nimkit.sharedApplication()
     keyBindingsPath = defaultKosmoKeyBindingsPath()
@@ -5118,15 +5155,39 @@ proc runKosmo*(paths: openArray[string]) =
     if not manager.cliServer.isNil:
       manager.cliServer.close()
 
-  if paths.len == 0:
+  if initialRequest.isNone:
     newKosmoApplication(manager).show()
   else:
-    let response = manager.openCliRequest(
-      KosmoCliOpenRequest(requestId: randomIdentifier(), paths: @paths)
-    )
+    let response = manager.openCliRequest(initialRequest.get())
     for message in response.errors:
       stderr.writeLine(message)
   app.run()
+
+proc runKosmo*(paths: openArray[string]) =
+  ## Run Kosmo as a standalone NimKit text-editor application.
+  if paths.len == 0:
+    runKosmoRequest(none(KosmoCliOpenRequest))
+  else:
+    runKosmoRequest(
+      some(
+        KosmoCliOpenRequest(
+          requestId: randomIdentifier(), kind: kcrOpenPaths, paths: @paths
+        )
+      )
+    )
+
+proc runKosmoDiff*(content: string, workingDirectory = getCurrentDir()) =
+  ## Run Kosmo with a static Git Diff view populated from standard input.
+  runKosmoRequest(
+    some(
+      KosmoCliOpenRequest(
+        requestId: randomIdentifier(),
+        kind: kcrShowDiff,
+        workingDirectory: workingDirectory,
+        diffText: content,
+      )
+    )
+  )
 
 proc runKosmo*(filePath = "") =
   ## Compatibility overload for callers opening one initial path.
@@ -5145,6 +5206,30 @@ when isMainModule:
     echo KosmoUsage
   elif commandLine.version:
     echo KosmoVersion
+  elif commandLine.diff:
+    if commandLine.paths.len > 0:
+      stderr.writeLine("Kosmo --diff does not accept file or folder arguments")
+      quit(1)
+    if kosmoCliInputIsTerminal():
+      stderr.writeLine("Kosmo --diff reads a unified Git diff from standard input")
+      quit(1)
+    var content: string
+    try:
+      content = stdin.readKosmoCliDiff()
+    except CatchableError as error:
+      stderr.writeLine(error.msg)
+      quit(1)
+    let workingDirectory = getCurrentDir()
+    let response = showDiffInRunningKosmo(content, workingDirectory)
+    if response.delivered:
+      reportCliErrors(response.errors)
+      quit(if response.errors.len == 0: 0 else: 1)
+    if commandLine.background:
+      stderr.writeLine(
+        "Kosmo --bg --diff requires a running Kosmo instance to receive the pipe"
+      )
+      quit(1)
+    runKosmoDiff(content, workingDirectory)
   else:
     let paths = resolveKosmoCliPaths(commandLine.paths)
     if paths.errors.len > 0:

--- a/src/merenda/nimkit/text/matterhighlighting.nim
+++ b/src/merenda/nimkit/text/matterhighlighting.nim
@@ -67,6 +67,8 @@ const EmbeddedGrammarArchives = [
   embedGrammarArchive(lispPackage),
   embedGrammarArchive(astroPackage),
   embedGrammarArchive(tclPackage),
+  embedGrammarArchive(terraformSyntaxPackage),
+  embedGrammarArchive(terraformPlanPackage),
 ]
 
 var
@@ -140,10 +142,26 @@ func normalizedMatterLanguage(language: string): string =
   of "py": "python"
   of "rs": "rust"
   of "sh", "bash": "shell"
+  of "hcl", "tf": "terraform"
   of "tex": "latex"
   of "ts": "typescript"
   of "yml": "yaml"
   else: name
+
+func primaryMatterGrammar(modeName: string): Option[GrammarContribution] =
+  result = findMoeGrammar(modeName)
+  if result.isSome:
+    return
+  for contribution in knownGrammars:
+    if contribution.isPrimary and contribution.languageId == modeName:
+      return some(contribution)
+
+iterator relatedMatterGrammars(primary: GrammarContribution): GrammarContribution =
+  yield primary
+  for contribution in knownGrammars:
+    if contribution.packageKey == primary.packageKey and
+        contribution.scopeName != primary.scopeName:
+      yield contribution
 
 proc grammarForLanguage(language: string): Grammar =
   let modeName = language.normalizedMatterLanguage()
@@ -155,13 +173,13 @@ proc grammarForLanguage(language: string): Grammar =
   if matterGrammarCache.hasKey(modeName):
     return matterGrammarCache[modeName]
 
-  let primary = findMoeGrammar(modeName)
+  let primary = primaryMatterGrammar(modeName)
   if primary.isNone:
     matterGrammarCache[modeName] = nil
     return
 
   let registry = newRegistry()
-  for contribution in importedGrammars(modeName):
+  for contribution in relatedMatterGrammars(primary.get()):
     let archive = archiveContents(contribution.dataArchivePath)
     if archive.len == 0:
       raise newException(

--- a/tests/integrations/kosmocliopen.nim
+++ b/tests/integrations/kosmocliopen.nim
@@ -10,9 +10,12 @@ const ClientValueCapacity = 2048
 
 type CliClientState = object
   path: array[ClientValueCapacity, char]
+  diffText: array[ClientValueCapacity, char]
+  workingDirectory: array[ClientValueCapacity, char]
   endpoint: array[ClientValueCapacity, char]
   registry: array[ClientValueCapacity, char]
   origin: array[ClientValueCapacity, char]
+  showsDiff: bool
   delivered: Atomic[bool]
   errorCount: Atomic[int]
   done: Atomic[bool]
@@ -27,12 +30,22 @@ proc load(buffer: ptr array[ClientValueCapacity, char]): string =
 
 proc sendOpenRequest(state: ptr CliClientState) {.thread.} =
   try:
-    let response = openInRunningKosmo(
-      [state.path.addr.load()],
-      preferredEndpoint = state.endpoint.addr.load(),
-      originWindow = state.origin.addr.load(),
-      registryDirectory = state.registry.addr.load(),
-    )
+    let response =
+      if state.showsDiff:
+        showDiffInRunningKosmo(
+          state.diffText.addr.load(),
+          state.workingDirectory.addr.load(),
+          preferredEndpoint = state.endpoint.addr.load(),
+          originWindow = state.origin.addr.load(),
+          registryDirectory = state.registry.addr.load(),
+        )
+      else:
+        openInRunningKosmo(
+          [state.path.addr.load()],
+          preferredEndpoint = state.endpoint.addr.load(),
+          originWindow = state.origin.addr.load(),
+          registryDirectory = state.registry.addr.load(),
+        )
     state.delivered.store(response.delivered, moRelease)
     state.errorCount.store(response.errors.len, moRelease)
   except CatchableError:
@@ -40,15 +53,22 @@ proc sendOpenRequest(state: ptr CliClientState) {.thread.} =
   state.done.store(true, moRelease)
 
 proc requestWhilePumping(
-    path, endpoint, registry: string, origin = ""
+    path, endpoint, registry: string,
+    origin = "",
+    diffText = "",
+    workingDirectory = "",
+    showsDiff = false,
 ): tuple[delivered: bool, errorCount: int] =
   let state = cast[ptr CliClientState](allocShared0(sizeof(CliClientState)))
   defer:
     deallocShared(state)
   path.store(state.path)
+  diffText.store(state.diffText)
+  workingDirectory.store(state.workingDirectory)
   endpoint.store(state.endpoint)
   registry.store(state.registry)
   origin.store(state.origin)
+  state.showsDiff = showsDiff
   var thread: Thread[ptr CliClientState]
   createThread(thread, sendOpenRequest, state)
   let deadline = getMonoTime() + initDuration(seconds = 5)
@@ -138,6 +158,40 @@ suite "Kosmo CLI open transport":
     check response.delivered
     check firstOrigin == "owning-window"
     check secondRequests == 0
+
+  test "piped diffs preserve their content directory and origin window":
+    let
+      registry = createTempDir("merenda-kosmo-cli-diff-", "")
+      diffText = "diff --git a/a.nim b/a.nim\n@@ -1 +1 @@\n-old\n+new\n"
+    defer:
+      removeDir(registry)
+    var received: seq[KosmoCliOpenRequest]
+    let server = startKosmoCliOpenServer(
+      proc(request: KosmoCliOpenRequest): KosmoCliOpenResponse =
+        received.add request
+        KosmoCliOpenResponse(),
+      registry,
+    )
+    defer:
+      server.close()
+
+    let response = requestWhilePumping(
+      "",
+      server.endpointPath(),
+      registry,
+      origin = "diff-window",
+      diffText = diffText,
+      workingDirectory = registry,
+      showsDiff = true,
+    )
+    check response.delivered
+    check response.errorCount == 0
+    require received.len == 1
+    check received[0].kind == kcrShowDiff
+    check received[0].paths.len == 0
+    check received[0].diffText == diffText
+    check received[0].workingDirectory == registry
+    check received[0].originWindow == "diff-window"
 
   test "wrong credentials are rejected and endpoint files are removed on close":
     let registry = createTempDir("merenda-kosmo-cli-auth-", "")

--- a/tests/integrations/kosmocliopen.nim
+++ b/tests/integrations/kosmocliopen.nim
@@ -1,0 +1,199 @@
+## Process-local transport coverage for Kosmo CLI open requests.
+
+import std/[atomics, json, monotimes, os, tempfiles, times, unittest]
+
+import sigils/[core, threads]
+
+import merenda/kosmo/cliopen
+
+const ClientValueCapacity = 2048
+
+type CliClientState = object
+  path: array[ClientValueCapacity, char]
+  endpoint: array[ClientValueCapacity, char]
+  registry: array[ClientValueCapacity, char]
+  origin: array[ClientValueCapacity, char]
+  delivered: Atomic[bool]
+  errorCount: Atomic[int]
+  done: Atomic[bool]
+
+proc store(value: string, buffer: var array[ClientValueCapacity, char]) =
+  doAssert value.len < buffer.len
+  for index, character in value:
+    buffer[index] = character
+
+proc load(buffer: ptr array[ClientValueCapacity, char]): string =
+  $cast[cstring](addr buffer[][0])
+
+proc sendOpenRequest(state: ptr CliClientState) {.thread.} =
+  try:
+    let response = openInRunningKosmo(
+      [state.path.addr.load()],
+      preferredEndpoint = state.endpoint.addr.load(),
+      originWindow = state.origin.addr.load(),
+      registryDirectory = state.registry.addr.load(),
+    )
+    state.delivered.store(response.delivered, moRelease)
+    state.errorCount.store(response.errors.len, moRelease)
+  except CatchableError:
+    state.errorCount.store(-1, moRelease)
+  state.done.store(true, moRelease)
+
+proc requestWhilePumping(
+    path, endpoint, registry: string, origin = ""
+): tuple[delivered: bool, errorCount: int] =
+  let state = cast[ptr CliClientState](allocShared0(sizeof(CliClientState)))
+  defer:
+    deallocShared(state)
+  path.store(state.path)
+  endpoint.store(state.endpoint)
+  registry.store(state.registry)
+  origin.store(state.origin)
+  var thread: Thread[ptr CliClientState]
+  createThread(thread, sendOpenRequest, state)
+  let deadline = getMonoTime() + initDuration(seconds = 5)
+  while not state.done.load(moAcquire) and getMonoTime() < deadline:
+    discard getCurrentSigilThread().pollAll(NonBlocking)
+    sleep(1)
+  check state.done.load(moAcquire)
+  thread.joinThread()
+  result = (
+    delivered: state.delivered.load(moAcquire),
+    errorCount: state.errorCount.load(moAcquire),
+  )
+
+suite "Kosmo CLI open transport":
+  test "authenticated requests reach the newest responsive process":
+    let
+      registry = createTempDir("merenda-kosmo-cli-registry-", "")
+      target = registry / "notes with spaces.md"
+    defer:
+      removeDir(registry)
+    var
+      firstRequests: seq[KosmoCliOpenRequest]
+      secondRequests: seq[KosmoCliOpenRequest]
+    let first = startKosmoCliOpenServer(
+      proc(request: KosmoCliOpenRequest): KosmoCliOpenResponse =
+        firstRequests.add request
+        KosmoCliOpenResponse(),
+      registry,
+    )
+    defer:
+      first.close()
+    let second = startKosmoCliOpenServer(
+      proc(request: KosmoCliOpenRequest): KosmoCliOpenResponse =
+        secondRequests.add request
+        KosmoCliOpenResponse(),
+      registry,
+    )
+    defer:
+      second.close()
+
+    let response = requestWhilePumping(target, "", registry)
+    check response.delivered
+    check response.errorCount == 0
+    check firstRequests.len == 0
+    require secondRequests.len == 1
+    check secondRequests[0].paths == @[target]
+    check secondRequests[0].originWindow.len == 0
+
+    let staleEndpoint = readFile(second.endpointPath())
+    second.close()
+    writeFile(registry / "current.json", staleEndpoint)
+    let fallback = requestWhilePumping(target, "", registry)
+    check fallback.delivered
+    check fallback.errorCount == 0
+    require firstRequests.len == 1
+    check firstRequests[0].paths == @[target]
+
+  test "an embedded-terminal endpoint takes precedence over the newest process":
+    let
+      registry = createTempDir("merenda-kosmo-cli-origin-", "")
+      target = registry / "terminal-target.nim"
+    defer:
+      removeDir(registry)
+    var
+      firstOrigin: string
+      secondRequests: int
+    let first = startKosmoCliOpenServer(
+      proc(request: KosmoCliOpenRequest): KosmoCliOpenResponse =
+        firstOrigin = request.originWindow
+        KosmoCliOpenResponse(),
+      registry,
+    )
+    defer:
+      first.close()
+    let second = startKosmoCliOpenServer(
+      proc(request: KosmoCliOpenRequest): KosmoCliOpenResponse =
+        inc secondRequests
+        KosmoCliOpenResponse(),
+      registry,
+    )
+    defer:
+      second.close()
+
+    let response = requestWhilePumping(
+      target, first.endpointPath(), registry, origin = "owning-window"
+    )
+    check response.delivered
+    check firstOrigin == "owning-window"
+    check secondRequests == 0
+
+  test "wrong credentials are rejected and endpoint files are removed on close":
+    let registry = createTempDir("merenda-kosmo-cli-auth-", "")
+    defer:
+      removeDir(registry)
+    var requestCount: int
+    let server = startKosmoCliOpenServer(
+      proc(request: KosmoCliOpenRequest): KosmoCliOpenResponse =
+        discard request
+        inc requestCount
+        KosmoCliOpenResponse(),
+      registry,
+    )
+    let endpointPath = server.endpointPath()
+    let badEndpointPath = registry / "bad-endpoint.json"
+    var endpoint = parseJson(readFile(endpointPath))
+    endpoint["token"] = %"incorrect-authentication-token"
+    writeFile(badEndpointPath, $endpoint)
+    let emptyRegistry = createTempDir("merenda-kosmo-cli-empty-", "")
+    defer:
+      removeDir(emptyRegistry)
+
+    let response =
+      requestWhilePumping(registry / "rejected.nim", badEndpointPath, emptyRegistry)
+    check not response.delivered
+    check requestCount == 0
+    server.close()
+    check not fileExists(endpointPath)
+    check not fileExists(registry / "current.json")
+
+  test "handler failures are delivered without trying another process":
+    let
+      registry = createTempDir("merenda-kosmo-cli-handler-", "")
+      target = registry / "handler-error.nim"
+    defer:
+      removeDir(registry)
+    var fallbackRequests: int
+    let fallback = startKosmoCliOpenServer(
+      proc(request: KosmoCliOpenRequest): KosmoCliOpenResponse =
+        discard request
+        inc fallbackRequests
+        KosmoCliOpenResponse(),
+      registry,
+    )
+    defer:
+      fallback.close()
+    let failing = startKosmoCliOpenServer(
+      proc(request: KosmoCliOpenRequest): KosmoCliOpenResponse =
+        discard request
+        raise newException(IOError, "open failed"),
+      registry,
+    )
+    defer:
+      failing.close()
+
+    let response = requestWhilePumping(target, "", registry)
+    check response.delivered
+    check response.errorCount == 1
+    check fallbackRequests == 0

--- a/tests/kosmo/cli.nim
+++ b/tests/kosmo/cli.nim
@@ -1,5 +1,5 @@
 ## Kosmo standalone command-line handling shared by the Kosmo test runner.
-import std/[os, tempfiles, times, unittest]
+import std/[os, strutils, tempfiles, times, unittest]
 
 import merenda/kosmo/cli
 
@@ -12,6 +12,7 @@ suite "Kosmo command line":
     check not commandLine.help
     check commandLine.arguments == @["notes.md", "--literal", "with spaces.md"]
     check commandLine.filePath == "notes.md"
+    check commandLine.paths == @["notes.md", "--literal", "with spaces.md"]
 
   test "background child arguments cannot request another background launch":
     let parent = parseKosmoCommandLine(@["project", "--bg", "README.md"])
@@ -30,12 +31,14 @@ suite "Kosmo command line":
     check not child.background
     check child.arguments == @["--", "--bg"]
     check child.filePath == "--bg"
+    check child.paths == @["--bg"]
 
   test "the first non-option remains the target path":
     let commandLine = parseKosmoCommandLine(@["", "later", "--bg"])
     check commandLine.background
     check commandLine.arguments == @["", "later"]
     check commandLine.filePath == ""
+    check commandLine.paths == @["", "later"]
 
   test "help does not become an editor path":
     let commandLine = parseKosmoCommandLine(@["--bg", "--help"])
@@ -56,6 +59,33 @@ suite "Kosmo command line":
     check not commandLine.version
     check commandLine.arguments == @["--", "--version"]
     check commandLine.filePath == "--version"
+    check commandLine.paths == @["--version"]
+
+  test "CLI paths resolve against the invoking shell and retain input order":
+    let
+      root = createTempDir("merenda-kosmo-cli-paths-", "")
+      folder = root / "project"
+      filePath = root / "notes.md"
+    defer:
+      removeDir(root)
+    createDir(folder)
+    writeFile(filePath, "notes")
+    let paths =
+      resolveKosmoCliPaths(@["notes.md", "project", "new.md", "./notes.md"], root)
+    check paths.errors.len == 0
+    check paths.paths == @[filePath, folder, root / "new.md"]
+
+  test "CLI path validation distinguishes new files from missing folders":
+    let root = createTempDir("merenda-kosmo-cli-errors-", "")
+    defer:
+      removeDir(root)
+    let paths =
+      resolveKosmoCliPaths(@["", "missing/", "missing/child.txt", "new.txt"], root)
+    check paths.paths == @[root / "new.txt"]
+    check paths.errors.len == 3
+    check paths.errors[0] == "Kosmo cannot open an empty path"
+    check paths.errors[1].endsWith("missing")
+    check paths.errors[2].endsWith("missing/child.txt")
 
   when not defined(windows):
     test "detached launcher preserves the requested directory and arguments":

--- a/tests/kosmo/cli.nim
+++ b/tests/kosmo/cli.nim
@@ -54,6 +54,13 @@ suite "Kosmo command line":
     check commandLine.arguments.len == 0
     check commandLine.filePath.len == 0
 
+  test "diff input is selected without becoming a path":
+    let commandLine = parseKosmoCommandLine(@["--bg", "--diff"])
+    check commandLine.background
+    check commandLine.diff
+    check commandLine.arguments.len == 0
+    check commandLine.paths.len == 0
+
   test "double dash preserves a literal version path":
     let commandLine = parseKosmoCommandLine(@["--", "--version"])
     check not commandLine.version
@@ -86,6 +93,25 @@ suite "Kosmo command line":
     check paths.errors[0] == "Kosmo cannot open an empty path"
     check paths.errors[1].endsWith("missing")
     check paths.errors[2].endsWith("missing/child.txt")
+
+  test "diff input is read exactly and bounded":
+    let root = createTempDir("merenda-kosmo-cli-diff-", "")
+    defer:
+      removeDir(root)
+    let path = root / "input.diff"
+    writeFile(path, "@@ -1 +1 @@\n-old\n+new\n")
+    let input = open(path, fmRead)
+    defer:
+      input.close()
+    check input.readKosmoCliDiff() == "@@ -1 +1 @@\n-old\n+new\n"
+
+    let oversizedPath = root / "oversized.diff"
+    writeFile(oversizedPath, "12345")
+    let oversized = open(oversizedPath, fmRead)
+    defer:
+      oversized.close()
+    expect ValueError:
+      discard oversized.readKosmoCliDiff(maxBytes = 4)
 
   when not defined(windows):
     test "detached launcher preserves the requested directory and arguments":

--- a/tests/kosmo/cliopen.nim
+++ b/tests/kosmo/cliopen.nim
@@ -1,0 +1,88 @@
+## Kosmo window-routing behavior for command-line open requests.
+
+import std/[options, os, tempfiles, unittest]
+
+import merenda/nimkit
+import merenda/kosmo/kosmo
+
+proc hasOpenPath(frontend: KosmoApplication, path: string): bool =
+  for tab in frontend.editorView.editor.tabs():
+    if tab.filePath == some(path):
+      return true
+
+suite "Kosmo CLI window routing":
+  test "an embedded terminal targets its owning project window":
+    let
+      firstRoot = createTempDir("merenda-kosmo-cli-first-", "")
+      secondRoot = createTempDir("merenda-kosmo-cli-second-", "")
+      firstFile = firstRoot / "first.nim"
+      secondFile = secondRoot / "second.nim"
+      app = newApplication("Kosmo CLI origin")
+      manager = newKosmoWindowManager(app)
+      first = newKosmoApplication(manager, firstRoot, monitorsGitStatus = false)
+      second = newKosmoApplication(manager, secondRoot, monitorsGitStatus = false)
+    defer:
+      manager.close()
+      removeDir(firstRoot)
+      removeDir(secondRoot)
+    writeFile(firstFile, "discard")
+    writeFile(secondFile, "discard")
+    second.show()
+
+    let response = manager.openCliRequestForTesting(
+      KosmoCliOpenRequest(
+        requestId: "origin", paths: @[firstFile], originWindow: first.cliWindowId()
+      )
+    )
+    check response.delivered
+    check response.errors.len == 0
+    check first.hasOpenPath(firstFile)
+    check not second.hasOpenPath(firstFile)
+
+  test "folders create one new multi-root project window for the request":
+    let
+      firstRoot = createTempDir("merenda-kosmo-cli-project-a-", "")
+      secondRoot = createTempDir("merenda-kosmo-cli-project-b-", "")
+      filePath = secondRoot / "opened.nim"
+      app = newApplication("Kosmo CLI projects")
+      manager = newKosmoWindowManager(app)
+      existing = newKosmoApplication(manager, monitorsGitStatus = false)
+    defer:
+      manager.close()
+      removeDir(firstRoot)
+      removeDir(secondRoot)
+    writeFile(filePath, "discard")
+    existing.show()
+
+    let response = manager.openCliRequestForTesting(
+      KosmoCliOpenRequest(
+        requestId: "folders", paths: @[firstRoot, filePath, secondRoot]
+      )
+    )
+    check response.delivered
+    check response.errors.len == 0
+    let windows = manager.managedWindows()
+    require windows.len == 2
+    let project = windows[^1]
+    check project.fileTree.rootPaths == @[firstRoot, secondRoot]
+    check project.hasOpenPath(filePath)
+    check not existing.hasOpenPath(filePath)
+
+  test "a file request without a window creates an editor-only destination":
+    let
+      root = createTempDir("merenda-kosmo-cli-file-window-", "")
+      filePath = root / "new-file.nim"
+      manager = newKosmoWindowManager(newApplication("Kosmo CLI file"))
+    defer:
+      manager.close()
+      removeDir(root)
+
+    let response = manager.openCliRequestForTesting(
+      KosmoCliOpenRequest(requestId: "file", paths: @[filePath])
+    )
+    check response.delivered
+    check response.errors.len == 0
+    let windows = manager.managedWindows()
+    require windows.len == 1
+    check not windows[0].hasFileBrowser()
+    check windows[0].hasOpenPath(filePath)

--- a/tests/kosmo/cliopen.nim
+++ b/tests/kosmo/cliopen.nim
@@ -86,3 +86,42 @@ suite "Kosmo CLI window routing":
     require windows.len == 1
     check not windows[0].hasFileBrowser()
     check windows[0].hasOpenPath(filePath)
+
+  test "a piped diff targets its originating window and opens the Git Diff tab":
+    let
+      root = createTempDir("merenda-kosmo-cli-piped-diff-", "")
+      app = newApplication("Kosmo CLI piped diff")
+      manager = newKosmoWindowManager(app)
+      origin = newKosmoApplication(manager, root, monitorsGitStatus = false)
+      active = newKosmoApplication(manager, monitorsGitStatus = false)
+      diffText =
+        "diff --git a/source.nim b/source.nim\n" & "--- a/source.nim\n+++ b/source.nim\n" &
+        "@@ -1 +1 @@\n-let value = 1\n+let value = 2\n"
+    defer:
+      manager.close()
+      removeDir(root)
+    origin.show()
+    active.show()
+
+    let response = manager.openCliRequestForTesting(
+      KosmoCliOpenRequest(
+        requestId: "piped-diff",
+        kind: kcrShowDiff,
+        originWindow: origin.cliWindowId(),
+        workingDirectory: root,
+        diffText: diffText,
+      )
+    )
+    check response.delivered
+    check response.errors.len == 0
+    require not origin.gitDiffPanel.isNil
+    require origin.gitDiffPanel.waitForDiff()
+    check active.gitDiffPanel.isNil
+    check origin.gitDiffPanel.snapshot.source == gdsStandardInput
+    check origin.gitDiffPanel.snapshot.rootPath == root
+    require origin.gitDiffPanel.snapshot.files.len == 1
+    check origin.gitDiffPanel.snapshot.files[0].path == "source.nim"
+    check origin.gitDiffPanel.snapshot.files[0].additions == 1
+    check origin.gitDiffPanel.snapshot.files[0].deletions == 1
+    check not origin.gitDiffPanel.refreshButton.enabled
+    check origin.documentTabs.selectedDocumentTabIdentifier == KosmoGitDiffTabIdentifier

--- a/tests/kosmo/gitdiff.nim
+++ b/tests/kosmo/gitdiff.nim
@@ -40,6 +40,30 @@ proc rendersDisclosureArrow(view: View, expanded: bool): bool =
   bars == {1, 2, 3}
 
 suite "Kosmo Git diff":
+  test "piped Git output becomes static per-file diff sections":
+    let snapshot = parseGitDiff(
+      "diff --git a/src/main.nim b/src/main.nim\n" & "index 1234567..abcdef0 100644\n" &
+        "--- a/src/main.nim\n+++ b/src/main.nim\n" &
+        "@@ -1,2 +1,2 @@\n-let value = 1\n+let value = 2\n unchanged\n" &
+        "diff --git a/assets/logo.bin b/assets/logo.bin\n" &
+        "Binary files a/assets/logo.bin and b/assets/logo.bin differ\n",
+      getCurrentDir(),
+    )
+    check snapshot.source == gdsStandardInput
+    check snapshot.rootPath == getCurrentDir()
+    check snapshot.errorMessage.len == 0
+    require snapshot.files.len == 2
+    check snapshot.files[0].path == "src/main.nim"
+    check snapshot.files[0].additions == 1
+    check snapshot.files[0].deletions == 1
+    check snapshot.files[0].syntaxPatch == snapshot.files[0].patch
+    check snapshot.files[1].path == "assets/logo.bin"
+    check snapshot.files[1].binary
+
+    let malformed = parseGitDiff("not a diff\n", getCurrentDir())
+    check malformed.files.len == 0
+    check malformed.errorMessage == "Standard input is not a unified Git diff."
+
   test "summary and expanded files share wheel scrolling":
     let root = createTempDir("kosmo-diff-scroll-", "")
     defer:

--- a/tests/kosmo/gitdiff.nim
+++ b/tests/kosmo/gitdiff.nim
@@ -265,6 +265,33 @@ suite "Kosmo Git diff":
       ]
       check storage.attributesAt(index).lineBackgroundColor.a > 0
 
+  test "Terraform HCL changes use Matter syntax highlighting":
+    let root = createTempDir("kosmo-diff-terraform-", "")
+    defer:
+      removeDir(root)
+    initRepository(root)
+    writeFile(
+      root / "main.hcl", "resource \"aws_instance\" \"web\" {\n  ami = \"ami-old\"\n}\n"
+    )
+    git(root, "add", ".")
+    git(root, "commit", "-qm", "Initial")
+    writeFile(
+      root / "main.hcl", "resource \"aws_instance\" \"web\" {\n  ami = \"ami-new\"\n}\n"
+    )
+    let panel = newKosmoGitDiffPanel(root)
+    defer:
+      panel.close()
+    require panel.waitForDiff()
+    let
+      storage = panel.textViewForFile(0).textStorage()
+      text = storage.stringValue()
+      location = text.find("ami-new")
+    require location >= 0
+    let index = text[0 ..< location].runeLen
+    check storage.attributesAt(index).foregroundColor ==
+      panel.markdownView.markdownStyle().syntaxTokenColors[stcString]
+    check storage.attributesAt(index).lineBackgroundColor.a > 0
+
   test "standard hunks include staged unstaged untracked deleted and binary files":
     let root = createTempDir("kosmo-git-diff-", "")
     defer:

--- a/tests/tintegrations.nim
+++ b/tests/tintegrations.nim
@@ -1,4 +1,5 @@
 ## Shared runner for tests requiring cross-component or process-level integration.
 import integrations/application_sigils
 import integrations/figdraw_text_offsets
+import integrations/kosmocliopen
 import integrations/urlassets

--- a/tests/tkosmo.nim
+++ b/tests/tkosmo.nim
@@ -4,6 +4,7 @@ import std/[strutils, unicode, unittest]
 import merenda/nimkit
 import merenda/kosmo/kosmo
 import kosmo/cli
+import kosmo/cliopen
 import kosmo/config
 import kosmo/contextpanel
 import kosmo/editorsearch


### PR DESCRIPTION
`kosmo <file-or-folder ...>` now resolves paths from the invoking shell and routes them to a running Kosmo process. Files open in the active window, commands from embedded terminals return to their owning window, and folder requests create one new multi-root project window. Missing files are accepted when their parent exists; invalid paths fail before anything is opened.

`git diff <path> | kosmo --diff` sends the unified diff to the same destination selection logic and renders it as a static snapshot in Kosmo's Git Diff view. The view preserves per-file sections, change counts, syntax highlighting, binary markers, and the invoking working directory. Static snapshots disable Refresh. Empty input opens a clean diff view, malformed input remains visible with an error, and input is bounded to 8 MiB. With no responsive process, Kosmo opens an editor-only window for the snapshot; `--bg --diff` reports that a running instance is required because the detached child cannot retain the pipe.

Terraform source highlighting now embeds Matter 0.4.1's Terraform grammar archives and maps `.hcl` and `.tf` language tags to the Terraform grammar, including inside repository and piped Git Diff sections.

Running processes publish private authenticated loopback endpoints. Embedded-terminal endpoints take precedence, other shells select the newest responsive process, and stale endpoints fall back safely. Once a request may have been delivered, Kosmo does not retry it in another process. With no responsive process, ordinary path commands start Kosmo normally and preserve the existing `--bg` behavior.

The branch includes the latest `origin/main` workspace visibility and bounded-loading changes and advances the Merenda package version to `0.17.7`.

Validation:

- `atlas-run tests` (4/4 shared runners passed)
- `atlas-run tests --compile-only examples/all_compile.nim`
- Release-style standalone `nim c` build with `-d:moe.embedded`
- Standalone `--help`, `--version`, and invalid `--diff` argument smoke checks
