### PR TITLE
Fix X11 repaint and native window close lifecycle

### DIFF
--- a/src/merenda/nimkit/app/application.nim
+++ b/src/merenda/nimkit/app/application.nim
@@ -131,6 +131,14 @@ proc prepareApplicationEventLoop(app: Application)
 proc pollApplicationEvents(app: Application)
 proc waitForApplicationEvents(app: Application)
 
+proc requestNativeDisplayRefresh(app: Application) =
+  ## Some native backends report an event without marking its surface dirty.
+  ## Refresh every visible host after native activity so exposed content is
+  ## rebuilt even when the backend omits a dedicated expose callback.
+  for window in app.xWindows:
+    if not window.isNil and window.isVisible:
+      window.requestNativeDisplayUpdate()
+
 proc resolvedApplicationName(name: string): string =
   if name.len > 0:
     return name
@@ -1206,7 +1214,8 @@ proc prepareApplicationEventLoop(app: Application) =
 proc pollApplicationEvents(app: Application) =
   for window in app.xWindows:
     if not window.isNil and window.isVisible and window.nativeReady:
-      nimkitBackend.pollNativeEvents()
+      if nimkitBackend.pollNativeEvents():
+        app.requestNativeDisplayRefresh()
       break
 
 proc waitForApplicationEvents(app: Application) =
@@ -1217,16 +1226,19 @@ proc waitForApplicationEvents(app: Application) =
   let
     now = getMonoTime()
     deadline = app.nextAnimationDeadline(now)
+  var eventActivity: bool
   if deadline.isSome:
     let timeout = deadline.get() - now
-    nimkitBackend.waitForNativeEvents(
+    eventActivity = nimkitBackend.waitForNativeEvents(
       if timeout.inNanoseconds > 0:
         timeout
       else:
         initDuration()
     )
   else:
-    nimkitBackend.waitForNativeEvents()
+    eventActivity = nimkitBackend.waitForNativeEvents()
+  if eventActivity:
+    app.requestNativeDisplayRefresh()
 
 proc runForFrames*(app: Application, frames: Natural): int =
   if frames == 0:

--- a/src/merenda/nimkit/app/backend.nim
+++ b/src/merenda/nimkit/app/backend.nim
@@ -51,23 +51,25 @@ proc installNativeEventLoopWaker*(thread: SigilThreadPtr) =
       thread.installSiwinEventLoopWaker(siwinshim.sharedSiwinGlobals())
       nativeEventLoopSigilThread = thread
 
-proc waitForNativeEvents*() =
+proc waitForNativeEvents*(): bool =
   when defined(useNativeDynlib):
     sleep(8)
   else:
-    siwinshim.sharedSiwinGlobals().waitEvents()
+    result =
+      siwinshim.sharedSiwinGlobals().waitEvents(Duration.high) == siwinshim.eventActivity
 
-proc waitForNativeEvents*(timeout: Duration) =
+proc waitForNativeEvents*(timeout: Duration): bool =
   when defined(useNativeDynlib):
     let nanoseconds = max(timeout.inNanoseconds, 0'i64)
     let milliseconds = nanoseconds div 1_000_000 + ord(nanoseconds mod 1_000_000 != 0)
     sleep(min(milliseconds, int.high.int64).int)
   else:
-    discard siwinshim.sharedSiwinGlobals().waitEvents(timeout)
+    result =
+      siwinshim.sharedSiwinGlobals().waitEvents(timeout) == siwinshim.eventActivity
 
-proc pollNativeEvents*() =
+proc pollNativeEvents*(): bool =
   when not defined(useNativeDynlib):
-    discard siwinshim.sharedSiwinGlobals().pollEvents()
+    result = siwinshim.sharedSiwinGlobals().pollEvents()
 
 type RenderExecutionMode* = enum
   remAutomatic

--- a/src/merenda/nimkit/app/windows.nim
+++ b/src/merenda/nimkit/app/windows.nim
@@ -2849,13 +2849,21 @@ proc dispatchHostFocusChanged*(window: Window, focused: bool) =
   discard window.requestNativeDisplayUpdateIfNeeded()
 
 proc markHostClosed(window: Window) =
+  if window.xClosed:
+    return
+  window.sendWindowDelegate(windowWillClose(), window)
+  emit window.willClose()
+  window.postWindowNotification(nkWindowWillClose)
   window.clearToolTip()
   window.releaseThreadRenderer(waitForRelease = true)
   window.stopInsertionPointBlink()
   window.stopAnimationClock()
+  discard window.saveFrameUsingName()
   window.xClosed = true
   window.xVisibleRequested = false
   window.xMiniaturized = false
+  window.xIsKeyWindow = false
+  window.xIsMainWindow = false
   window.xBackdropActive = false
   if window.xTransientSession.active:
     discard window.dismissTransientSession(tdrOwnerClosed)
@@ -2864,6 +2872,12 @@ proc markHostClosed(window: Window) =
   if not window.xOwnerWindow.isNil:
     window.xOwnerWindow.detachAuxiliaryWindow(window)
     window.xOwnerWindow = nil
+  if not window.xSheetParent.isNil and window.xSheetParent.xSheet == window:
+    window.xSheetParent.xSheet = nil
+    window.xSheetParent = nil
+  emit window.didClose()
+  window.postWindowNotification(nkWindowDidClose)
+  window.sendWindowDelegate(windowDidClose(), window)
   window.notifyApplication(WindowDidCloseSelector)
 
 proc useThreadRenderer*(window: Window, renderer: ThreadRendererClient) =

--- a/tests/integrations/nativewindowlifecycle.nim
+++ b/tests/integrations/nativewindowlifecycle.nim
@@ -1,0 +1,78 @@
+## Native window lifecycle regressions.
+import std/[unittest]
+
+import figdraw/windowing/siwinshim
+
+import merenda/nimkit
+import merenda/nimkit/app/windows as nimkitWindows
+import merenda/kosmo/kosmo
+
+type NativeWindowDelegateSpy = ref object of Responder
+  events: seq[string]
+
+protocol NativeWindowDelegateSpyHooks of WindowDelegateProtocol:
+  method windowWillClose(
+      delegate: NativeWindowDelegateSpy, window: nimkitWindows.Window
+  ) =
+    discard window
+    delegate.events.add("willClose")
+
+  method windowDidClose(
+      delegate: NativeWindowDelegateSpy, window: nimkitWindows.Window
+  ) =
+    discard window
+    delegate.events.add("didClose")
+
+suite "NimKit native window lifecycle":
+  test "native close delivers the regular window lifecycle callbacks":
+    block nativeDelegateClose:
+      let
+        app = newApplication("Native Delegate Close Test")
+        window = newWindow("Native Delegate Close", frame = rect(80, 80, 240, 140))
+        delegate = NativeWindowDelegateSpy()
+
+      initResponder(delegate)
+      discard delegate.withProtocol(NativeWindowDelegateSpyHooks)
+      window.delegate = delegate
+      window.setContentView(newView(frame = rect(0, 0, 240, 140)))
+      app.addWindow(window)
+      window.makeKeyAndOrderFront()
+
+      try:
+        check app.runForFrames(1) == 1
+        check window.nativeReady
+        let nativeWindow = window.nativeWindowOrNil()
+        require not nativeWindow.isNil
+        siwinshim.close(nativeWindow)
+        check window.isClosed
+        check delegate.events == @["willClose", "didClose"]
+      except CatchableError:
+        skip()
+        break nativeDelegateClose
+      finally:
+        if not window.isClosed:
+          window.close()
+
+  test "native Kosmo close closes its independent settings window":
+    block nativeKosmoClose:
+      let
+        app = newApplication("Native Kosmo Close Test")
+        frontend = newKosmoApplication(app, monitorsGitStatus = false)
+
+      try:
+        frontend.show()
+        check frontend.showSettings()
+        let settings = frontend.settingsWindow()
+        require not settings.isNil
+        check app.runForFrames(2) == 2
+        check frontend.window.nativeReady
+        let nativeWindow = frontend.window.nativeWindowOrNil()
+        require not nativeWindow.isNil
+        siwinshim.close(nativeWindow)
+        check frontend.window.isClosed
+        check settings.window.isClosed
+      except CatchableError:
+        skip()
+        break nativeKosmoClose
+      finally:
+        frontend.close()

--- a/tests/integrations/nativewindowrepaint.nim
+++ b/tests/integrations/nativewindowrepaint.nim
@@ -1,0 +1,53 @@
+## Native window repaint regressions.
+import std/[monotimes, os, times, unittest]
+
+import figdraw/windowing/siwinshim
+
+import merenda/nimkit
+
+when defined(linux) or defined(bsd):
+  import x11/x except Window
+  import x11/xlib
+  import siwin/platforms/x11/window as x11Window
+
+suite "NimKit native window repaint":
+  when defined(linux) or defined(bsd):
+    test "X11 expose activity requests a native repaint":
+      block nativeExposeRepaint:
+        let
+          app = newApplication("Native Expose Repaint Test")
+          window = newWindow("Native Expose Repaint", frame = rect(80, 80, 240, 140))
+
+        window.setContentView(newView(frame = rect(0, 0, 240, 140)))
+        app.addWindow(window)
+        window.makeKeyAndOrderFront()
+
+        try:
+          check app.runForFrames(2) == 2
+          check window.nativeReady
+          let nativeWindow = window.nativeWindowOrNil()
+          require not nativeWindow.isNil
+          if nativeWindow.siwinDisplayServerName() != "x11":
+            skip()
+            break nativeExposeRepaint
+
+          let
+            x11NativeWindow = x11Window.WindowX11(nativeWindow)
+            display = cast[ptr Display](x11NativeWindow.nativeDisplayHandle())
+            handle = x11NativeWindow.nativeWindowHandle().culong
+          require not display.isNil
+          require handle != 0
+
+          let before = window.nativeRenderCount()
+          discard display.XClearArea(handle, 0, 0, 0, 0, 1)
+          discard display.XFlush()
+          let deadline = getMonoTime() + initDuration(seconds = 5)
+          while getMonoTime() < deadline and window.nativeRenderCount() <= before:
+            discard app.runForFrames(1)
+            sleep(1)
+          check window.nativeRenderCount() > before
+        except CatchableError:
+          skip()
+          break nativeExposeRepaint
+        finally:
+          window.close()

--- a/tests/tintegrations.nim
+++ b/tests/tintegrations.nim
@@ -3,6 +3,7 @@ import integrations/application_sigils
 import integrations/figdraw_text_offsets
 import integrations/kosmocliopen
 import integrations/kosmoterminalenvironment
+import integrations/nativewindowlifecycle
 import integrations/nativewindowrepaint
 import integrations/nativewindowscale
 import integrations/urlassets

--- a/tests/tintegrations.nim
+++ b/tests/tintegrations.nim
@@ -3,6 +3,7 @@ import integrations/application_sigils
 import integrations/figdraw_text_offsets
 import integrations/kosmocliopen
 import integrations/kosmoterminalenvironment
+import integrations/nativewindowrepaint
 import integrations/nativewindowscale
 import integrations/urlassets
 import integrations/backgroundworkershutdown


### PR DESCRIPTION
## Summary

- repaint visible native windows when the backend reports activity, including X11 expose/damage events
- restore normal native-close lifecycle callbacks and auxiliary-window cleanup
- close independent Kosmo settings windows when the main window is closed through the native window control
- add integration regressions for both issue paths

Fixes #74
Fixes #75

## Verification

- `atlas-run tests integrations` ✅
- `FIGDRAW_FORCE_OPENGL=1 atlas-run tests integrations` ✅
- `atlas-run tests` ⚠️ 3/4 runners passed; the existing Kosmo `workspacefiles.nim` assertion fails with `ignoredSpy.changes == 0` at lines 576–577, unrelated to these changes.
