### PR TITLE
Use Matter highlighting in Kosmo Moe

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,12 @@ a path starts with a dash. Tagged releases provide Linux, macOS, and Windows
 binaries; see [Releasing Kosmo binaries](docs/releasing-kosmo.md) for artifact and
 macOS signing details.
 
+For arbitrary text, use `sometool | kosmo --file:txt` (or `--file:log`,
+`--file:hcl`, etc.). This opens a separate modified editor buffer named `stdin.txt`
+after stdin reaches EOF. The extension selects syntax highlighting; saving uses the invoking
+directory. No file is read or written until you explicitly save. Input is limited
+to 8 MiB, and `--bg --file:txt` requires an already running Kosmo instance.
+
 Pipe unified Git output to `kosmo --diff` to render a static snapshot in Kosmo's
 Git Diff view, for example `git diff some-folder | kosmo --diff`. The same process
 and embedded-terminal routing rules apply. Piped diffs are limited to 8 MiB and

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Atlas:
 atlas install -tuk --features:kosmo
 ```
 
+Merenda's `config.nims` enables Moe's optional Matter backend for repository
+builds. Applications that consume Merenda as an Atlas dependency must add the
+same conditional define to their own `config.nims`:
+
+```nim
+when defined(features.merenda.kosmo):
+  switch("define", "features.moe.matter")
+```
+
 Kosmo's browser and quick open share a background file inventory. See
 [workspace updates](docs/kosmo-workspace.md) for file/Git watching, process
 lifetime, and the current Linux polling fallback.
@@ -221,9 +230,10 @@ Language-tagged fenced code blocks use the same frontend-neutral
 presentation colors. The Markdown parser still owns all document structure and
 inline styling—the syntax highlighter never receives the Markdown source outside
 the contents of a tagged fence. Matter's bundled TextMate grammars are the
-default in both NimKit and Kosmo, while SynEdit and Moe remain available as
-alternative highlighters. A nil highlighter or unknown language retains the
-ordinary monospace `codeColor`.
+default for NimKit Markdown and Kosmo's Moe editor. Moe falls back to its
+built-in tokenizer when a mode has no bundled grammar; a nil Markdown
+highlighter or unknown fenced language retains the ordinary monospace
+`codeColor`.
 
 ## Cached URL Assets
 

--- a/config.nims
+++ b/config.nims
@@ -30,6 +30,9 @@ when defined(linux) and defined(gcc):
 
 switch("define", "features.markdown.regex") # temporary hack until we get atlas 0.15.1
 
+when defined(features.merenda.kosmo):
+  switch("define", "features.moe.matter")
+
 import std/strutils
 import std/os
 

--- a/config.nims
+++ b/config.nims
@@ -31,6 +31,7 @@ when defined(linux) and defined(gcc):
 switch("define", "features.markdown.regex") # temporary hack until we get atlas 0.15.1
 
 when defined(features.merenda.kosmo):
+  switch("define", "moe.embedded")
   switch("define", "features.moe.matter")
 
 import std/strutils

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -17,7 +17,7 @@ requires "cborious"
 requires "unicodedb >= 0.14.0"
 requires "faststreams >= 0.5.1"
 requires "gh:elcritch/nim-markdown#devel[regex]"
-requires "gh:elcritch/matter >= 0.4.1"
+requires "gh:elcritch/matter#333b79c75fa883a3ebb5ddd7d4fdbd7a11819b94"
 requires "gh:elcritch/terminex >= 0.3.0"
 requires "gh:Araq/iconbundler"
 requires "libbacktrace"
@@ -28,7 +28,7 @@ feature "uirelays":
   requires "gh:nim-lang/uirelays#688dd44"
 
 feature "kosmo":
-  requires "gh:elcritch/moe#develop"
+  requires "gh:elcritch/moe#5e39a1bc8184809641542c1cb2c2d08b82854c81"
 
 feature "references":
   requires "https://github.com/ravynsoft/ravynos"

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -1,4 +1,4 @@
-version       = "0.17.7"
+version       = "0.17.8"
 author        = "Jaremy Creechley"
 description   = "Nim-native UI toolkit"
 license       = "BSD-3-Clause"

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -28,8 +28,7 @@ feature "uirelays":
   requires "gh:nim-lang/uirelays#688dd44"
 
 feature "kosmo":
-  requires "gh:elcritch/moe#fix/git-refresh-lifecycle"
-  # requires "gh:elcritch/moe#integration-improvements"
+  requires "gh:elcritch/moe#develop"
 
 feature "references":
   requires "https://github.com/ravynsoft/ravynos"

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -28,7 +28,7 @@ feature "uirelays":
   requires "gh:nim-lang/uirelays#688dd44"
 
 feature "kosmo":
-  requires "gh:elcritch/moe#5e39a1bc8184809641542c1cb2c2d08b82854c81"
+  requires "gh:elcritch/moe#develop"
 
 feature "references":
   requires "https://github.com/ravynsoft/ravynos"

--- a/src/merenda/kosmo/cli.nim
+++ b/src/merenda/kosmo/cli.nim
@@ -1,6 +1,6 @@
 ## Command-line handling and detached launching for standalone Kosmo.
 
-import std/[os, sets, terminal]
+import std/[os, sequtils, sets, strutils, terminal]
 
 when defined(windows):
   import std/[widestrs, winlean]
@@ -18,10 +18,12 @@ const
     """
 Usage: kosmo [--bg] [--version] [--] [file-or-folder ...]
        command-producing-diff | kosmo --diff
+       command-producing-text | kosmo --file:txt
 
 Options:
   --bg        Start Kosmo detached from the invoking shell.
   --diff      Render a unified Git diff read from standard input.
+  --file:type Open stdin as stdin.type (e.g. --file:txt; maximum 8 MiB).
   --version   Show the Kosmo version.
   --          Stop parsing options.
   -h, --help  Show this help text.
@@ -32,6 +34,8 @@ type KosmoStandaloneCommandLine* = object ## Parsed standalone command-line opti
   help*: bool
   version*: bool
   diff*: bool
+  stdinName*: string
+  errors*: seq[string]
   arguments*: seq[string]
   filePath*: string
   paths*: seq[string]
@@ -66,12 +70,28 @@ proc parseKosmoCommandLine*(arguments: openArray[string]): KosmoStandaloneComman
         result.version = true
       of KosmoDiffFlag:
         result.diff = true
+      of "--file":
+        result.errors.add "Use --file:type, for example --file:txt"
       else:
+        if argument.startsWith("--file:"):
+          let fileType = argument[7 .. ^1]
+          if fileType.len == 0 or fileType.len > 64 or
+              fileType.anyIt(
+                it notin {'a' .. 'z', 'A' .. 'Z', '0' .. '9', '_', '-', '.'}
+              ) or fileType[0] == '.' or fileType[^1] == '.' or ".." in fileType:
+            result.errors.add "--file:type requires a file extension such as txt or log"
+          elif result.stdinName.len > 0:
+            result.errors.add "Specify --file:type only once"
+          else:
+            result.stdinName = "stdin." & fileType
+          continue
         result.arguments.add argument
         if not hasFilePath:
           result.filePath = argument
           hasFilePath = true
         result.paths.add argument
+  if result.stdinName.len > 0 and (result.diff or result.paths.len > 0):
+    result.errors.add "--file cannot be combined with --diff or file/folder arguments"
 
 proc resolveKosmoCliPaths*(
     paths: openArray[string], workingDirectory = getCurrentDir()
@@ -100,8 +120,8 @@ proc kosmoCliInputIsTerminal*(): bool =
   ## Return whether `--diff` would read interactively instead of from a pipe.
   stdin.isatty()
 
-proc readKosmoCliDiff*(input: File, maxBytes = KosmoCliDiffInputLimit): string =
-  ## Read a bounded diff payload, including an empty diff from a clean work tree.
+proc readKosmoCliText*(input: File, maxBytes = KosmoCliDiffInputLimit): string =
+  ## Read stdin through EOF, preserving bytes and enforcing the input limit.
   const ChunkSize = 64 * 1024
   var buffer: array[ChunkSize, char]
   while true:
@@ -109,10 +129,14 @@ proc readKosmoCliDiff*(input: File, maxBytes = KosmoCliDiffInputLimit): string =
     if count == 0:
       break
     if result.len + count > maxBytes:
-      raise newException(ValueError, "Kosmo diff input exceeds the 8 MiB limit")
+      raise newException(ValueError, "Kosmo stdin input exceeds the size limit")
     let start = result.len
     result.setLen(start + count)
     copyMem(addr result[start], addr buffer[0], count)
+
+proc readKosmoCliDiff*(input: File, maxBytes = KosmoCliDiffInputLimit): string =
+  ## Read a bounded diff payload, including an empty diff from a clean work tree.
+  input.readKosmoCliText(maxBytes)
 
 when defined(windows):
   const CreateNewProcessGroup = 0x00000200'i32

--- a/src/merenda/kosmo/cliopen.nim
+++ b/src/merenda/kosmo/cliopen.nim
@@ -22,6 +22,7 @@ type
   KosmoCliRequestKind* = enum
     kcrOpenPaths
     kcrShowDiff
+    kcrOpenStdin
 
   KosmoCliOpenRequest* = object
     requestId*: string
@@ -30,6 +31,8 @@ type
     originWindow*: string
     workingDirectory*: string
     diffText*: string
+    stdinName*: string
+    stdinText*: string
 
   KosmoCliOpenResponse* = object
     delivered*: bool
@@ -129,6 +132,8 @@ proc requestJson(endpoint: KosmoCliEndpoint, request: KosmoCliOpenRequest): Json
     "originWindow": request.originWindow,
     "workingDirectory": request.workingDirectory,
     "diffText": request.diffText,
+    "stdinName": request.stdinName,
+    "stdinText": request.stdinText,
   }
 
 proc parseRequest(content: string, endpoint: KosmoCliEndpoint): KosmoCliOpenRequest =
@@ -145,6 +150,8 @@ proc parseRequest(content: string, endpoint: KosmoCliEndpoint): KosmoCliOpenRequ
   result.originWindow = node{"originWindow"}.getStr()
   result.workingDirectory = node{"workingDirectory"}.getStr()
   result.diffText = node{"diffText"}.getStr()
+  result.stdinName = node{"stdinName"}.getStr()
+  result.stdinText = node{"stdinText"}.getStr()
   for path in node["paths"]:
     result.paths.add path.getStr()
   if result.requestId.len == 0:
@@ -161,6 +168,10 @@ proc parseRequest(content: string, endpoint: KosmoCliEndpoint): KosmoCliOpenRequ
         not result.workingDirectory.isAbsolute() or
         result.diffText.len > KosmoCliMaxDiffBytes:
       raise newException(ValueError, "Invalid Kosmo CLI diff request")
+  of kcrOpenStdin:
+    if result.stdinName.len == 0 or result.stdinText.len > KosmoCliMaxDiffBytes or
+        not result.workingDirectory.isAbsolute() or result.paths.len > 0:
+      raise newException(ValueError, "Invalid Kosmo CLI stdin request")
 
 func responseJson(response: KosmoCliOpenResponse): JsonNode =
   %*{
@@ -281,6 +292,30 @@ proc showDiffInRunningKosmo*(
       originWindow: originWindow,
       workingDirectory: workingDirectory,
       diffText: diffText,
+    ),
+    preferredEndpoint,
+    registryDirectory,
+  )
+
+proc openStdinInRunningKosmo*(
+    name, content, workingDirectory: string,
+    preferredEndpoint = getEnv(KosmoCliEndpointEnvironment),
+    originWindow = getEnv(KosmoCliWindowEnvironment),
+    registryDirectory = defaultKosmoCliRegistryDirectory(),
+): KosmoCliOpenResponse =
+  ## Forward stdin as a named, unsaved editor buffer.
+  if name.len == 0 or content.len > KosmoCliMaxDiffBytes or
+      not workingDirectory.isAbsolute():
+    result.errors.add "Invalid Kosmo stdin input (maximum 8 MiB)"
+    return
+  sendToRunningKosmo(
+    KosmoCliOpenRequest(
+      requestId: randomIdentifier(),
+      kind: kcrOpenStdin,
+      stdinName: name,
+      stdinText: content,
+      workingDirectory: workingDirectory,
+      originWindow: originWindow,
     ),
     preferredEndpoint,
     registryDirectory,

--- a/src/merenda/kosmo/filetree.nim
+++ b/src/merenda/kosmo/filetree.nim
@@ -459,6 +459,38 @@ proc `filterText=`*(tree: KosmoFileTree, text: string) =
     return
   tree.reloadFilteredTree()
 
+proc revealPath*(tree: KosmoFileTree, path: string): bool {.discardable.} =
+  ## Expand, select, and scroll to a path visible in the current roots and scope.
+  if tree.isNil or path.len == 0:
+    return
+  let targetPath = normalizedPath(absolutePath(path))
+  var rootPath: string
+  for root in tree.xRootPaths:
+    if targetPath == root or targetPath.isRelativeTo(root):
+      rootPath = root
+      break
+  if rootPath.len == 0 or not tree.displayModeIncludes(targetPath):
+    return
+  if tree.xFilterText.strip().len > 0 and targetPath notin tree.xMatchingPaths:
+    return
+
+  var ancestors: seq[string]
+  var currentPath = targetPath.parentDir()
+  while currentPath.len > 0:
+    ancestors.add currentPath
+    if currentPath == rootPath:
+      break
+    let parentPath = currentPath.parentDir()
+    if parentPath == currentPath:
+      return
+    currentPath = parentPath
+  if ancestors.len == 0 or ancestors[^1] != rootPath:
+    return
+  ancestors.reverse()
+  for ancestor in ancestors:
+    tree.expandItem(ancestor)
+  result = tree.selectItemWithIdentifier(targetPath)
+
 proc reloadRoots(tree: KosmoFileTree, expanded: seq[string]) =
   tree.xWorkspaceFiles.setRoots(tree.xRootPaths)
   tree.xChildren.clear()

--- a/src/merenda/kosmo/gitdiff.nim
+++ b/src/merenda/kosmo/gitdiff.nim
@@ -10,7 +10,9 @@ import ../nimkit/foundation/selectors as nimkitSelectors
 from ../nimkit/view/viewgeometry import setFrameFromLayout
 import ../nimkit/foundation/mainthreadwork
 
-const KosmoGitDiffTabIdentifier* = "kosmo.gitDiff"
+const
+  KosmoGitDiffTabIdentifier* = "kosmo.gitDiff"
+  GitDiffRefreshDebounceInterval = initDuration(milliseconds = 300)
 
 type
   GitDiffHighlightKey = tuple[source, language: string]
@@ -88,6 +90,9 @@ type
     worker: AgentProxy[GitDiffWorker]
     sections: Table[string, GitDiffSection]
     readingGit: bool
+    refreshPending: bool
+    refreshDeadline: MonoTime
+    refreshDebounce: Duration
     relayoutPending: bool
     generation: uint64
     readGeneration: uint64
@@ -98,6 +103,7 @@ type
     keyEquivalentHandler: GitDiffKeyEquivalentHandler
     xHighlightBuildCount: int
     xHighlightThreadId: int
+    xRepositoryReadCount: int
 
 proc newGitDiffControl(): SharedPtr[GitDiffControl] =
   result = newSharedPtr(GitDiffControl)
@@ -1047,6 +1053,22 @@ proc displayDiff*(panel: KosmoGitDiffPanel, snapshot: GitDiffSnapshot) =
 
 proc refresh*(panel: KosmoGitDiffPanel)
 
+proc pollRepositoryRefresh*(panel: KosmoGitDiffPanel): bool {.discardable.} =
+  ## Start a trailing repository refresh once its quiet period has elapsed.
+  if panel.isNil or panel.closed or not panel.refreshPending or panel.loading:
+    return
+  if getMonoTime() >= panel.refreshDeadline:
+    panel.refreshPending = false
+    panel.refresh()
+    result = true
+
+proc scheduleRepositoryRefresh*(panel: KosmoGitDiffPanel) =
+  ## Coalesce repository notifications until the workspace has been quiet.
+  if panel.isNil or panel.closed or panel.snapshot.source != gdsRepository:
+    return
+  panel.refreshPending = true
+  panel.refreshDeadline = getMonoTime() + panel.refreshDebounce
+
 proc displayRepositoryDiff*(panel: KosmoGitDiffPanel, rootPath: string) =
   ## Replace static input if needed, then refresh the selected repository.
   if panel.isNil or panel.closed:
@@ -1058,7 +1080,9 @@ proc displayRepositoryDiff*(panel: KosmoGitDiffPanel, rootPath: string) =
 proc refresh*(panel: KosmoGitDiffPanel) =
   ## Refresh the current repository on a worker thread.
   if not panel.closed and not panel.loading and panel.snapshot.source == gdsRepository:
+    panel.refreshPending = false
     inc panel.readGeneration
+    inc panel.xRepositoryReadCount
     panel.loading = true
     panel.readingGit = true
     panel.refreshButton.enabled = false
@@ -1071,11 +1095,12 @@ proc waitForDiff*(panel: KosmoGitDiffPanel, timeoutMilliseconds = 10000): bool =
   ## Deliver worker results until the diff finishes, for callers without an event loop.
   let deadline = getMonoTime() + initDuration(milliseconds = timeoutMilliseconds)
   while getMonoTime() < deadline:
+    discard panel.pollRepositoryRefresh()
     discard getCurrentSigilThread().pollAll(NonBlocking)
     discard drainMainThreadWork()
     var pending =
-      panel.loading or panel.relayoutPending or panel.markdownView.isMarkdownParsing() or
-      panel.markdownView.isMarkdownRendering() or
+      panel.loading or panel.refreshPending or panel.relayoutPending or
+      panel.markdownView.isMarkdownParsing() or panel.markdownView.isMarkdownRendering() or
       panel.markdownView.textView().layoutManager().isBackgroundLayoutPending()
     for path, section in panel.sections:
       if path notin panel.collapsed:
@@ -1090,6 +1115,7 @@ proc close*(panel: KosmoGitDiffPanel) {.slot.} =
     panel.closed = true
     inc panel.generation
     panel.loading = false
+    panel.refreshPending = false
     for section in panel.sections.values:
       section.textView.removeFromSuperview()
     panel.sections.clear()
@@ -1136,6 +1162,10 @@ proc highlightThreadId*(panel: KosmoGitDiffPanel): int =
   ## Thread that prepared the latest highlighted snapshot; zero before completion.
   panel.xHighlightThreadId
 
+proc repositoryReadCount*(panel: KosmoGitDiffPanel): int =
+  ## Number of repository snapshots requested, for refresh diagnostics.
+  panel.xRepositoryReadCount
+
 proc textViewForFile*(panel: KosmoGitDiffPanel, index: int): nimkit.TextView =
   ## Retained per-file text; collapsed sections keep their prepared storage.
   if index in 0 ..< panel.snapshot.files.len:
@@ -1152,6 +1182,7 @@ proc newKosmoGitDiffPanel(
     expandButton: nimkit.newButton("Expand All"),
     collapseButton: nimkit.newButton("Collapse All"),
     snapshot: GitDiffSnapshot(rootPath: rootPath),
+    refreshDebounce: GitDiffRefreshDebounceInterval,
     disclosureButtons: initTable[string, GitDiffDisclosureButton](),
     pool: newSigilThreadPool(workers = 1),
     control: newGitDiffControl(),

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -4082,6 +4082,7 @@ proc showSettings*(frontend: KosmoApplication): bool {.discardable.} =
     shortcuts = frontend.dockController.shortcutBindings.kosmoShortcutSettings()
     moeThemes = frontend.dockController.editor.availableMoeThemes()
     moeThemeSettings = moeThemes.moeThemeSettings()
+    textMateGrammars = frontend.dockController.editor.availableTextMateGrammars()
     selectedMoeThemeIdentifier =
       frontend.dockController.editor.activeMoeThemeIdentifier()
   if frontend.xSettingsWindow.isNil or frontend.xSettingsWindow.window.isClosed():
@@ -4114,6 +4115,7 @@ proc showSettings*(frontend: KosmoApplication): bool {.discardable.} =
         if not weakFrontend.isNil:
           return weakFrontend[].setMoeTheme(identifier)
       ,
+      textMateGrammars = textMateGrammars,
     )
   else:
     frontend.xSettingsWindow.optionAsMeta = frontend.xTerminalOptionAsMeta
@@ -4122,6 +4124,7 @@ proc showSettings*(frontend: KosmoApplication): bool {.discardable.} =
     frontend.xSettingsWindow.updateMoeThemes(
       moeThemeSettings, selectedMoeThemeIdentifier
     )
+    frontend.xSettingsWindow.textMateGrammars = textMateGrammars
   result = not frontend.application.showWindow(
     frontend.xSettingsWindow.window, frontend.xSettingsWindow.contentView,
     frontend.xSettingsWindow.firstResponder,

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -844,13 +844,17 @@ proc selectEditorContent(view: KosmoEditorView, id: KosmoBufferId) =
   group.selectedTabIdentifier = id.tabIdentifier
   group.pane.setContentView(view)
 
-func statusText(status: KosmoStatus, tabs: openArray[KosmoTab]): string =
+proc statusText(
+    status: KosmoStatus, tabs: openArray[KosmoTab], workingDirectory: string
+): string =
   var parts: seq[string]
+  var activeFilePath: Option[string]
   if status.modeLabel.len > 0:
     parts.add status.modeLabel
   for tab in tabs:
     if tab.active:
       parts.add tab.title
+      activeFilePath = tab.filePath
       break
   if status.message.len > 0:
     parts.add status.message
@@ -863,6 +867,15 @@ func statusText(status: KosmoStatus, tabs: openArray[KosmoTab]): string =
     if status.gitDeleted != 0:
       git.add " -" & $status.gitDeleted
     parts.add git
+  if activeFilePath.isSome:
+    let
+      filePath = activeFilePath.get
+      basePath =
+        if workingDirectory.len > 0:
+          absolutePath(workingDirectory)
+        else:
+          getCurrentDir()
+    parts.add normalizedPath(absolutePath(filePath, basePath))
   parts.join("  •  ")
 
 proc visibleTabs(view: KosmoEditorView, tabs: openArray[KosmoTab]): seq[KosmoTab] =
@@ -1091,7 +1104,7 @@ proc syncChrome(view: KosmoEditorView) =
   let tabs = view.visibleTabs(view.editor.tabs())
   view.syncTabs(tabs)
   if not view.statusLabel.isNil and view.isActiveEditorGroup():
-    let text = view.editor.status().statusText(tabs)
+    let text = view.editor.status().statusText(tabs, view.editor.workingDirectory())
     if view.statusLabel.text != text:
       view.statusLabel.text = text
   let command = view.editor.commandLine()

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -2,7 +2,8 @@
 
 when not defined(features.merenda.kosmo):
   {.
-    error: """
+    error:
+      """
 Kosmo requires the "kosmo" feature. Enable it with Atlas:
 
   atlas install -tuk --features:kosmo
@@ -4130,10 +4131,11 @@ proc showSettings*(frontend: KosmoApplication): bool {.discardable.} =
       moeThemeSettings, selectedMoeThemeIdentifier
     )
     frontend.xSettingsWindow.textMateGrammars = textMateGrammars
-  result = not frontend.application.showWindow(
-    frontend.xSettingsWindow.window, frontend.xSettingsWindow.contentView,
-    frontend.xSettingsWindow.firstResponder,
-  ).isNil
+  result =
+    not frontend.application.showWindow(
+      frontend.xSettingsWindow.window, frontend.xSettingsWindow.contentView,
+      frontend.xSettingsWindow.firstResponder,
+    ).isNil
 
 proc showGitDiffSnapshot(
     frontend: KosmoApplication, snapshot: GitDiffSnapshot, refreshesRepository: bool
@@ -4477,7 +4479,11 @@ proc configureKosmoSettingsMenu(frontend: KosmoApplication) =
   let applicationMenu = mainMenu[0].submenu()
   if not applicationMenu.isNil and applicationMenu.len > 2:
     let settingsItem = applicationMenu[2]
-    let manager = if frontend.xWindowManager.isNil: nil else: frontend.xWindowManager[]
+    let manager =
+      if frontend.xWindowManager.isNil:
+        nil
+      else:
+        frontend.xWindowManager[]
     settingsItem.identifier = KosmoShowSettingsAction
     settingsItem.action = nimkit.actionSelector(KosmoShowSettingsAction)
     settingsItem.target = nimkit.newActionTarget(
@@ -4532,7 +4538,11 @@ proc configureKosmoWorkspaceMenu(frontend: KosmoApplication) =
   let windowMenu = frontend.application.windowsMenu()
   if windowMenu.isNil or not windowMenu.menuItemWithIdentifier(KosmoNextTabAction).isNil:
     return
-  let manager = if frontend.xWindowManager.isNil: nil else: frontend.xWindowManager[]
+  let manager =
+    if frontend.xWindowManager.isNil:
+      nil
+    else:
+      frontend.xWindowManager[]
 
   proc addAction(title, identifier: string) =
     let item = nimkit.newMenuItem(title, nimkit.actionSelector(identifier))
@@ -5061,6 +5071,23 @@ proc openCliRequest(
   if manager.isNil:
     result.errors.add "Kosmo has no active window manager"
     return
+  if request.kind == kcrOpenStdin:
+    var destination = manager.frontendForCliRequest(request.originWindow)
+    if destination.isNil:
+      destination = newKosmoApplication(manager, hasFileBrowser = false)
+    let controller = destination.dockController
+    let group = controller.activePaneGroup()
+    let id = controller.editor.newStdinBuffer(
+      request.stdinName, request.stdinText, request.workingDirectory
+    )
+    if id.isNone:
+      result.errors.add "Kosmo could not create the stdin buffer"
+    else:
+      group.addBuffer(id.get)
+      controller.activatePaneTab(group, id.get.tabIdentifier)
+      destination.show()
+    result.delivered = true
+    return
   if request.kind == kcrShowDiff:
     var destination = manager.frontendForCliRequest(request.originWindow)
     if destination.isNil:
@@ -5269,6 +5296,38 @@ when isMainModule:
     echo KosmoUsage
   elif commandLine.version:
     echo KosmoVersion
+  elif commandLine.errors.len > 0:
+    reportCliErrors(commandLine.errors)
+    quit(1)
+  elif commandLine.stdinName.len > 0:
+    if kosmoCliInputIsTerminal():
+      stderr.writeLine("Kosmo --file reads text from standard input")
+      quit(1)
+    var content: string
+    try:
+      content = stdin.readKosmoCliText()
+    except CatchableError as error:
+      stderr.writeLine(error.msg)
+      quit(1)
+    let directory = getCurrentDir()
+    let response = openStdinInRunningKosmo(commandLine.stdinName, content, directory)
+    if response.delivered:
+      reportCliErrors(response.errors)
+      quit(if response.errors.len == 0: 0 else: 1)
+    if commandLine.background:
+      stderr.writeLine("Kosmo --bg --file requires a running Kosmo instance")
+      quit(1)
+    runKosmoRequest(
+      some(
+        KosmoCliOpenRequest(
+          requestId: randomIdentifier(),
+          kind: kcrOpenStdin,
+          stdinName: commandLine.stdinName,
+          stdinText: content,
+          workingDirectory: directory,
+        )
+      )
+    )
   elif commandLine.diff:
     if commandLine.paths.len > 0:
       stderr.writeLine("Kosmo --diff does not accept file or folder arguments")

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -276,6 +276,7 @@ type
     lastSplitWidth: float32
     fileTreeWidth: float32
     onShowFileExplorer: proc() {.closure.}
+    onRevealActiveFile: proc() {.closure.}
     onFindInFiles: proc() {.closure.}
     onQuickOpen: proc() {.closure.}
     onNewTerminal: proc() {.closure.}
@@ -364,6 +365,7 @@ proc `sidebarFocused=`(controller: KosmoDockController, focused: bool) =
     )
 
 proc showFileExplorer*(frontend: KosmoApplication): bool {.discardable.}
+proc revealActiveFile*(frontend: KosmoApplication): bool {.discardable.}
 proc showFindInFiles*(frontend: KosmoApplication): bool {.discardable.}
 func hasFileBrowser*(frontend: KosmoApplication): bool
 proc showQuickOpen*(frontend: KosmoApplication): bool {.discardable.}
@@ -844,6 +846,14 @@ proc selectEditorContent(view: KosmoEditorView, id: KosmoBufferId) =
   group.selectedTabIdentifier = id.tabIdentifier
   group.pane.setContentView(view)
 
+proc resolvedEditorFilePath(path, workingDirectory: string): string =
+  let basePath =
+    if workingDirectory.len > 0:
+      absolutePath(workingDirectory)
+    else:
+      getCurrentDir()
+  normalizedPath(absolutePath(path, basePath))
+
 proc statusText(
     status: KosmoStatus, tabs: openArray[KosmoTab], workingDirectory: string
 ): string =
@@ -868,14 +878,7 @@ proc statusText(
       git.add " -" & $status.gitDeleted
     parts.add git
   if activeFilePath.isSome:
-    let
-      filePath = activeFilePath.get
-      basePath =
-        if workingDirectory.len > 0:
-          absolutePath(workingDirectory)
-        else:
-          getCurrentDir()
-    parts.add normalizedPath(absolutePath(filePath, basePath))
+    parts.add resolvedEditorFilePath(activeFilePath.get, workingDirectory)
   parts.join("  •  ")
 
 proc visibleTabs(view: KosmoEditorView, tabs: openArray[KosmoTab]): seq[KosmoTab] =
@@ -1849,6 +1852,9 @@ protocol KosmoEditorCommandDispatch of nimkit.ResponderCommandDispatchProtocol:
     of KosmoShowFileExplorerAction:
       if not controller.frontend.isNil:
         discard controller.frontend[].showFileExplorer()
+    of KosmoRevealActiveFileAction:
+      if not controller.frontend.isNil:
+        discard controller.frontend[].revealActiveFile()
     of KosmoFindInFilesAction:
       if not controller.frontend.isNil:
         discard controller.frontend[].showFindInFiles()
@@ -2641,6 +2647,9 @@ protocol KosmoEditorPaneCommandDispatch of nimkit.ResponderCommandDispatchProtoc
     of KosmoShowFileExplorerAction:
       if not controller.frontend.isNil:
         discard controller.frontend[].showFileExplorer()
+    of KosmoRevealActiveFileAction:
+      if not controller.frontend.isNil:
+        discard controller.frontend[].revealActiveFile()
     of KosmoFindInFilesAction:
       if not controller.frontend.isNil:
         discard controller.frontend[].showFindInFiles()
@@ -3838,6 +3847,10 @@ protocol KosmoContentCommandDispatch of nimkit.ResponderCommandDispatchProtocol:
       if content.onShowFileExplorer.isNil:
         return false
       content.onShowFileExplorer()
+    of KosmoRevealActiveFileAction:
+      if content.onRevealActiveFile.isNil:
+        return false
+      content.onRevealActiveFile()
     of KosmoFindInFilesAction:
       if content.onFindInFiles.isNil:
         return false
@@ -3875,6 +3888,27 @@ proc showFileExplorer*(frontend: KosmoApplication): bool {.discardable.} =
   result = frontend.window.makeFirstResponder(frontend.fileTree)
   if result:
     frontend.dockController.activatePanelWindow(frontend.window)
+
+proc revealActiveFile*(frontend: KosmoApplication): bool {.discardable.} =
+  ## Reveal the selected editor tab when it is visible in the file-browser scope.
+  if frontend.isNil or not frontend.hasFileBrowser() or frontend.fileTree.isNil or
+      frontend.sidebarTabs.isNil or frontend.dockController.isNil:
+    return
+  let
+    controller = frontend.dockController
+    group = controller.activePaneGroup()
+  if group.isNil:
+    return
+  var bufferId: KosmoBufferId
+  if not group.selectedTabIdentifier.parseTabIdentifier(bufferId):
+    return
+  for tab in controller.editor.tabs():
+    if tab.id == bufferId and tab.filePath.isSome:
+      let path =
+        resolvedEditorFilePath(tab.filePath.get, controller.editor.workingDirectory())
+      if frontend.fileTree.revealPath(path):
+        result = frontend.showFileExplorer()
+      return
 
 proc showFindInFiles*(frontend: KosmoApplication): bool {.discardable.} =
   ## Select the find sidebar tab and focus its search query.
@@ -4518,6 +4552,8 @@ proc configureKosmoWorkspaceMenu(frontend: KosmoApplication) =
         discard controller.splitCurrentPaneTab(group, nimkit.dpRight)
       of KosmoShowFileExplorerAction:
         discard active.showFileExplorer()
+      of KosmoRevealActiveFileAction:
+        discard active.revealActiveFile()
       of KosmoFindInFilesAction:
         discard active.showFindInFiles()
       else:
@@ -4534,6 +4570,7 @@ proc configureKosmoWorkspaceMenu(frontend: KosmoApplication) =
   addAction("Split Right", KosmoSplitVerticalAction)
   windowMenu.addSeparator()
   addAction("Show Files", KosmoShowFileExplorerAction)
+  addAction("Reveal Active File", KosmoRevealActiveFileAction)
   addAction("Find in Files", KosmoFindInFilesAction)
 
   let
@@ -4733,6 +4770,9 @@ proc newKosmoApplication*(
   documentView.onShowFileExplorer = proc() =
     if not controller.frontend.isNil:
       discard controller.frontend[].showFileExplorer()
+  documentView.onRevealActiveFile = proc() =
+    if not controller.frontend.isNil:
+      discard controller.frontend[].revealActiveFile()
   documentView.onFindInFiles = proc() =
     if not controller.frontend.isNil:
       discard controller.frontend[].showFindInFiles()

--- a/src/merenda/kosmo/kosmo.nim
+++ b/src/merenda/kosmo/kosmo.nim
@@ -3671,12 +3671,17 @@ proc openTerminalLink(lifecycle: KosmoWindowLifecycle, link: string) {.slot.} =
 proc workspaceGitChanged(lifecycle: KosmoWindowLifecycle) {.slot.} =
   if not lifecycle.frontend.isNil and not lifecycle.frontend[].xClosed:
     # All panes share one Moe engine. Invalidate once, not once per pane.
-    lifecycle.frontend[].dockController.editor.notifyGitRepositoryChanged()
+    let frontend = lifecycle.frontend[]
+    frontend.dockController.editor.notifyGitRepositoryChanged()
+    if not frontend.gitDiffPanel.isNil:
+      frontend.gitDiffPanel.scheduleRepositoryRefresh()
 
 proc pollWorkspaceGit(lifecycle: KosmoWindowLifecycle) {.slot.} =
   if not lifecycle.frontend.isNil and not lifecycle.frontend[].xClosed:
     let frontend = lifecycle.frontend[]
     let controller = frontend.dockController
+    if not frontend.gitDiffPanel.isNil:
+      discard frontend.gitDiffPanel.pollRepositoryRefresh()
     frontend.fileTree.workspaceFiles.setGitRoots(controller.editor.gitWatchRoots())
     if controller.editor.pollGitStatus():
       for group in controller.groups:

--- a/src/merenda/kosmo/moe.nim
+++ b/src/merenda/kosmo/moe.nim
@@ -499,6 +499,7 @@ proc newKosmoEditor*(text = "", workingDirectory = ""): KosmoEditor =
   var config = newEditorConfig()
   config.standard.mouse = true
   config.standard.statusLine = false
+  config.standard.colorMode = cm24bit
   config.tabLine.enable = false
   config.highlight.backend = hbMatter
   config.highlight.matterGrammarSet = newKosmoMatterGrammarSet()

--- a/src/merenda/kosmo/moe.nim
+++ b/src/merenda/kosmo/moe.nim
@@ -453,6 +453,11 @@ proc newKosmoMatterGrammarSet(): moeMatter.MatterGrammarSet =
     sources.add moeMatter.MatterGrammarSource(
       content: contribution.bundledMatterGrammarContents(),
       path: contribution.archiveMember,
+      fileTypes:
+        if contribution.scopeName == matterPackages.terraformGrammar.scopeName:
+          @["hcl"]
+        else:
+          @[],
     )
   moeMatter.newMatterGrammarSet(sources)
 

--- a/src/merenda/kosmo/moe.nim
+++ b/src/merenda/kosmo/moe.nim
@@ -19,6 +19,7 @@ import
   ]
 import moepkg/buffer/undo as moeUndo
 import moepkg/buffer/search as moeSearch
+from moepkg/buffer/file_io import loadFileWithContent
 from moepkg/buffer/core import BufferId, getLine, getTextString, len
 from moepkg/command_handlers/visual_commands import visualDelete
 from moepkg/registers import setYankedRegister
@@ -938,6 +939,21 @@ proc newEmptyBuffer*(editor: KosmoEditor): Option[KosmoBufferId] =
     editor.editor.state.statusMessage = outcome.error
     return
   some(editor.editor.activeBuffer.id.toKosmoBufferId)
+
+proc newStdinBuffer*(
+    editor: KosmoEditor, name, content, directory: string
+): Option[KosmoBufferId] =
+  ## Create a separate modified buffer; stdin never reads or writes the named file.
+  result = editor.newEmptyBuffer()
+  if result.isNone:
+    return
+  let buffer = editor.editor.activeBuffer
+  let loaded = buffer.loadFileWithContent(absolutePath(name, directory), content)
+  if loaded.isErr:
+    editor.editor.state.statusMessage = loaded.error
+    return none(KosmoBufferId)
+  buffer.savedChangeId = -1
+  buffer.highlightNeedsUpdate = true
 
 proc revealLocation*(
     editor: KosmoEditor, line, column: int, centered = false

--- a/src/merenda/kosmo/moe.nim
+++ b/src/merenda/kosmo/moe.nim
@@ -6,6 +6,7 @@
 
 import std/[algorithm, options, os, strutils, unicode]
 
+import matter/grammarpackages as matterPackages
 import moepkg/celina_backend as celina
 from pkg/figdraw import figDataDir
 import pkg/results as pkgResults
@@ -27,7 +28,10 @@ from moepkg/render_utils import steadyBottomAreaHeight
 from moepkg/search_utils import shouldIgnoreCase
 import moepkg/key_bindings/registry as moeKeys
 import moepkg/modes as moeModes
+import moepkg/syntax/matter_backend as moeMatter
 import moepkg/types as moeTypes
+
+import ../nimkit/text/mattergrammarassets
 
 when not defined(moe.embedded):
   when hasAsyncSupport:
@@ -442,12 +446,24 @@ template inWorkingDirectory(editor: KosmoEditor, body: untyped): untyped =
     finally:
       setCurrentDir(previousDirectory)
 
+proc newKosmoMatterGrammarSet(): moeMatter.MatterGrammarSet =
+  var sources =
+    newSeqOfCap[moeMatter.MatterGrammarSource](matterPackages.knownGrammars.len)
+  for contribution in matterPackages.knownGrammars:
+    sources.add moeMatter.MatterGrammarSource(
+      content: contribution.bundledMatterGrammarContents(),
+      path: contribution.archiveMember,
+    )
+  moeMatter.newMatterGrammarSet(sources)
+
 proc newKosmoEditor*(text = "", workingDirectory = ""): KosmoEditor =
   ## Create an editor with Moe's default configuration and optional initial text.
   var config = newEditorConfig()
   config.standard.mouse = true
   config.standard.statusLine = false
   config.tabLine.enable = false
+  config.highlight.backend = hbMatter
+  config.highlight.matterGrammarSet = newKosmoMatterGrammarSet()
   result = KosmoEditor(editor: newEditor(config))
   result.workingDirectory = workingDirectory
   discard result.editor.addCommandAlias("x", claSaveAndQuit)

--- a/src/merenda/kosmo/moe.nim
+++ b/src/merenda/kosmo/moe.nim
@@ -38,10 +38,21 @@ when not defined(moe.embedded):
     {.error: "Merenda's Moe facade requires Celina's synchronous backend".}
 
 type
+  KosmoTextMateGrammarOrigin* {.pure.} = enum
+    BuiltIn
+    Added
+
+  KosmoTextMateGrammar* = object
+    ## A TextMate grammar available to Kosmo without exposing Matter types.
+    name*: string
+    scopeName*: string
+    origin*: KosmoTextMateGrammarOrigin
+
   KosmoEditor* = ref object
     editor: Editor
     temporaryBufferId: Option[BufferId]
     workingDirectory: string
+    textMateGrammars: seq[KosmoTextMateGrammar]
 
   KosmoBufferId* = distinct int
     ## Stable identity for a Moe buffer without exposing Moe's buffer types.
@@ -461,6 +472,28 @@ proc newKosmoMatterGrammarSet(): moeMatter.MatterGrammarSet =
     )
   moeMatter.newMatterGrammarSet(sources)
 
+proc builtInTextMateGrammars(): seq[KosmoTextMateGrammar] =
+  for contribution in matterPackages.knownGrammars:
+    result.add KosmoTextMateGrammar(
+      name: contribution.displayName,
+      scopeName: contribution.scopeName,
+      origin: KosmoTextMateGrammarOrigin.BuiltIn,
+    )
+  result.sort do(left, right: KosmoTextMateGrammar) -> int:
+    result = cmpIgnoreCase(left.name, right.name)
+    if result == 0:
+      result = cmp(left.scopeName, right.scopeName)
+
+func title*(origin: KosmoTextMateGrammarOrigin): string =
+  case origin
+  of KosmoTextMateGrammarOrigin.BuiltIn: "Built-in"
+  of KosmoTextMateGrammarOrigin.Added: "Added"
+
+proc availableTextMateGrammars*(editor: KosmoEditor): seq[KosmoTextMateGrammar] =
+  ## Return the TextMate grammars currently installed for Moe highlighting.
+  if not editor.isNil and not editor.editor.isNil:
+    result = editor.textMateGrammars
+
 proc newKosmoEditor*(text = "", workingDirectory = ""): KosmoEditor =
   ## Create an editor with Moe's default configuration and optional initial text.
   var config = newEditorConfig()
@@ -469,7 +502,8 @@ proc newKosmoEditor*(text = "", workingDirectory = ""): KosmoEditor =
   config.tabLine.enable = false
   config.highlight.backend = hbMatter
   config.highlight.matterGrammarSet = newKosmoMatterGrammarSet()
-  result = KosmoEditor(editor: newEditor(config))
+  result =
+    KosmoEditor(editor: newEditor(config), textMateGrammars: builtInTextMateGrammars())
   result.workingDirectory = workingDirectory
   discard result.editor.addCommandAlias("x", claSaveAndQuit)
   result.editor.setFrontendGitStatusEnabled(true)

--- a/src/merenda/kosmo/settings.nim
+++ b/src/merenda/kosmo/settings.nim
@@ -11,6 +11,7 @@ const
   KosmoTerminalSettingsTabIdentifier* = "kosmo.settings.terminal"
   KosmoShortcutsSettingsTabIdentifier* = "kosmo.settings.shortcuts"
   KosmoMoeThemesSettingsTabIdentifier* = "kosmo.settings.moeThemes"
+  KosmoTextMateGrammarsSettingsTabIdentifier* = "kosmo.settings.textMateGrammars"
   KosmoOptionAsMetaIdentifier* = "kosmo.settings.terminal.optionAsMeta"
   KosmoTerminalLinksIdentifier* = "kosmo.settings.terminal.links"
   KosmoShortcutsTableIdentifier* = "kosmo.settings.shortcuts.table"
@@ -18,11 +19,15 @@ const
   KosmoEditorInputPolicyIdentifier* = "kosmo.settings.shortcuts.editorInput"
   KosmoMoeThemesTableIdentifier* = "kosmo.settings.moeThemes.table"
   KosmoMoeThemeSelectorIdentifier* = KosmoMoeThemesTableIdentifier
+  KosmoTextMateGrammarsTableIdentifier* = "kosmo.settings.textMateGrammars.table"
   KosmoShortcutActionColumnIdentifier* = "action"
   KosmoShortcutDescriptionColumnIdentifier* = "description"
   KosmoShortcutKeysColumnIdentifier* = "keys"
   KosmoMoeThemeNameColumnIdentifier* = "theme"
   KosmoMoeThemePreviewColumnIdentifier* = "preview"
+  KosmoTextMateGrammarNameColumnIdentifier* = "grammar"
+  KosmoTextMateGrammarScopeColumnIdentifier* = "scope"
+  KosmoTextMateGrammarOriginColumnIdentifier* = "origin"
   KosmoMoeThemePreviewText* = "let fn = \"text\" #"
   KosmoShortcutActionColumnWidth = 175.0'f32
   KosmoShortcutDescriptionColumnWidth = 310.0'f32
@@ -56,6 +61,9 @@ type
     selectedIdentifier: string
     handler: KosmoMoeThemeHandler
 
+  KosmoTextMateGrammarsTableSource = ref object of nimkit.Responder
+    grammars: seq[KosmoTextMateGrammar]
+
   KosmoSettingsWindow* = ref object of nimkit.Responder
     xWindow: nimkit.Panel
     xContentView: nimkit.View
@@ -73,6 +81,8 @@ type
     xEditorInputPolicyHandler: KosmoEditorInputPolicyHandler
     xMoeThemesTable: nimkit.TableView
     xMoeThemesSource: KosmoMoeThemesTableSource
+    xTextMateGrammarsTable: nimkit.TableView
+    xTextMateGrammarsSource: KosmoTextMateGrammarsTableSource
 
 protocol KosmoShortcutsTableDataSource of nimkit.TableViewDataSource:
   method numberOfRows(
@@ -269,6 +279,62 @@ proc newKosmoMoeThemesTableSource(
   discard result.withProtocol(KosmoMoeThemesTableDataSource)
   discard result.withProtocol(KosmoMoeThemesTableDelegate)
 
+protocol KosmoTextMateGrammarsTableDataSource of nimkit.TableViewDataSource:
+  method numberOfRows(
+      source: KosmoTextMateGrammarsTableSource, tableView: nimkit.TableView
+  ): int =
+    discard tableView
+    source.grammars.len
+
+  method textForCell(
+      source: KosmoTextMateGrammarsTableSource,
+      tableView: nimkit.TableView,
+      row: int,
+      column: nimkit.TableColumn,
+  ): string =
+    discard tableView
+    if row notin 0 ..< source.grammars.len:
+      return
+    let grammar = source.grammars[row]
+    case column.identifier()
+    of KosmoTextMateGrammarNameColumnIdentifier:
+      grammar.name
+    of KosmoTextMateGrammarScopeColumnIdentifier:
+      grammar.scopeName
+    of KosmoTextMateGrammarOriginColumnIdentifier:
+      grammar.origin.title()
+    else:
+      ""
+
+protocol KosmoTextMateGrammarsTableDelegate of nimkit.TableViewDelegate:
+  method shouldSelectTableRow(
+      source: KosmoTextMateGrammarsTableSource, tableView: nimkit.TableView, row: int
+  ): bool =
+    discard source
+    discard tableView
+    discard row
+    false
+
+  method shouldEditCell(
+      source: KosmoTextMateGrammarsTableSource,
+      tableView: nimkit.TableView,
+      row: int,
+      column: nimkit.TableColumn,
+  ): bool =
+    discard source
+    discard tableView
+    discard row
+    discard column
+    false
+
+proc newKosmoTextMateGrammarsTableSource(
+    grammars: openArray[KosmoTextMateGrammar]
+): KosmoTextMateGrammarsTableSource =
+  result = KosmoTextMateGrammarsTableSource(grammars: @grammars)
+  nimkit.initResponder(result)
+  discard result.withProtocol(KosmoTextMateGrammarsTableDataSource)
+  discard result.withProtocol(KosmoTextMateGrammarsTableDelegate)
+
 proc newSettingsPage(): tuple[view: nimkit.View, stack: nimkit.StackView] =
   result.stack = nimkit.newStackView(nimkit.laVertical)
   result.stack.spacing = 12.0
@@ -365,6 +431,16 @@ proc updateMoeThemes*(
       ""
   settings.xMoeThemesTable.selectedIndex = selectedRow
 
+proc `textMateGrammars=`*(
+    settings: KosmoSettingsWindow, grammars: openArray[KosmoTextMateGrammar]
+) =
+  ## Replace the read-only list of TextMate grammars available to Kosmo.
+  if settings.isNil or settings.xTextMateGrammarsSource.isNil or
+      settings.xTextMateGrammarsTable.isNil:
+    return
+  settings.xTextMateGrammarsSource.grammars = @grammars
+  settings.xTextMateGrammarsTable.reloadData()
+
 proc newKosmoSettingsWindow*(
     optionAsMeta = true,
     optionAsMetaHandler: KosmoOptionAsMetaHandler = nil,
@@ -378,11 +454,13 @@ proc newKosmoSettingsWindow*(
     moeThemes: openArray[KosmoMoeThemeSetting] = [],
     selectedMoeThemeIdentifier = "",
     moeThemeHandler: KosmoMoeThemeHandler = nil,
+    textMateGrammars: openArray[KosmoTextMateGrammar] = [],
 ): KosmoSettingsWindow =
   ## Create Kosmo's settings panel, which intentionally contains no Merenda settings.
   let
     shortcutsSource = newKosmoShortcutsTableSource(shortcuts)
     moeThemesSource = newKosmoMoeThemesTableSource(moeThemeHandler)
+    textMateGrammarsSource = newKosmoTextMateGrammarsTableSource(textMateGrammars)
   result = KosmoSettingsWindow(
     xWindow: nimkit.newPanel("Kosmo Settings", nimkit.rect(180, 160, 760, 420)),
     xContentView: nimkit.newView(),
@@ -392,6 +470,7 @@ proc newKosmoSettingsWindow*(
     xEditorInputPolicyHandler: editorInputPolicyHandler,
     xShortcutsSource: shortcutsSource,
     xMoeThemesSource: moeThemesSource,
+    xTextMateGrammarsSource: textMateGrammarsSource,
   )
   nimkit.initResponder(result)
   let
@@ -401,6 +480,7 @@ proc newKosmoSettingsWindow*(
     terminalPage = newSettingsPage()
     shortcutsPage = newSettingsPage()
     moeThemesPage = newSettingsPage()
+    textMateGrammarsPage = newSettingsPage()
     optionButton = nimkit.newCheckBox("Use Option/Alt as Meta")
     terminalLinksButton = nimkit.newCheckBox(
       when defined(macosx) or defined(macos):
@@ -412,6 +492,7 @@ proc newKosmoSettingsWindow*(
     editorInputPolicyChoice = nimkit.newComboBox(["Vim", "Native", "Hybrid"])
     shortcutsTable = nimkit.newTableView()
     moeThemesTable = nimkit.newTableView()
+    textMateGrammarsTable = nimkit.newTableView()
     optionChanged = nimkit.actionSelector("kosmo.optionAsMetaChanged")
     terminalLinksChanged = nimkit.actionSelector("kosmo.terminalLinksChanged")
     shortcutProfileChanged = nimkit.actionSelector("kosmo.shortcutProfileChanged")
@@ -424,6 +505,7 @@ proc newKosmoSettingsWindow*(
   result.xShortcutProfileChoice = shortcutProfileChoice
   result.xEditorInputPolicyChoice = editorInputPolicyChoice
   result.xMoeThemesTable = moeThemesTable
+  result.xTextMateGrammarsTable = textMateGrammarsTable
 
   optionButton.identifier = KosmoOptionAsMetaIdentifier
   optionButton.accessibilityLabel = "Use Option or Alt as Meta"
@@ -558,6 +640,48 @@ proc newKosmoSettingsWindow*(
   )
   moeThemesPage.stack.fillAvailableSpace(moeThemesTable)
 
+  textMateGrammarsTable.identifier = KosmoTextMateGrammarsTableIdentifier
+  textMateGrammarsTable.accessibilityLabel = "Available TextMate grammars"
+  textMateGrammarsTable.columnSizing = nimkit.tvcsFill
+  textMateGrammarsTable.selectionMode = nimkit.tsmNone
+  textMateGrammarsTable.usesAlternatingRowBackgrounds = true
+  textMateGrammarsTable.showsRowSeparators = true
+  textMateGrammarsTable.addColumn(
+    nimkit.newTableColumn(
+      KosmoTextMateGrammarNameColumnIdentifier,
+      "Grammar",
+      width = 250.0,
+      minWidth = 180.0,
+      sizingPolicy = nimkit.tcspFlexible,
+    )
+  )
+  textMateGrammarsTable.addColumn(
+    nimkit.newTableColumn(
+      KosmoTextMateGrammarScopeColumnIdentifier,
+      "Scope",
+      width = 330.0,
+      minWidth = 220.0,
+      sizingPolicy = nimkit.tcspFlexible,
+    )
+  )
+  textMateGrammarsTable.addColumn(
+    nimkit.newTableColumn(
+      KosmoTextMateGrammarOriginColumnIdentifier,
+      "Origin",
+      width = 100.0,
+      sizingPolicy = nimkit.tcspFixed,
+    )
+  )
+  textMateGrammarsTable.dataSource = textMateGrammarsSource
+  textMateGrammarsTable.delegate = textMateGrammarsSource
+  textMateGrammarsPage.stack.addArrangedSubview(
+    nimkit.newHeadingLabel("TextMate Grammars"),
+    nimkit.newLabel(
+      "These grammars are available to Moe and Markdown syntax highlighting."
+    ),
+  )
+  textMateGrammarsPage.stack.fillAvailableSpace(textMateGrammarsTable)
+
   tabs.identifier = KosmoSettingsTabsIdentifier
   discard tabs.addTabViewItem(
     nimkit.newTabViewItem(
@@ -572,6 +696,12 @@ proc newKosmoSettingsWindow*(
   discard tabs.addTabViewItem(
     nimkit.newTabViewItem(
       "Moe Themes", moeThemesPage.view, KosmoMoeThemesSettingsTabIdentifier
+    )
+  )
+  discard tabs.addTabViewItem(
+    nimkit.newTabViewItem(
+      "TextMate Grammars", textMateGrammarsPage.view,
+      KosmoTextMateGrammarsSettingsTabIdentifier,
     )
   )
   layout.spacing = 12.0

--- a/src/merenda/kosmo/shortcuts.nim
+++ b/src/merenda/kosmo/shortcuts.nim
@@ -19,6 +19,7 @@ const
   KosmoSplitHorizontalAction* = "kosmo.splitHorizontal"
   KosmoSplitVerticalAction* = "kosmo.splitVertical"
   KosmoShowFileExplorerAction* = "kosmo.showFileExplorer"
+  KosmoRevealActiveFileAction* = "kosmo.revealActiveFile"
   KosmoFindInFilesAction* = "kosmo.findInFiles"
   KosmoQuickOpenAction* = "kosmo.quickOpen"
   KosmoShowSettingsAction* = "kosmo.showSettings"
@@ -210,6 +211,11 @@ func kosmoActions*(): seq[KosmoAction] =
         description: "Show and focus the file explorer.",
       ),
       KosmoAction(
+        identifier: KosmoRevealActiveFileAction,
+        title: "Reveal Active File",
+        description: "Reveal the active editor file in the file explorer.",
+      ),
+      KosmoAction(
         identifier: KosmoFindInFilesAction,
         title: "Find in Files",
         description: "Show and focus Find in Files.",
@@ -357,6 +363,7 @@ proc initKosmoKeyBindings*(
   result.addBinding("primary-shift-[", KosmoPreviousTabAction, profile, platform)
   result.addBinding("primary-shift-]", KosmoNextTabAction, profile, platform)
   result.addBinding("primary-shift-e", KosmoShowFileExplorerAction, profile, platform)
+  result.addBinding("primary-shift-l", KosmoRevealActiveFileAction, profile, platform)
   result.addBinding("primary-shift-f", KosmoFindInFilesAction, profile, platform)
   result.addBinding("primary-,", KosmoShowSettingsAction, profile, platform)
   result.addBinding("primary-z", KosmoUndoAction, profile, platform)

--- a/src/merenda/nimkit/text/mattergrammarassets.nim
+++ b/src/merenda/nimkit/text/mattergrammarassets.nim
@@ -1,0 +1,97 @@
+## Compile-time embedded Matter grammar archives shared by NimKit and Kosmo.
+##
+## Applications can use the bundled grammars without locating Matter's package
+## data at runtime. Archive validation and extraction live here so each consumer
+## embeds the same source constants instead of maintaining its own archive list.
+
+import std/[compilesettings, os]
+
+import matter/[engine, grammarpackages]
+import zippy
+import zippy/crc
+
+const ZipLocalHeader = "PK\x03\x04"
+
+proc findMatterPackageRoot(): string {.compileTime.} =
+  for searchPath in querySettingSeq(MultipleValueSetting.searchPaths):
+    let
+      sourceDir = searchPath
+      packageRoot = sourceDir.parentDir
+    if fileExists(sourceDir / "matter.nim") and
+        dirExists(packageRoot / "data" / "grammars"):
+      return packageRoot
+  raise newException(ValueError, "could not locate Matter's grammar archives")
+
+const MatterPackageRoot = findMatterPackageRoot()
+
+template embedGrammarArchive(package: untyped): untyped =
+  (
+    path: package.dataArchivePath,
+    contents: staticRead(MatterPackageRoot / package.dataArchivePath),
+  )
+
+const EmbeddedGrammarArchives = block:
+  var archives: array[knownPackages.len, tuple[path, contents: string]]
+  for index, package in knownPackages:
+    archives[index] = embedGrammarArchive(package)
+  archives
+
+func littleEndian16(contents: string, offset: int): int =
+  ord(contents[offset]) or (ord(contents[offset + 1]) shl 8)
+
+func littleEndian32(contents: string, offset: int): uint32 =
+  uint32(ord(contents[offset])) or (uint32(ord(contents[offset + 1])) shl 8) or
+    (uint32(ord(contents[offset + 2])) shl 16) or
+    (uint32(ord(contents[offset + 3])) shl 24)
+
+func archiveContents(path: string): string =
+  for archive in EmbeddedGrammarArchives:
+    if archive.path == path:
+      return archive.contents
+
+proc readZipMember(contents, member: string): string =
+  var offset = 0
+  while offset + 30 <= contents.len and
+      contents[offset ..< offset + ZipLocalHeader.len] == ZipLocalHeader:
+    let
+      flags = contents.littleEndian16(offset + 6)
+      compression = contents.littleEndian16(offset + 8)
+      expectedCrc32 = contents.littleEndian32(offset + 14)
+      compressedSize = contents.littleEndian32(offset + 18).int
+      uncompressedSize = contents.littleEndian32(offset + 22).int
+      nameSize = contents.littleEndian16(offset + 26)
+      extraSize = contents.littleEndian16(offset + 28)
+      nameStart = offset + 30
+      dataStart = nameStart + nameSize + extraSize
+      dataStop = dataStart + compressedSize
+    if flags != 0 or compression notin [0, 8] or dataStart > contents.len or
+        dataStop > contents.len:
+      raise newException(MatterError, "invalid bundled Matter grammar archive")
+    if contents[nameStart ..< nameStart + nameSize] == member:
+      let compressed = contents[dataStart ..< dataStop]
+      try:
+        case compression
+        of 0:
+          result = compressed
+        of 8:
+          result = zippy.uncompress(compressed, zippy.dfDeflate)
+        else:
+          discard
+      except zippy.ZippyError as error:
+        raise newException(
+          MatterError, "invalid bundled Matter grammar archive: " & error.msg
+        )
+      if result.len != uncompressedSize or crc32(result) != expectedCrc32:
+        raise newException(MatterError, "invalid bundled Matter grammar archive")
+      return
+    offset = dataStop
+  raise newException(MatterError, "missing bundled Matter grammar: " & member)
+
+proc bundledMatterGrammarContents*(contribution: GrammarContribution): string =
+  ## Return one validated grammar source from Matter's embedded archive catalog.
+  let archive = archiveContents(contribution.dataArchivePath)
+  if archive.len == 0:
+    raise newException(
+      MatterError, "missing bundled Matter archive: " & contribution.dataArchivePath
+    )
+  archive.readZipMember(contribution.archiveMember)

--- a/src/merenda/nimkit/text/matterhighlighting.nim
+++ b/src/merenda/nimkit/text/matterhighlighting.nim
@@ -4,127 +4,20 @@
 ## not need to locate Matter's package data at runtime. Each thread lazily
 ## compiles and caches only the grammars it uses.
 
-import std/[compilesettings, options, os, strutils, tables, unicode]
+import std/[options, strutils, tables, unicode]
 
 import matter
-import zippy
-import zippy/crc
 
+import ./mattergrammarassets
 import ./syntaxhighlighting
 import ./texttypes
 
-type EmbeddedGrammarArchive = tuple[path, contents: string]
-
-const
-  ZipLocalHeader = "PK\x03\x04"
-  MatterMaximumTokenizedLineBytes = 96
-    ## Keep recursive TextMate regex matching within Nim's worker-thread stack.
-
-proc findMatterPackageRoot(): string {.compileTime.} =
-  for searchPath in querySettingSeq(MultipleValueSetting.searchPaths):
-    let
-      sourceDir = searchPath
-      packageRoot = sourceDir.parentDir
-    if fileExists(sourceDir / "matter.nim") and
-        dirExists(packageRoot / "data" / "grammars"):
-      return packageRoot
-  raise newException(ValueError, "could not locate Matter's grammar archives")
-
-const MatterPackageRoot = findMatterPackageRoot()
-
-template embedGrammarArchive(package: untyped): untyped =
-  (
-    path: package.dataArchivePath,
-    contents: staticRead(MatterPackageRoot / package.dataArchivePath),
-  )
-
-const EmbeddedGrammarArchives = [
-  embedGrammarArchive(vscodeCppPackage),
-  embedGrammarArchive(vscodeCsharpPackage),
-  embedGrammarArchive(vscodeDiffPackage),
-  embedGrammarArchive(vscodeDockerPackage),
-  embedGrammarArchive(vscodeGitBasePackage),
-  embedGrammarArchive(vscodeGoPackage),
-  embedGrammarArchive(vscodeHtmlPackage),
-  embedGrammarArchive(vscodeJavaPackage),
-  embedGrammarArchive(vscodeJavascriptPackage),
-  embedGrammarArchive(vscodeLatexPackage),
-  embedGrammarArchive(vscodeLogPackage),
-  embedGrammarArchive(vscodeLuaPackage),
-  embedGrammarArchive(vscodeMarkdownPackage),
-  embedGrammarArchive(vscodeRustPackage),
-  embedGrammarArchive(vscodeShellscriptPackage),
-  embedGrammarArchive(vscodeTypescriptPackage),
-  embedGrammarArchive(vscodeXmlPackage),
-  embedGrammarArchive(vscodeYamlPackage),
-  embedGrammarArchive(vscodeJsonPackage),
-  embedGrammarArchive(vscodePythonPackage),
-  embedGrammarArchive(nimVscodePackage),
-  embedGrammarArchive(fishPackage),
-  embedGrammarArchive(haskellPackage),
-  embedGrammarArchive(hyprlangPackage),
-  embedGrammarArchive(tomlPackage),
-  embedGrammarArchive(lispPackage),
-  embedGrammarArchive(astroPackage),
-  embedGrammarArchive(tclPackage),
-  embedGrammarArchive(terraformSyntaxPackage),
-  embedGrammarArchive(terraformPlanPackage),
-]
+const MatterMaximumTokenizedLineBytes = 96
+  ## Keep recursive TextMate regex matching within Nim's worker-thread stack.
 
 var
   matterGrammarCache {.threadvar.}: Table[string, Grammar]
   matterGrammarCacheInitialized {.threadvar.}: bool
-
-func littleEndian16(contents: string, offset: int): int =
-  ord(contents[offset]) or (ord(contents[offset + 1]) shl 8)
-
-func littleEndian32(contents: string, offset: int): uint32 =
-  uint32(ord(contents[offset])) or (uint32(ord(contents[offset + 1])) shl 8) or
-    (uint32(ord(contents[offset + 2])) shl 16) or
-    (uint32(ord(contents[offset + 3])) shl 24)
-
-func archiveContents(path: string): string =
-  for archive in EmbeddedGrammarArchives:
-    if archive.path == path:
-      return archive.contents
-
-proc readZipMember(contents, member: string): string =
-  var offset = 0
-  while offset + 30 <= contents.len and
-      contents[offset ..< offset + ZipLocalHeader.len] == ZipLocalHeader:
-    let
-      flags = contents.littleEndian16(offset + 6)
-      compression = contents.littleEndian16(offset + 8)
-      expectedCrc32 = contents.littleEndian32(offset + 14)
-      compressedSize = contents.littleEndian32(offset + 18).int
-      uncompressedSize = contents.littleEndian32(offset + 22).int
-      nameSize = contents.littleEndian16(offset + 26)
-      extraSize = contents.littleEndian16(offset + 28)
-      nameStart = offset + 30
-      dataStart = nameStart + nameSize + extraSize
-      dataStop = dataStart + compressedSize
-    if flags != 0 or compression notin [0, 8] or dataStart > contents.len or
-        dataStop > contents.len:
-      raise newException(MatterError, "invalid bundled Matter grammar archive")
-    if contents[nameStart ..< nameStart + nameSize] == member:
-      let compressed = contents[dataStart ..< dataStop]
-      try:
-        case compression
-        of 0:
-          result = compressed
-        of 8:
-          result = zippy.uncompress(compressed, zippy.dfDeflate)
-        else:
-          discard
-      except zippy.ZippyError as error:
-        raise newException(
-          MatterError, "invalid bundled Matter grammar archive: " & error.msg
-        )
-      if result.len != uncompressedSize or crc32(result) != expectedCrc32:
-        raise newException(MatterError, "invalid bundled Matter grammar archive")
-      return
-    offset = dataStop
-  raise newException(MatterError, "missing bundled Matter grammar: " & member)
 
 func normalizedMatterLanguage(language: string): string =
   let name = language.strip().toLowerAscii()
@@ -180,14 +73,9 @@ proc grammarForLanguage(language: string): Grammar =
 
   let registry = newRegistry()
   for contribution in relatedMatterGrammars(primary.get()):
-    let archive = archiveContents(contribution.dataArchivePath)
-    if archive.len == 0:
-      raise newException(
-        MatterError, "missing bundled Matter archive: " & contribution.dataArchivePath
-      )
     registry.addGrammar(
       parseRawGrammar(
-        archive.readZipMember(contribution.archiveMember), contribution.archiveMember
+        contribution.bundledMatterGrammarContents(), contribution.archiveMember
       )
     )
   result = registry.loadGrammar(primary.get.scopeName)

--- a/tests/integrations/kosmocliopen.nim
+++ b/tests/integrations/kosmocliopen.nim
@@ -16,6 +16,7 @@ type CliClientState = object
   registry: array[ClientValueCapacity, char]
   origin: array[ClientValueCapacity, char]
   showsDiff: bool
+  opensStdin: bool
   delivered: Atomic[bool]
   errorCount: Atomic[int]
   done: Atomic[bool]
@@ -31,7 +32,16 @@ proc load(buffer: ptr array[ClientValueCapacity, char]): string =
 proc sendOpenRequest(state: ptr CliClientState) {.thread.} =
   try:
     let response =
-      if state.showsDiff:
+      if state.opensStdin:
+        openStdinInRunningKosmo(
+          state.path.addr.load(),
+          state.diffText.addr.load(),
+          state.workingDirectory.addr.load(),
+          preferredEndpoint = state.endpoint.addr.load(),
+          originWindow = state.origin.addr.load(),
+          registryDirectory = state.registry.addr.load(),
+        )
+      elif state.showsDiff:
         showDiffInRunningKosmo(
           state.diffText.addr.load(),
           state.workingDirectory.addr.load(),
@@ -58,6 +68,7 @@ proc requestWhilePumping(
     diffText = "",
     workingDirectory = "",
     showsDiff = false,
+    opensStdin = false,
 ): tuple[delivered: bool, errorCount: int] =
   let state = cast[ptr CliClientState](allocShared0(sizeof(CliClientState)))
   defer:
@@ -69,6 +80,7 @@ proc requestWhilePumping(
   registry.store(state.registry)
   origin.store(state.origin)
   state.showsDiff = showsDiff
+  state.opensStdin = opensStdin
   var thread: Thread[ptr CliClientState]
   createThread(thread, sendOpenRequest, state)
   let deadline = getMonoTime() + initDuration(seconds = 5)
@@ -83,6 +95,36 @@ proc requestWhilePumping(
   )
 
 suite "Kosmo CLI open transport":
+  test "stdin preserves text name and originating window across transport":
+    let registry = createTempDir("kosmo-stdin-transport-", "")
+    defer:
+      removeDir(registry)
+    var received: seq[KosmoCliOpenRequest]
+    let server = startKosmoCliOpenServer(
+      proc(request: KosmoCliOpenRequest): KosmoCliOpenResponse =
+        received.add request
+        KosmoCliOpenResponse(),
+      registry,
+    )
+    defer:
+      server.close()
+    let response = requestWhilePumping(
+      "output.log",
+      server.endpointPath(),
+      registry,
+      origin = "stdin-window",
+      diffText = "hello λ\nworld\n",
+      workingDirectory = registry,
+      opensStdin = true,
+    )
+    check response.delivered
+    check response.errorCount == 0
+    require received.len == 1
+    check received[0].kind == kcrOpenStdin
+    check received[0].stdinName == "output.log"
+    check received[0].stdinText == "hello λ\nworld\n"
+    check received[0].originWindow == "stdin-window"
+
   test "authenticated requests reach the newest responsive process":
     let
       registry = createTempDir("merenda-kosmo-cli-registry-", "")

--- a/tests/kosmo/cli.nim
+++ b/tests/kosmo/cli.nim
@@ -4,6 +4,21 @@ import std/[os, strutils, tempfiles, times, unittest]
 import merenda/kosmo/cli
 
 suite "Kosmo command line":
+  test "stdin file names are distinct from paths and reject conflicting modes":
+    let parsed = parseKosmoCommandLine(@["--file:log"])
+    check parsed.stdinName == "stdin.log"
+    check parsed.paths.len == 0
+    check parsed.errors.len == 0
+    for args in [
+      @["--file"],
+      @["--file:"],
+      @["--file:log", "--diff"],
+      @["--file:log", "other.txt"],
+      @["--file:../txt"],
+      @["--file:txt", "--file:log"],
+    ]:
+      check parseKosmoCommandLine(args).errors.len > 0
+
   test "background launch removes every background flag and keeps other arguments":
     let commandLine = parseKosmoCommandLine(
       @["--bg", "notes.md", "--literal", "--bg", "with spaces.md"]

--- a/tests/kosmo/cliopen.nim
+++ b/tests/kosmo/cliopen.nim
@@ -1,6 +1,6 @@
 ## Kosmo window-routing behavior for command-line open requests.
 
-import std/[options, os, tempfiles, unittest]
+import std/[options, os, strutils, tempfiles, unittest]
 
 import merenda/nimkit
 import merenda/kosmo/kosmo
@@ -11,6 +11,47 @@ proc hasOpenPath(frontend: KosmoApplication, path: string): bool =
       return true
 
 suite "Kosmo CLI window routing":
+  test "stdin creates separate modified buffers without changing existing files":
+    let root = createTempDir("kosmo-stdin-", "")
+    let manager = newKosmoWindowManager(newApplication("Stdin files"))
+    let frontend = newKosmoApplication(manager, root, monitorsGitStatus = false)
+    defer:
+      manager.close()
+      removeDir(root)
+    writeFile(root / "output.py", "original\n")
+    require frontend.openPath(root / "output.py")
+    let originalCount = frontend.editorView.editor.tabs().len
+    for content in ["def answer():\n  return 42\n", ""]:
+      let response = manager.openCliRequestForTesting(
+        KosmoCliOpenRequest(
+          requestId: "stdin",
+          kind: kcrOpenStdin,
+          stdinName: "output.py",
+          stdinText: content,
+          workingDirectory: root,
+          originWindow: frontend.cliWindowId(),
+        )
+      )
+      check response.delivered
+      check response.errors.len == 0
+      let tabs = frontend.editorView.editor.tabs()
+      for tab in tabs:
+        if tab.active:
+          check tab.modified
+          check tab.filePath == some(root / "output.py")
+          # Moe stores the final newline in its endOfLine flag, outside the lines.
+          var lines = content
+          lines.removeSuffix("\n")
+          check frontend.editorView.editor.bufferText(tab.id) == some(lines)
+      check readFile(root / "output.py") == "original\n"
+    check frontend.editorView.editor.tabs().len == originalCount + 2
+    let editor = frontend.editorView.editor
+    for content in ["hello\n", "hello", ""]:
+      require editor.newStdinBuffer("saved.txt", content, root).isSome
+      discard editor.save()
+      require fileExists(root / "saved.txt")
+      check readFile(root / "saved.txt") == content
+
   test "an embedded terminal targets its owning project window":
     let
       firstRoot = createTempDir("merenda-kosmo-cli-first-", "")

--- a/tests/kosmo/gitdiff.nim
+++ b/tests/kosmo/gitdiff.nim
@@ -235,6 +235,33 @@ suite "Kosmo Git diff":
     require panel.waitForDiff()
     check panel.highlightBuildCount() == initialCount + 1
 
+  test "repository change bursts trigger one trailing refresh":
+    let root = createTempDir("kosmo-diff-debounce-", "")
+    defer:
+      removeDir(root)
+    initRepository(root)
+    for index in 0 ..< 8:
+      writeFile(root / ("file" & $index & ".nim"), "let value = 0\n")
+    git(root, "add", ".")
+    git(root, "commit", "-qm", "base")
+    let panel = newKosmoGitDiffPanel(root)
+    defer:
+      panel.close()
+    require panel.waitForDiff()
+    let initialReads = panel.repositoryReadCount()
+    check initialReads == 1
+
+    for index in 0 ..< 8:
+      writeFile(root / ("file" & $index & ".nim"), "let value = " & $(index + 1) & "\n")
+      panel.scheduleRepositoryRefresh()
+      discard panel.pollRepositoryRefresh()
+      sleep(10)
+    check panel.repositoryReadCount() == initialReads
+
+    require panel.waitForDiff()
+    check panel.repositoryReadCount() == initialReads + 1
+    check panel.snapshot.files.len == 8
+
   test "Matter highlights both file versions independently beneath diff tints":
     let root = createTempDir("kosmo-diff-matter-", "")
     defer:

--- a/tests/kosmo/matterhighlighting.nim
+++ b/tests/kosmo/matterhighlighting.nim
@@ -35,7 +35,7 @@ proc renderMoeFile(fileName, source: string): RenderBuffer =
   defer:
     editor.close()
   doAssert editor.openFile(path).loaded
-  result = newRenderBuffer(48, 8)
+  result = newRenderBuffer(48, 16)
   editor.render(result)
 
 template checkDistinctHighlight(fileName, source, firstNeedle, secondNeedle: string) =
@@ -89,8 +89,15 @@ suite "Kosmo Matter highlighting":
 
   test "Moe highlights Terraform HCL files":
     checkDistinctHighlight(
-      "matter.hcl", "resource \"thing\" \"example\" {\n  enabled = true\n}\n", "thing",
-      "true",
+      "root.hcl",
+      "# =============================================================================\n" &
+        "# Root Terragrunt Configuration\n" &
+        "# =============================================================================\n" &
+        "# This is the root terragrunt.hcl that all environments include.\n" &
+        "# It defines the common S3 backend pattern and generates the AWS provider block.\n" &
+        "\n" & "terragrunt_version_constraint = \">= 1.1.2, < 2.0.0\"\n",
+      "Root",
+      "1.1.2",
     )
 
   test "Moe highlights Markdown headings and inline code":

--- a/tests/kosmo/matterhighlighting.nim
+++ b/tests/kosmo/matterhighlighting.nim
@@ -1,5 +1,7 @@
-## Matter highlighting in Kosmo Markdown previews.
-import std/[strutils, unicode, unittest]
+## Matter highlighting in Kosmo editors and Markdown previews.
+import std/[os, strutils, tempfiles, unicode, unittest]
+
+import celina/core/colors as celinaColors
 
 import merenda/kosmo/kosmo
 import merenda/nimkit
@@ -10,7 +12,45 @@ proc runeIndexOf(source, needle: string): int =
   if byteIndex >= 0:
     result = source[0 ..< byteIndex].runeLen
 
+proc renderedLocation(buffer: RenderBuffer, needle: string): tuple[column, row: int] =
+  result = (column: -1, row: -1)
+  for row in 0 ..< buffer.height:
+    var line: string
+    for column in 0 ..< buffer.width:
+      line.add buffer.cell(column, row).symbol
+    let column = line.find(needle)
+    if column >= 0:
+      return (column: column, row: row)
+
 suite "Kosmo Matter highlighting":
+  test "Moe editors use Matter highlighting by default":
+    let
+      root = createTempDir("kosmo-moe-matter-", "")
+      path = root / "matter-default.nim"
+    writeFile(path, "proc answer = discard\nproc explicit() = discard\n")
+    defer:
+      removeFile(path)
+      removeDir(root)
+
+    let editor = newKosmoEditor()
+    defer:
+      editor.close()
+    require editor.openFile(path).loaded
+
+    var buffer = newRenderBuffer(32, 8)
+    editor.render(buffer)
+    let
+      keyword = buffer.renderedLocation("proc")
+      parameterless = buffer.renderedLocation("answer")
+      explicit = buffer.renderedLocation("explicit")
+    require keyword.column >= 0
+    require parameterless.column >= 0
+    require explicit.column >= 0
+    check buffer.cell(parameterless.column, parameterless.row).style.fg ==
+      buffer.cell(explicit.column, explicit.row).style.fg
+    check buffer.cell(parameterless.column, parameterless.row).style.fg !=
+      buffer.cell(keyword.column, keyword.row).style.fg
+
   test "Markdown previews use Matter for fenced code":
     let frontend = newKosmoApplication(
       newApplication("Kosmo Matter Highlighting Test"), monitorsGitStatus = false

--- a/tests/kosmo/matterhighlighting.nim
+++ b/tests/kosmo/matterhighlighting.nim
@@ -22,6 +22,33 @@ proc renderedLocation(buffer: RenderBuffer, needle: string): tuple[column, row: 
     if column >= 0:
       return (column: column, row: row)
 
+proc renderMoeFile(fileName, source: string): RenderBuffer =
+  let
+    root = createTempDir("kosmo-moe-matter-", "")
+    path = root / fileName
+  writeFile(path, source)
+  defer:
+    removeFile(path)
+    removeDir(root)
+
+  let editor = newKosmoEditor()
+  defer:
+    editor.close()
+  doAssert editor.openFile(path).loaded
+  result = newRenderBuffer(48, 8)
+  editor.render(result)
+
+template checkDistinctHighlight(fileName, source, firstNeedle, secondNeedle: string) =
+  block:
+    let
+      buffer = renderMoeFile(fileName, source)
+      first = buffer.renderedLocation(firstNeedle)
+      second = buffer.renderedLocation(secondNeedle)
+    require first.column >= 0
+    require second.column >= 0
+    check buffer.cell(first.column, first.row).style.fg !=
+      buffer.cell(second.column, second.row).style.fg
+
 suite "Kosmo Matter highlighting":
   test "Moe editors use Matter highlighting by default":
     let
@@ -50,6 +77,20 @@ suite "Kosmo Matter highlighting":
       buffer.cell(explicit.column, explicit.row).style.fg
     check buffer.cell(parameterless.column, parameterless.row).style.fg !=
       buffer.cell(keyword.column, keyword.row).style.fg
+
+  test "Moe highlights JavaScript files":
+    checkDistinctHighlight("matter.js", "const answer = \"kosmo\";\n", "const", "kosmo")
+
+  test "Moe highlights Python files":
+    checkDistinctHighlight(
+      "matter.py", "def answer():\n  return \"kosmo\"\n", "def", "kosmo"
+    )
+
+  test "Moe highlights Terraform HCL files":
+    checkDistinctHighlight(
+      "matter.hcl", "resource \"thing\" \"example\" {\n  enabled = true\n}\n", "thing",
+      "true",
+    )
 
   test "Markdown previews use Matter for fenced code":
     let frontend = newKosmoApplication(

--- a/tests/kosmo/matterhighlighting.nim
+++ b/tests/kosmo/matterhighlighting.nim
@@ -73,6 +73,7 @@ suite "Kosmo Matter highlighting":
     require keyword.column >= 0
     require parameterless.column >= 0
     require explicit.column >= 0
+    check buffer.cell(keyword.column, keyword.row).style.fg.kind == celinaColors.Rgb
     check buffer.cell(parameterless.column, parameterless.row).style.fg ==
       buffer.cell(explicit.column, explicit.row).style.fg
     check buffer.cell(parameterless.column, parameterless.row).style.fg !=

--- a/tests/kosmo/matterhighlighting.nim
+++ b/tests/kosmo/matterhighlighting.nim
@@ -92,6 +92,14 @@ suite "Kosmo Matter highlighting":
       "true",
     )
 
+  test "Moe highlights Markdown headings and inline code":
+    checkDistinctHighlight(
+      "matter.md", "# Matter heading\nUse `kosmo` here.\n", "Matter heading", "Use"
+    )
+    checkDistinctHighlight(
+      "matter.md", "# Matter heading\nUse `kosmo` here.\n", "Use", "kosmo"
+    )
+
   test "Markdown previews use Matter for fenced code":
     let frontend = newKosmoApplication(
       newApplication("Kosmo Matter Highlighting Test"), monitorsGitStatus = false

--- a/tests/kosmo/panelshortcuts.nim
+++ b/tests/kosmo/panelshortcuts.nim
@@ -3,6 +3,7 @@ import std/[os, tempfiles, unittest]
 
 import merenda/nimkit
 import merenda/kosmo/kosmo
+import merenda/kosmo/workspacefiles
 
 proc commandNumberEvent(number: range[1 .. 8]): KeyEvent =
   let key = Key(key1.ord + number - 1)
@@ -23,6 +24,11 @@ proc keyWindowIs(app: Application, expected: Window): bool =
 
 proc controlKeyEvent(key: Key): KeyEvent =
   KeyEvent(key: key, keyCode: key.ord, modifiers: {kmControl})
+
+proc primaryShiftKeyEvent(key: Key): KeyEvent =
+  KeyEvent(
+    key: key, keyCode: key.ord, modifiers: shortcutModifiers() + {nimkit.kmShift}
+  )
 
 suite "Kosmo synthetic panel shortcuts":
   test "pane navigation focuses a displayed terminal instead of its detached editor":
@@ -132,6 +138,43 @@ suite "Kosmo synthetic panel shortcuts":
     let searchFocused =
       frontend.window.fieldEditorClient() == frontend.searchPanel.queryField
     check searchFocused
+
+  test "primary-shift-L reveals the active file only when it is in the browser":
+    let
+      root = createTempDir("merenda-kosmo-reveal-root-", "")
+      outsideRoot = createTempDir("merenda-kosmo-reveal-outside-", "")
+      firstFolder = root / "first"
+      secondFolder = firstFolder / "second"
+      activePath = secondFolder / "active.nim"
+      outsidePath = outsideRoot / "outside.nim"
+      app = newApplication("Kosmo Reveal Active File Test")
+      frontend = newKosmoApplication(app, root, monitorsGitStatus = false)
+    createDir(firstFolder)
+    createDir(secondFolder)
+    writeFile(activePath, "discard\n")
+    writeFile(outsidePath, "discard\n")
+    defer:
+      frontend.close()
+      removeDir(root)
+      removeDir(outsideRoot)
+    app.presentSyntheticWindow(frontend)
+    require frontend.fileTree.workspaceFiles.waitForFiles()
+    require frontend.openPath(activePath)
+    require frontend.showFindInFiles()
+
+    require app.performMenuKeyEquivalent(primaryShiftKeyEvent(keyL))
+    check frontend.sidebarTabs.selectedIndex == 0
+    check frontend.fileTree.selectedItemIdentifier == absolutePath(activePath)
+    check frontend.fileTree.isItemExpanded(absolutePath(root))
+    check frontend.fileTree.isItemExpanded(absolutePath(firstFolder))
+    check frontend.fileTree.isItemExpanded(absolutePath(secondFolder))
+    check frontend.window.firstResponderIs(frontend.fileTree)
+
+    require frontend.openPath(outsidePath)
+    require frontend.showFindInFiles()
+    require app.performMenuKeyEquivalent(primaryShiftKeyEvent(keyL))
+    check frontend.sidebarTabs.selectedIndex == 1
+    check frontend.fileTree.selectedItemIdentifier == absolutePath(activePath)
 
   test "relative Moe saves use the active project's directory":
     let

--- a/tests/kosmo/search.nim
+++ b/tests/kosmo/search.nim
@@ -104,13 +104,15 @@ suite "Kosmo":
     require not tabsView.isNil
     require tabsView of TabView
     let settingsTabs = TabView(tabsView)
-    check settingsTabs.len == 3
+    check settingsTabs.len == 4
     check settingsTabs[0].label == "Terminal"
     check settingsTabs[0].identifier == KosmoTerminalSettingsTabIdentifier
     check settingsTabs[1].label == "Shortcuts"
     check settingsTabs[1].identifier == KosmoShortcutsSettingsTabIdentifier
     check settingsTabs[2].label == "Moe Themes"
     check settingsTabs[2].identifier == KosmoMoeThemesSettingsTabIdentifier
+    check settingsTabs[3].label == "TextMate Grammars"
+    check settingsTabs[3].identifier == KosmoTextMateGrammarsSettingsTabIdentifier
     check settingsTabs.selectedIndex == 0
 
     discard settingsPanel.buildRenders()
@@ -349,6 +351,56 @@ suite "Kosmo":
       KosmoMoeDefaultThemeIdentifier
     check frontend.settingsWindow().selectedMoeThemeIdentifier() ==
       KosmoMoeDefaultThemeIdentifier
+    check settingsTabs.selectTabViewItemAtIndex(3)
+    discard settingsPanel.buildRenders()
+
+    let textMateGrammarsView = settingsPanel.contentView().viewWithIdentifier(
+        KosmoTextMateGrammarsTableIdentifier
+      )
+    require not textMateGrammarsView.isNil
+    require textMateGrammarsView of TableView
+    let
+      textMateGrammarsTable = TableView(textMateGrammarsView)
+      grammarColumn = textMateGrammarsTable.columnWithIdentifier(
+        KosmoTextMateGrammarNameColumnIdentifier
+      )
+      scopeColumn = textMateGrammarsTable.columnWithIdentifier(
+        KosmoTextMateGrammarScopeColumnIdentifier
+      )
+      originColumn = textMateGrammarsTable.columnWithIdentifier(
+        KosmoTextMateGrammarOriginColumnIdentifier
+      )
+      availableGrammars = frontend.editorView.editor.availableTextMateGrammars()
+    check textMateGrammarsTable.columnCount == 3
+    check textMateGrammarsTable.selectionMode == tsmNone
+    check textMateGrammarsTable.rowCount == availableGrammars.len
+    require not grammarColumn.isNil
+    require not scopeColumn.isNil
+    require not originColumn.isNil
+    check grammarColumn.title == "Grammar"
+    check scopeColumn.title == "Scope"
+    check originColumn.title == "Origin"
+    var foundTerraform = false
+    for row in 0 ..< textMateGrammarsTable.rowCount:
+      check textMateGrammarsTable.tableCellText(row, grammarColumn).len > 0
+      check textMateGrammarsTable.tableCellText(row, scopeColumn).len > 0
+      check textMateGrammarsTable.tableCellText(row, originColumn) == "Built-in"
+      if textMateGrammarsTable.tableCellText(row, scopeColumn) == "source.hcl.terraform":
+        check textMateGrammarsTable.tableCellText(row, grammarColumn) == "Terraform"
+        foundTerraform = true
+    check foundTerraform
+
+    var grammarsWithAddition = availableGrammars
+    grammarsWithAddition.add KosmoTextMateGrammar(
+      name: "Example Added Grammar",
+      scopeName: "source.example-added",
+      origin: KosmoTextMateGrammarOrigin.Added,
+    )
+    frontend.settingsWindow().textMateGrammars = grammarsWithAddition
+    check textMateGrammarsTable.rowCount == availableGrammars.len + 1
+    check textMateGrammarsTable.tableCellText(
+      textMateGrammarsTable.rowCount - 1, originColumn
+    ) == "Added"
     check settingsTabs.selectTabViewItemAtIndex(0)
 
     let optionView =

--- a/tests/kosmo/shortcutprofiles.nim
+++ b/tests/kosmo/shortcutprofiles.nim
@@ -62,6 +62,13 @@ suite "Kosmo shortcut profiles":
       actionSelector(8.focusPanelAction())
     check bindings.match([keyEvent(key9, {kmCommand})]).kind == kbmNone
 
+  test "macOS profile maps command-shift-L to reveal the active file":
+    let bindings =
+      initKosmoKeyBindings(KosmoShortcutProfile.MacOS, KosmoShortcutPlatform.MacOS)
+
+    check bindings.bindingFor([keyEvent(keyL, {kmCommand, kmShift})]) ==
+      actionSelector(KosmoRevealActiveFileAction)
+
   test "structured configuration resolves profile, editor mode, and symbolic bindings":
     let loaded = applyKosmoShortcutConfigurationJson(
       """{

--- a/tests/kosmo/tabs.nim
+++ b/tests/kosmo/tabs.nim
@@ -106,6 +106,39 @@ suite "Kosmo":
     check "NORMAL" in frontend.statusLabel.text
     check "second.txt" in frontend.statusLabel.text
 
+  test "status bar shows the active full file path after Git status":
+    let
+      root = createTempDir("merenda-kosmo-status-path-", "")
+      nested = root / "nested"
+      filePath = nested / "status.txt"
+    createDir(nested)
+    writeFile(filePath, "status")
+    require execShellCmd("git -C " & quoteShell(root) & " init -qb status-path") == 0
+    defer:
+      removeFile(filePath)
+      removeDir(nested)
+      removeDir(root)
+
+    let frontend =
+      newKosmoApplication(newApplication("Kosmo Status Path Test"), filePath = root)
+    defer:
+      frontend.close()
+    require frontend.openPath(filePath)
+
+    let deadline = getMonoTime() + initDuration(seconds = 60)
+    while "Git: status-path" notin frontend.statusLabel.text and getMonoTime() < deadline:
+      discard getCurrentSigilThread().pollAll(NonBlocking)
+      frontend.editorView.refresh()
+      sleep(10)
+
+    let
+      statusText = frontend.statusLabel.text
+      gitPosition = statusText.find("Git: status-path")
+      pathPosition = statusText.find(absolutePath(filePath))
+    check gitPosition >= 0
+    check pathPosition > gitPosition
+    check statusText.endsWith(absolutePath(filePath))
+
   test "File menu opens a new blank editor tab":
     let
       frontend = newKosmoApplication(newApplication("Kosmo New Tab Test"))

--- a/tests/kosmo/workspacefiles.nim
+++ b/tests/kosmo/workspacefiles.nim
@@ -22,6 +22,12 @@ template eventually(condition: untyped) =
       sleep(10)
     check condition
 
+proc pumpFor(milliseconds: int) =
+  let deadline = getMonoTime() + initDuration(milliseconds = milliseconds)
+  while getMonoTime() < deadline:
+    discard getCurrentSigilThread().pollAll(NonBlocking)
+    sleep(10)
+
 suite "Kosmo shared workspace inventory":
   test "non-Git discovery limits depth and entries while browsing stays lazy":
     let root = createTempDir("kosmo-bounded-inventory-", "")
@@ -355,6 +361,19 @@ suite "Kosmo shared workspace inventory":
     require frontend.openPath(externalRoot / "external.nim")
     eventually(frontend.editorView.editor.status().gitBranch == "external-start")
     eventually(externalRoot in frontend.fileTree.workspaceFiles.gitRoots)
+
+    # The root list is published before the native backend finishes registering
+    # every Git metadata directory. Wait for the exact handles before changing
+    # HEAD, then drain the initial dirty pulse so the checkout event cannot be
+    # coalesced with watcher setup.
+    eventually(
+      not frontend.fileTree.workspaceFiles.watch.isNil and
+        externalRoot in frontend.fileTree.workspaceFiles.watch.directories and
+        externalRoot / ".git" in frontend.fileTree.workspaceFiles.watch.metadata and
+        frontend.fileTree.workspaceFiles.watch.handles.len ==
+        frontend.fileTree.workspaceFiles.watch.directories.len
+    )
+    pumpFor(500)
 
     require runGitCommand(externalRoot, ["checkout", "-qb", "external-next"]).exitCode ==
       0

--- a/tests/kosmo/workspacefiles.nim
+++ b/tests/kosmo/workspacefiles.nim
@@ -362,16 +362,19 @@ suite "Kosmo shared workspace inventory":
     eventually(frontend.editorView.editor.status().gitBranch == "external-start")
     eventually(externalRoot in frontend.fileTree.workspaceFiles.gitRoots)
 
-    # The root list is published before the native backend finishes registering
-    # every Git metadata directory. Wait for the exact handles before changing
-    # HEAD, then drain the initial dirty pulse so the checkout event cannot be
-    # coalesced with watcher setup.
+    # The root list is published before the watcher backend finishes registering
+    # every Git metadata directory. Native backends need all handles before
+    # changing HEAD; Linux intentionally uses the polling fallback instead.
+    # Drain the initial dirty pulse so the checkout event cannot be coalesced
+    # with watcher setup.
     eventually(
       not frontend.fileTree.workspaceFiles.watch.isNil and
         externalRoot in frontend.fileTree.workspaceFiles.watch.directories and
-        externalRoot / ".git" in frontend.fileTree.workspaceFiles.watch.metadata and
+        externalRoot / ".git" in frontend.fileTree.workspaceFiles.watch.metadata and (
+        frontend.fileTree.workspaceFiles.watch.fallback or
         frontend.fileTree.workspaceFiles.watch.handles.len ==
         frontend.fileTree.workspaceFiles.watch.directories.len
+      )
     )
     pumpFor(500)
 


### PR DESCRIPTION
## Summary

- enable the Moe Matter backend through config.nims and make it the default Kosmo editor highlighter
- share the embedded Matter grammar catalog with NimKit Markdown highlighting, using Matter knownPackages as the source of truth
- consume the dynamic Moe grammar/file-type API and add the Terraform HCL alias
- cover rendered Nim, JavaScript, Python, Terraform/Terragrunt HCL, Markdown, and fenced-code highlighting
- add a TextMate Grammars settings tab listing each installed grammar, scope, and Built-in/Added origin
- show the active full file path after Git information in the Kosmo status bar
- add Command-Shift-L to reveal the active editor file in the browser while respecting its roots, filter, and scope
- debounce repository notifications so formatter bursts cause one trailing Git diff refresh
- track Moe's develop branch after merging the corrected embedded grammar and color handling

## Dependency work

- Moe develop (e376b03e): dynamic TextMate file-type selection, Markdown scope mapping, and embedded frontends retain their requested color precision
- Matter 333b79c7: stable external grammar cache identities and bare Oniguruma property-escape compatibility

The Moe API design and final integration were reviewed by Astra subagents; the review feedback drove the scope-keyed dynamic grammar registry, filename-based selection, Save As invalidation, additive aliases, and collision coverage.

## Verification

- atlas install -tuk
- env -u TERM -u COLORTERM atlas-run tests (4/4 runners passed before the follow-up debounce)
- atlas-run tests kosmo (1/1 runner passed after the debounce and Terragrunt regression)
- atlas-run tests --compile-only examples/all_compile.nim (1/1 compiled)
- Moe Matter backend, embedded color, and incremental highlighting suites passed
- Matter full suite passed (17/17)