### PR TITLE
Fix missing GCC runtime in Windows Kosmo release

### DIFF
--- a/.github/workflows/release-kosmo.yml
+++ b/.github/workflows/release-kosmo.yml
@@ -764,11 +764,15 @@ jobs:
           Push-Location data
           windres kosmo.rc -O coff -o ../build/kosmo.res
           Pop-Location
+          # The setup action uses MinGW. Link its exception runtime into the
+          # executable so the release ZIP does not require libgcc_s_seh-1.dll
+          # beside kosmo.exe.
           nim c `
             --opt:size `
             --debugger:native `
             --lineTrace:off `
             --stackTrace:off `
+            --passL:-static-libgcc `
             -d:nimStackTraceOverride `
             --app:gui `
             -d:moe.embedded `
@@ -785,6 +789,10 @@ jobs:
           }
           if (-not (& nm dist/kosmo.exe | Select-String -Quiet 'backtrace_create_state')) {
             throw 'Kosmo executable is missing libbacktrace.'
+          }
+          $imports = & objdump -p dist/kosmo.exe
+          if ($imports -match '(?im)^\s*DLL Name:\s+libgcc_s.*\.dll\s*$') {
+            throw 'Kosmo executable must not depend on a MinGW GCC runtime DLL.'
           }
           $process = Start-Process `
             -FilePath "$PWD/dist/kosmo.exe" `

--- a/merenda.nimble
+++ b/merenda.nimble
@@ -1,4 +1,4 @@
-version       = "0.18.3"
+version       = "0.18.4"
 author        = "Jaremy Creechley"
 description   = "Nim-native UI toolkit"
 license       = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

- statically link MinGW's GCC exception runtime into `kosmo.exe`
- reject release executables that import `libgcc_s*.dll`
- bump Merenda to `0.18.4`

This keeps the existing MinGW toolchain, which remains compatible with the project's MinGW-oriented native dependencies, while making the release ZIP runnable without `libgcc_s_seh-1.dll`. The CI installer remains on latest Atlas; Atlas 0.16.2 now resolves the cold dependency graph successfully.

## Verification

- `actionlint .github/workflows/release-kosmo.yml`
- YAML parse with Ruby
- cold `atlas install -tuk --features:kosmo` with Atlas 0.16.2
- PR release workflow 34710471695: all Linux, macOS, FreeBSD, and Windows jobs pass
- PR test workflow 34710471678: Ubuntu/macOS tests and all examples pass
- independent PE inspection of the Windows artifact confirms no `libgcc_s*.dll` or `libstdc++` imports
